### PR TITLE
feat(server): add structured audit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,13 @@ This framework was built by someone running on way too much caffeine. If you enc
 
 ### Safe lab defaults
 
-- With `security.operatorToken` empty, the operator UI, API, file drop, log
-  stream, and terminal accept loopback clients only. This keeps the default
-  local workflow available without exposing operator control to the lab
-  network.
+- With `security.operatorToken` empty, the operator UI, API, file drop, and log
+  stream accept loopback clients only. This keeps the default local workflow
+  available without exposing operator control to the lab network.
+- The host-shell WebSocket is disabled by default. Set
+  `security.enableServerTerminal: true` only for a controlled lab that needs
+  it. Access requests and session open/close state are audited even when access
+  is denied; commands and terminal output are never recorded as audit fields.
 - For remote operator access, set a strong token through the environment
   instead of committing it to YAML:
 
@@ -231,6 +234,10 @@ This framework was built by someone running on way too much caffeine. If you enc
   credentials added by #104. See
   [Authenticated agent enrollment](docs/agent-enrollment.md) for rotation,
   recovery, and upgrade details.
+- Structured audit history is available to authenticated operators at
+  `GET /api/audit/events?limit=50&offset=0`. It is durable and redacted but
+  still contains sensitive object metadata; see
+  [audit retention and redaction](docs/storage.md#structured-audit-events).
 - Bind listeners only to the isolated lab segment and keep detonation VMs
   without direct internet egress. See
   [`docs/research/r1-measurement-protocol.md`](docs/research/r1-measurement-protocol.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,8 +3,8 @@
 MicroC2 is an academic C2 research testbed for controlled, authorized lab
 environments. The current implementation is a Go management server, a Rust
 agent, and a static browser UI. It is useful as a prototype and research base,
-but several security, audit, task-family, and transport boundaries are still
-being stabilized.
+but several security, evidence/reporting, task-family, and transport boundaries
+are still being stabilized.
 
 This document describes the repository as it exists today. It deliberately marks
 partially wired features and prototype assumptions so future work can start from
@@ -105,20 +105,41 @@ are visible during development.
 | `/api/agents/command` | `internal/handlers/api` | Deprecated adapter from an `agent_id` plus raw command to a v1 shell task. |
 | `/api/agents/{id}/command` | `internal/handlers/api` | Deprecated adapter from a raw command to a v1 shell task. |
 | `/api/agents/{id}/results` | `internal/handlers/api` | Deprecated bare-array result adapter with strict `limit`/`offset` pagination and a 16 MiB encoded-page ceiling; response headers expose count, total, and continuation offset. |
-| `/api/file_drop/upload` | `internal/handlers/api` | Upload operator files into the server file store. |
+| `/api/audit/events` | `internal/handlers/api` | Retrieve a bounded, newest-first page of Audit Event v1 records. |
+| `/api/file_drop/upload` | `internal/handlers/api` | Upload operator files into the server file store with a 32 MiB total request cap and same-directory atomic staging. |
 | `/api/file_drop/list` | `internal/handlers/api` | List operator file-drop contents. |
-| `/api/file_drop/download/{name}` | `internal/handlers/api` | Download a file-drop item. |
+| `/api/file_drop/download/{name}` | `internal/handlers/api` | Download a verified regular file with causal request/completion audit events. |
 | `/api/file_drop/delete/{name}` | `internal/handlers/api` | Delete a file-drop item. |
 | `/api/payload/generate` | `internal/handlers/api/payload` | Build an agent payload from a listener and payload config. |
 | `/api/payload/download/{id}` | `internal/handlers/api/payload` | Revalidate and download a generated payload tracked by durable metadata. |
 | `/api/payload/{id}/enrollment/revoke` | `internal/handlers/api/payload` | Idempotently retire future bootstrap enrollment while preserving issued sessions. |
 | `/ws/logs` | `internal/handlers/ws` | Stream recent and live server logs. |
-| `/ws/terminal` | `internal/handlers/ws` | Browser-accessible shell on the server host. |
+| `/ws/terminal` | `internal/handlers/ws` | Browser-accessible shell on the server host; disabled unless `security.enableServerTerminal` is explicitly true. |
 
 The operator guard allows loopback clients or a configured shared token and
-checks browser origins for HTTP and WebSocket routes. It is not actor-aware
-authentication or authorization. The server terminal can execute shell commands
-on the host running MicroC2 and remains a local, controlled-lab capability.
+checks browser origins for HTTP and WebSocket routes. Accepted requests carry a
+trusted audit actor identifying loopback or shared-token authentication. This
+is audit attribution, not individual-user authentication or authorization. The
+server terminal can execute shell commands on the host running MicroC2, is
+disabled by default, and remains a local, controlled-lab capability when
+enabled. Requested, denied, opened, and closed terminal access is audited;
+commands and output are never audit fields.
+
+### Structured Audit Contract
+
+The normative contracts are:
+
+- [Audit Event v1](schemas/audit-event-v1.schema.json)
+- [Audit Page v1](schemas/audit-page-v1.schema.json)
+
+Audit events are durable, newest-first by monotonic sequence, and use a closed
+redacted field set. Listener and agent-session lifecycle, payload
+build/download/artifact-reconciliation, file-drop actions, terminal access, and
+task queue/dispatch/running/result/cancellation paths emit events. Task and
+payload rows retain their causal root sequences, and listener lifecycle records
+link to their matching audit events. See
+[storage.md](storage.md#structured-audit-events) for transaction, retention,
+and redaction semantics.
 
 ### Typed Task Contract
 
@@ -254,7 +275,8 @@ filesystem artifacts:
   `data/microc2.db`, with `MICROC2_STORAGE_PATH` as the environment override.
 - SQLite records: listeners and lifecycle events, historical agents, typed
   tasks and results, legacy result projections, payload-build metadata,
-  bootstrap hashes/allowances, the enrollment HMAC key, and durable sessions.
+  structured audit events, bootstrap hashes/allowances, the enrollment HMAC
+  key, and durable sessions.
 - Listener compatibility configs: redacted, regenerable JSON projections under
   `{server.staticDir}/listeners/`.
 - Operator uploads: configured server upload directory, default `uploads`.
@@ -365,7 +387,10 @@ The main remaining gaps are tracked as issues:
 - #97: durable storage is merged into `dev`.
 - #104: authenticated agent enrollment is complete for the `dev` integration
   line; it does not imply a `dev` to `main` promotion.
-- #100: add structured, durable audit events.
+- #100: structured, durable audit events are complete on the `dev` integration
+  line; operator-facing evidence export is still future work.
+- #108: replace payload artifact check-then-use paths with cross-platform
+  open-beneath handles before any `dev` to `main` promotion.
 - #88: add file transfer and pivot controls as typed task families after #98.
 - #99: finish payload validation and manifests; current provenance is partial.
 - #65: finish the agent configuration system and optional OPSEC feature gating.

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,7 +14,7 @@ sequencing, see [roadmap.md](roadmap.md).
 
 - Keep the core small enough to understand, test, and extend.
 - Prefer stable lifecycle behavior over adding more protocols too early.
-- Make risky operator actions explicit, scoped, and eventually audited.
+- Make risky operator actions explicit, scoped, and auditable.
 - Use asynchronous polling and structured server-side queues as the baseline
   communication model.
 - Treat OPSEC as contextual behavior instead of relying only on binary
@@ -128,10 +128,11 @@ Current constraints:
   production multi-user authentication and authorization.
 - Authenticated agent enrollment from #104 is part of the `dev` integration
   line; bearer possession remains the trust boundary.
-- Listener lifecycle history is durable operational state, but structured,
-  actor-aware audit events are not implemented (#100).
-- The server terminal remains a powerful lab-only capability even with the
-  operator guard and origin checks.
+- Structured, actor-aware audit events cover listener, payload, file, terminal,
+  and task lifecycles; shared-token attribution still does not identify an
+  individual human.
+- The server terminal remains a powerful lab-only capability, is disabled by
+  default, and is audited without recording commands or output when enabled.
 
 The server now keeps the route surfaces explicit so they can be hardened
 independently:
@@ -315,19 +316,19 @@ to provide mTLS without CA-backed client-certificate verification.
 The project must still be operated as a lab-only prototype. The Phase 0 safety
 baseline guards operator routes with loopback-or-token access, restricts
 operator WebSocket origins, makes listener CORS explicit, keeps insecure agent
-transport opt-in, validates file-store basenames, and binds agent lifecycle
-requests to durable enrollment sessions through #104. The remaining design
-direction is:
+transport opt-in, validates file-store basenames, binds agent lifecycle
+requests to durable enrollment sessions through #104, and records closed,
+redacted audit events through #100. The remaining design direction is:
 
 - Evolve the shared-token guard into actor-aware authentication and roles before
   multi-user operation.
-- Add audit events for listener, payload, file, terminal, and agent tasking.
+- Build reporting and evidence export on top of the durable audit API.
 - Add target scoping and explicit confirmation metadata for risky future task
   types.
 - Add clear docs for isolated lab deployment.
 
-The Phase 0 route split and lab-safety work are complete in #75 and #78;
-structured governance continues in #100.
+The Phase 0 route split and lab-safety work are complete in #75 and #78; #100
+adds the first structured governance layer on the `dev` integration line.
 
 ## Documentation And Testing Expectations
 
@@ -343,13 +344,15 @@ paths.
 
 ## Near-Term Design Priorities
 
-1. Add causal structured audit events on top of the durable model (#100).
-2. Extend the typed task registry with file transfer and pivot operations now
+1. Extend the typed task registry with file transfer and pivot operations now
    that the v1 shell contract in #98 is stable (#88).
-3. Complete payload profile validation and full build manifests; current #99
+2. Complete payload profile validation and full build manifests; current #99
    provenance is partial P1 work.
+3. Add operator-facing evidence export and reporting on the structured audit
+   foundation.
 
-The data path remains #98 → #97 → #100; #98 is complete and #97 is merged into
-`dev`. Issue #104 closes the authenticated-enrollment boundary for the `dev`
-integration line. This sequence contains no `dev` to `main` promotion, and the
-feature work does not imply that one is ready.
+The data path #98 → #97 → #100 is complete on the `dev` integration line.
+Issue #104 closes the authenticated-enrollment boundary there as well. This
+sequence contains no `dev` to `main` promotion, and the feature work does not
+imply that one is ready. Cross-platform payload-path containment in #108 is an
+explicit promotion gate.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -123,7 +123,7 @@ Focus areas:
 - Replace raw string-only tasking as the primary API.
 - Store agents, tasks, results, payload metadata, and listener events durably;
   keep filesystem artifacts covered by coordinated backup and restore.
-- Add actor-aware audit records as a distinct layer on top of durable
+- Maintain actor-aware audit records as a distinct layer on top of durable
   operational state.
 - Build a consistent UI flow for agents, tasking, results, files, listeners,
   payloads, and logs.
@@ -150,7 +150,10 @@ Candidate issues:
 - #97 `[Server] Add durable storage for agents, tasks, results, payloads, and
   listener events` — merged into `dev`.
 - #100 `[Server] Add structured audit events for operator actions and agent
-  tasking`
+  tasking` — complete on the `dev` integration line with causal task/payload
+  links, redacted retention semantics, terminal auditing, and a paginated API.
+- #108 `[Security] Anchor payload artifact access beneath the configured root`
+  — required before any `dev` to `main` promotion.
 - #88 `[Agent] Wire file transfer and pivot controls into command dispatch` —
   extend the typed contract only after #98.
 - #65 `[Agent] Configuration System extension`
@@ -377,14 +380,15 @@ detection, Internet-scale botnet market measurement.
 
 Recommended next sequence:
 
-1. Add #100 on the durable model so operator and agent actions have causal,
-   reviewable audit events.
-2. Tackle #88 after #98, adding file transfer and pivot operations as explicit
+1. Tackle #88 after #98, adding file transfer and pivot operations as explicit
    task types instead of new string commands.
-3. Continue the bounded #99 payload-quality track alongside the data path.
+2. Continue the bounded #99 payload-quality track alongside the data path.
+3. Build evidence export and reporting views on the completed structured audit
+   foundation.
 
-The data path is **#98 → #97 → #100**. Issues #98 and #97 are complete, and
-#104 closes the authenticated-enrollment boundary for the `dev` integration
-line. No `dev` to `main` promotion is part of this sequence, and the #104
-implementation does not imply that one is ready. Issue #99 remains a bounded
-P1 payload-quality track that can proceed alongside it.
+The data path **#98 → #97 → #100** is complete on the `dev` integration line,
+and #104 closes the authenticated-enrollment boundary there. No `dev` to
+`main` promotion is part of this sequence, and completion does not imply that
+one is ready. Issue #108 is an explicit promotion gate for cross-platform
+payload-path containment. Issue #99 remains a bounded P1 payload-quality track
+that can proceed alongside it.

--- a/docs/schemas/audit-event-v1.schema.json
+++ b/docs/schemas/audit-event-v1.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/audit-event-v1.schema.json",
+  "title": "MicroC2 Audit Event v1",
+  "description": "Immutable, actor-aware audit record with a closed redacted field set. Commands, output, request bodies, credentials, file contents, terminal transcripts, and raw errors are intentionally excluded.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "sequence",
+    "occurred_at",
+    "actor",
+    "action",
+    "route",
+    "target",
+    "outcome"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time",
+      "maxLength": 35
+    },
+    "actor": {
+      "$ref": "#/$defs/actor"
+    },
+    "action": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[a-z0-9._:-]+$"
+    },
+    "route": {
+      "$ref": "#/$defs/text256"
+    },
+    "target": {
+      "$ref": "#/$defs/target"
+    },
+    "outcome": {
+      "enum": [
+        "succeeded",
+        "failed",
+        "denied",
+        "noop"
+      ]
+    },
+    "reason_code": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z0-9._:-]+$"
+    },
+    "causation_sequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "listener_id": {
+      "$ref": "#/$defs/text128"
+    },
+    "agent_id": {
+      "$ref": "#/$defs/text128"
+    },
+    "task_id": {
+      "$ref": "#/$defs/text128"
+    },
+    "payload_build_id": {
+      "$ref": "#/$defs/text128"
+    },
+    "file_name": {
+      "$ref": "#/$defs/text255"
+    },
+    "terminal_session_id": {
+      "$ref": "#/$defs/text128"
+    }
+  },
+  "$defs": {
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "operator",
+            "agent",
+            "system"
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/text128"
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-z0-9._:-]+$"
+        },
+        "id": {
+          "$ref": "#/$defs/text255"
+        }
+      }
+    },
+    "text128": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^(?!\\s)(?!.*\\s$)(?!.*\\p{Cc}).+$"
+    },
+    "text255": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "pattern": "^(?!\\s)(?!.*\\s$)(?!.*\\p{Cc}).+$"
+    },
+    "text256": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^(?!\\s)(?!.*\\s$)(?!.*\\p{Cc}).+$"
+    }
+  }
+}

--- a/docs/schemas/audit-page-v1.schema.json
+++ b/docs/schemas/audit-page-v1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/audit-page-v1.schema.json",
+  "title": "MicroC2 Audit Page v1",
+  "description": "Bounded, newest-first page of immutable structured audit events.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "events",
+    "limit",
+    "offset",
+    "total",
+    "next_offset"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "events": {
+      "type": "array",
+      "maxItems": 100,
+      "items": {
+        "$ref": "audit-event-v1.schema.json"
+      }
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100
+    },
+    "offset": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000000
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "next_offset": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    }
+  }
+}

--- a/docs/schemas/examples/audit-page-v1.json
+++ b/docs/schemas/examples/audit-page-v1.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "events": [
+    {
+      "schema_version": 1,
+      "sequence": 42,
+      "occurred_at": "2026-07-24T09:15:05Z",
+      "actor": {
+        "kind": "agent",
+        "id": "agent-lab-01"
+      },
+      "action": "task.result_received",
+      "route": "POST /api/agent/{agent_id}/results",
+      "target": {
+        "kind": "task",
+        "id": "task-7"
+      },
+      "outcome": "succeeded",
+      "causation_sequence": 41,
+      "listener_id": "listener-lab",
+      "agent_id": "agent-lab-01",
+      "task_id": "task-7"
+    },
+    {
+      "schema_version": 1,
+      "sequence": 41,
+      "occurred_at": "2026-07-24T09:15:00Z",
+      "actor": {
+        "kind": "operator",
+        "id": "shared-token"
+      },
+      "action": "task.queued",
+      "route": "POST /api/agents/{agent_id}/tasks",
+      "target": {
+        "kind": "task",
+        "id": "task-7"
+      },
+      "outcome": "succeeded",
+      "listener_id": "listener-lab",
+      "agent_id": "agent-lab-01",
+      "task_id": "task-7"
+    }
+  ],
+  "limit": 50,
+  "offset": 0,
+  "total": 2,
+  "next_offset": null
+}

--- a/docs/schemas/validate-examples.js
+++ b/docs/schemas/validate-examples.js
@@ -23,6 +23,7 @@ for (const file of schemaFiles) {
 }
 
 const exampleSchemas = new Map([
+    ['audit-page-v1.json', 'audit-page-v1.schema.json'],
     ['task-create-request-v1.json', 'task-create-request-v1.schema.json'],
     ['task-dispatched-v1.json', 'task-v1.schema.json'],
     ['task-page-v1.json', 'task-page-v1.schema.json'],
@@ -128,6 +129,30 @@ for (const testCase of lifecyclePositiveCases) {
 }
 
 const negativeCases = [
+    {
+        name: 'audit event rejects arbitrary details',
+        schema: 'audit-event-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'audit-page-v1.json')).events[0],
+            details: 'terminal output must never appear here'
+        }
+    },
+    {
+        name: 'audit event rejects a credential-shaped arbitrary field',
+        schema: 'audit-event-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'audit-page-v1.json')).events[0],
+            token: 'must-not-be-recorded'
+        }
+    },
+    {
+        name: 'audit page rejects an excessive offset',
+        schema: 'audit-page-v1.schema.json',
+        value: {
+            ...readJSON(path.join(exampleDirectory, 'audit-page-v1.json')),
+            offset: 1000001
+        }
+    },
     {
         name: 'create request rejects a blank command',
         schema: 'task-create-request-v1.schema.json',

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -2,15 +2,15 @@
 
 MicroC2's development branch uses one process-wide SQLite database for durable
 server state. It stores listener records and lifecycle events, historical agent
-metadata, typed task lifecycles and results, legacy result projections, and
-payload-build metadata. With #104 it also stores the enrollment HMAC key,
-payload bootstrap hashes and allowances, and durable agent-session state.
-Payload binaries, listener compatibility configs, operator uploads, and server
-logs remain files on disk.
+metadata, typed task lifecycles and results, legacy result projections,
+payload-build metadata, and immutable structured audit events. With #104 it
+also stores the enrollment HMAC key, payload bootstrap hashes and allowances,
+and durable agent-session state. Payload binaries, listener compatibility
+configs, operator uploads, and server logs remain files on disk.
 
-This is a single-process, local-lab persistence design. Issue #97 is merged into
-`dev`, and #104 builds authenticated enrollment on that foundation. Neither is
-a substitute for the structured audit trail planned in #100.
+This is a single-process, local-lab persistence design. Issues #97 and #104
+provide the durable and authenticated foundations on the `dev` integration
+line; #100 adds the separate actor-aware audit layer.
 
 ## Configuration
 
@@ -87,6 +87,11 @@ each build/listener/agent tuple. Per-build allowances count identities ever
 allocated from that bootstrap; revoking a session does not make its slot
 available to a different identity.
 
+`0004_structured_audit_events.sql` adds Audit Event v1 storage and causal links
+from tasks, payload builds, and listener lifecycle records. Existing records
+are backfilled with explicit `system` migration events, so an upgraded database
+does not pretend that pre-audit history had an authenticated human actor.
+
 A newly created database directory is restricted to mode `0700` on platforms
 that support POSIX permissions. The database file is created or tightened to
 mode `0600`. MicroC2 does not change permissions on an existing database parent
@@ -158,10 +163,10 @@ with current-user DPAPI, while Unix uses `0700` directories and `0600` files.
 Losing that state requires an explicit operator re-enrollment because the
 embedded bootstrap cannot replay after confirmation.
 
-Listener lifecycle events are append-only operational history. They cover
+Listener lifecycle events remain append-only operational history. They cover
 creation, import, start, stop, error, delete, compensated creation failure, and
-crash recovery, but they are not actor-aware security audit records. Issue
-#100 remains the audit boundary.
+crash recovery. Each new lifecycle record links to its structured audit event;
+older records are linked to explicit migration events.
 
 Payload metadata survives restart independently of the artifact bytes. A
 metadata row is created in `building` immediately before the build process
@@ -176,6 +181,61 @@ does not substitute different bytes.
 The compatibility `/static/` file server denies both `listeners` and `payloads`
 trees. Payload downloads must pass through the metadata and digest gate at
 `/api/payload/download/{id}`.
+
+## Structured Audit Events
+
+Audit Event v1 records:
+
+- a monotonic sequence and server receipt time;
+- an actor kind and identifier;
+- a stable action, route, target, and outcome;
+- an optional closed reason code and causal event sequence; and
+- only the relevant listener, agent, task, payload-build, file-basename, or
+  terminal-session identifiers.
+
+The normative contracts are [Audit Event v1](schemas/audit-event-v1.schema.json)
+and [Audit Page v1](schemas/audit-page-v1.schema.json). Authenticated operator
+requests identify the actor as `operator/loopback` or
+`operator/shared-token`. These identify the authentication mechanism, not an
+individual person. Agent lifecycle events use the enrolled runtime agent ID,
+and recovery or migration events use an explicit system actor.
+
+The application appends audit events transactionally with the durable state
+change where a shared SQLite transaction is available. Task and payload rows
+retain their root causal sequence; later lifecycle events reference it.
+Listener lifecycle rows retain the corresponding event sequence. Exact task
+status/result retries remain idempotent instead of manufacturing duplicate
+success events. Agent-session rotation, revocation, and required re-enrollment
+also share their state transaction with the audit append. Payload artifact
+reconciliation emits a root-linked event only when its durable state, detail,
+or verified hash changes; failed download attempts and rejected enrollment
+revocations receive closed reason codes.
+Audit history survives restart and is available newest-first at
+`GET /api/audit/events?limit=50&offset=0`; the operator endpoint allows 1–100
+events per page, caps requested offsets at 1,000,000, and sends
+`Cache-Control: no-store`.
+
+The event input is a closed allowlist. It deliberately has no arbitrary
+metadata, details, request-body, or raw-error field. MicroC2 never records:
+
+- task commands, stdout, stderr, or result error text;
+- terminal commands, terminal output, or transcripts;
+- operator or agent credentials, authorization headers, bootstrap values,
+  session bearers, or enrollment keys;
+- uploaded/downloaded file contents, multipart bodies, or full filesystem
+  paths; or
+- payload build output, compiler output, embedded configuration, or secret
+  build inputs.
+
+File basenames and object identifiers are still potentially sensitive
+metadata, and the SQLite database already contains credential-adjacent
+enrollment state. Protect the database and its backups accordingly. Audit
+events are application-level append-only: MicroC2 has no event update,
+selective-delete, TTL, or automatic-pruning API. The current retention period
+is therefore the lifetime of the database and its cold backups. If a lab has a
+shorter retention policy, rotate complete, coordinated database/artifact backup
+sets outside MicroC2 rather than editing individual audit rows or foreign-key
+links.
 
 ## Backup, Restore, And Upgrade
 
@@ -233,8 +293,8 @@ schema or migration ledger.
   4,096 active enrollment sessions.
 - Historical agent listings are bounded with `limit`/`offset` pagination:
   default 100 entries, maximum 500.
-- Listener lifecycle events are not the structured, actor-aware audit trail
-  tracked by #100.
+- Structured audit history is bounded only at the retrieval API. Storage has no
+  automatic retention or pruning policy.
 - Operator uploads, payload binaries, listener upload directories, and logs are
   files, not database blobs; backup and restore must include them separately.
   Listener config projections are redacted, regenerable compatibility files.

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"microc2/server/config"
+	"microc2/server/internal/audit"
 	"microc2/server/internal/behaviour"
 	"microc2/server/internal/common"
 	"microc2/server/internal/filestore"
@@ -59,6 +60,10 @@ func main() {
 	}
 	defer stateDatabase.Close()
 	log.Printf("[CONFIG] Durable state database: %s", stateDatabase.Path())
+	auditStore, err := audit.NewStore(stateDatabase)
+	if err != nil {
+		log.Fatalf("Failed to initialize structured audit store: %v", err)
+	}
 
 	// Set up the operator guard: loopback clients always pass; non-loopback
 	// clients need the configured operator token. Also enforces the origin
@@ -69,6 +74,11 @@ func main() {
 		log.Printf("[SECURITY] No operator token configured: operator API and terminal are restricted to loopback clients")
 	} else {
 		log.Printf("[SECURITY] Operator token configured: non-loopback operator access requires the %s header", handlers.OperatorTokenHeader)
+	}
+	if cfg.Security.EnableServerTerminal {
+		log.Printf("[SECURITY WARNING] Browser-accessible server terminal is explicitly enabled")
+	} else {
+		log.Printf("[SECURITY] Browser-accessible server terminal is disabled")
 	}
 
 	// Configure CORS origins for agent polling routes (wildcard only when
@@ -121,12 +131,17 @@ func main() {
 	}
 
 	// Initialize handlers
-	fileHandlers := api.NewFileHandlers(fileStore)
+	fileHandlers := api.NewAuditedFileHandlers(fileStore, auditStore)
 	staticHandlers, err := web.New(cfg.Server.StaticDir)
 	if err != nil {
 		log.Fatalf("Failed to initialize static handlers: %v", err)
 	}
-	wsHandlers := ws.New(logStreamer, operatorGuard.CheckOrigin)
+	wsHandlers := ws.NewWithTerminalPolicy(
+		logStreamer,
+		operatorGuard.CheckOrigin,
+		cfg.Security.EnableServerTerminal,
+		auditStore,
+	)
 	listenerHandlers := api.NewListenerHandlers(serverManager.GetListenerManager())
 
 	// Initialize payload handler

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -38,6 +38,48 @@ func TestLoadConfigDefaultsAgentTransportToSecure(t *testing.T) {
 	}
 }
 
+func TestLoadConfigDisablesServerTerminalByDefault(t *testing.T) {
+	t.Setenv("MICROC2_STORAGE_PATH", "")
+	root := t.TempDir()
+	configPath := filepath.Join(root, "settings.yaml")
+	writeTestConfig(t, configPath, "", filepath.Join(root, "static"))
+
+	loaded, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.Security.EnableServerTerminal {
+		t.Fatal("server terminal was enabled by default")
+	}
+}
+
+func TestLoadConfigAllowsExplicitServerTerminalEnablement(t *testing.T) {
+	t.Setenv("MICROC2_STORAGE_PATH", "")
+	root := t.TempDir()
+	configPath := filepath.Join(root, "settings.yaml")
+	writeTestConfig(t, configPath, "", filepath.Join(root, "static"))
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read test config: %v", err)
+	}
+	content = append(
+		content,
+		[]byte("security:\n  enableServerTerminal: true\n")...,
+	)
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		t.Fatalf("write terminal override: %v", err)
+	}
+
+	loaded, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if !loaded.Security.EnableServerTerminal {
+		t.Fatal("explicit server terminal enablement was ignored")
+	}
+}
+
 func TestLoadConfigAllowsExplicitInsecureIsolatedLabOverride(t *testing.T) {
 	t.Setenv("MICROC2_STORAGE_PATH", "")
 	root := t.TempDir()

--- a/server/config/settings.yaml
+++ b/server/config/settings.yaml
@@ -26,6 +26,9 @@ communication:
     
 security:
   enableCORS: true
+  # The browser-accessible server shell is disabled by default. Enable it only
+  # for an explicitly controlled lab after considering host-level impact.
+  enableServerTerminal: false
   agentTransport:
     # Plaintext HTTP agent listeners are rejected unless this isolated-lab
     # escape hatch is explicitly enabled.
@@ -33,8 +36,9 @@ security:
   # CORS origins for agent polling routes. Use ["*"] only as an explicit
   # escape hatch; empty list means no cross-origin access.
   corsOrigins: ["https://localhost:8443", "http://localhost:8080"]
-  # Shared token protecting the operator API, file drop, and server terminal.
-  # Empty means loopback-only operator access (safe lab default).
+  # Shared token protecting the operator API, file drop, and the server
+  # terminal when it is explicitly enabled. Empty means loopback-only operator
+  # access (safe lab default).
   # Can also be set via the MICROC2_OPERATOR_TOKEN environment variable.
   operatorToken: ""
   # Origins allowed to open operator WebSockets (log stream, terminal).

--- a/server/config/types.go
+++ b/server/config/types.go
@@ -31,15 +31,19 @@ type Config struct {
 	} `yaml:"communication"`
 
 	Security struct {
-		EnableCORS     bool     `yaml:"enableCORS"`
-		CORSOrigins    []string `yaml:"corsOrigins"`
-		AgentTransport struct {
+		EnableCORS bool `yaml:"enableCORS"`
+		// EnableServerTerminal permits the browser-accessible shell on the
+		// server host. Its secure default is false.
+		EnableServerTerminal bool     `yaml:"enableServerTerminal"`
+		CORSOrigins          []string `yaml:"corsOrigins"`
+		AgentTransport       struct {
 			// AllowInsecureIsolatedLab permits plaintext HTTP agent listeners.
 			// The secure production default is false.
 			AllowInsecureIsolatedLab bool `yaml:"allowInsecureIsolatedLab"`
 		} `yaml:"agentTransport"`
-		// OperatorToken protects the operator API and server terminal for
-		// non-loopback clients. Empty means loopback-only operator access.
+		// OperatorToken protects the operator API and, when explicitly enabled,
+		// the server terminal for non-loopback clients. Empty means
+		// loopback-only operator access.
 		// Can also be set via the MICROC2_OPERATOR_TOKEN environment variable.
 		OperatorToken string `yaml:"operatorToken"`
 		// OperatorAllowedOrigins lists origins allowed to call operator APIs

--- a/server/internal/audit/context.go
+++ b/server/internal/audit/context.go
@@ -1,0 +1,48 @@
+package audit
+
+import "context"
+
+type actorContextKey struct{}
+
+// WithActor attaches a trusted server-derived actor to a request context.
+func WithActor(ctx context.Context, actor Actor) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, actorContextKey{}, actor)
+}
+
+// ActorFromContext returns the trusted actor attached by an authentication
+// boundary. It never consults request headers or other caller-supplied values.
+func ActorFromContext(ctx context.Context) (Actor, bool) {
+	if ctx == nil {
+		return Actor{}, false
+	}
+	actor, ok := ctx.Value(actorContextKey{}).(Actor)
+	if !ok || actor.ID == "" {
+		return Actor{}, false
+	}
+	switch actor.Kind {
+	case ActorOperator, ActorAgent, ActorSystem:
+		return actor, true
+	default:
+		return Actor{}, false
+	}
+}
+
+// ActorOr returns a trusted contextual actor or the supplied server-owned
+// fallback.
+func ActorOr(ctx context.Context, fallback Actor) Actor {
+	if actor, ok := ActorFromContext(ctx); ok {
+		return actor
+	}
+	return fallback
+}
+
+func DefaultOperatorActor() Actor {
+	return Actor{Kind: ActorOperator, ID: "unspecified"}
+}
+
+func DefaultSystemActor() Actor {
+	return Actor{Kind: ActorSystem, ID: "microc2-server"}
+}

--- a/server/internal/audit/model.go
+++ b/server/internal/audit/model.go
@@ -1,0 +1,199 @@
+package audit
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	// SchemaVersion is the only structured audit contract currently exposed.
+	SchemaVersion = 1
+
+	MaxPageLimit     = 500
+	MaxPageOffset    = 1_000_000
+	DefaultPageLimit = 50
+)
+
+type ActorKind string
+
+const (
+	ActorOperator ActorKind = "operator"
+	ActorAgent    ActorKind = "agent"
+	ActorSystem   ActorKind = "system"
+)
+
+type Outcome string
+
+const (
+	OutcomeSucceeded Outcome = "succeeded"
+	OutcomeFailed    Outcome = "failed"
+	OutcomeDenied    Outcome = "denied"
+	OutcomeNoop      Outcome = "noop"
+)
+
+var ErrInvalidEvent = errors.New("invalid audit event")
+
+// Actor identifies the authenticated principal class responsible for an
+// event. The current operator guard can distinguish loopback from shared-token
+// access, but it cannot identify an individual human.
+type Actor struct {
+	Kind ActorKind `json:"kind"`
+	ID   string    `json:"id"`
+}
+
+// Target identifies the primary object acted upon.
+type Target struct {
+	Kind string `json:"kind"`
+	ID   string `json:"id"`
+}
+
+// Input is the closed, redacted set of fields accepted by the audit store.
+// There is deliberately no arbitrary metadata or error-text field.
+type Input struct {
+	Actor             Actor
+	Action            string
+	Route             string
+	Target            Target
+	Outcome           Outcome
+	ReasonCode        string
+	CausationSequence *int64
+	ListenerID        string
+	AgentID           string
+	TaskID            string
+	PayloadBuildID    string
+	FileName          string
+	TerminalSessionID string
+}
+
+// Event is one immutable durable audit record.
+type Event struct {
+	SchemaVersion     int       `json:"schema_version"`
+	Sequence          int64     `json:"sequence"`
+	OccurredAt        time.Time `json:"occurred_at"`
+	Actor             Actor     `json:"actor"`
+	Action            string    `json:"action"`
+	Route             string    `json:"route"`
+	Target            Target    `json:"target"`
+	Outcome           Outcome   `json:"outcome"`
+	ReasonCode        string    `json:"reason_code,omitempty"`
+	CausationSequence *int64    `json:"causation_sequence,omitempty"`
+	ListenerID        string    `json:"listener_id,omitempty"`
+	AgentID           string    `json:"agent_id,omitempty"`
+	TaskID            string    `json:"task_id,omitempty"`
+	PayloadBuildID    string    `json:"payload_build_id,omitempty"`
+	FileName          string    `json:"file_name,omitempty"`
+	TerminalSessionID string    `json:"terminal_session_id,omitempty"`
+}
+
+type PageOptions struct {
+	Limit  int
+	Offset int
+}
+
+// Page is a deterministic newest-first page. Sequence, rather than a
+// caller-controlled timestamp, is the ordering authority.
+type Page struct {
+	SchemaVersion int     `json:"schema_version"`
+	Events        []Event `json:"events"`
+	Limit         int     `json:"limit"`
+	Offset        int     `json:"offset"`
+	Total         int     `json:"total"`
+	NextOffset    *int    `json:"next_offset"`
+}
+
+func (input Input) validate() error {
+	switch input.Actor.Kind {
+	case ActorOperator, ActorAgent, ActorSystem:
+	default:
+		return invalidField("actor.kind", string(input.Actor.Kind))
+	}
+	if err := validateText("actor.id", input.Actor.ID, 128, false); err != nil {
+		return err
+	}
+	if err := validateCode("action", input.Action, 128); err != nil {
+		return err
+	}
+	if err := validateText("route", input.Route, 256, false); err != nil {
+		return err
+	}
+	if err := validateCode("target.kind", input.Target.Kind, 64); err != nil {
+		return err
+	}
+	if err := validateText("target.id", input.Target.ID, 255, false); err != nil {
+		return err
+	}
+	switch input.Outcome {
+	case OutcomeSucceeded, OutcomeFailed, OutcomeDenied, OutcomeNoop:
+	default:
+		return invalidField("outcome", string(input.Outcome))
+	}
+	if input.ReasonCode != "" {
+		if err := validateCode("reason_code", input.ReasonCode, 64); err != nil {
+			return err
+		}
+	}
+	if input.CausationSequence != nil && *input.CausationSequence <= 0 {
+		return invalidField("causation_sequence", fmt.Sprint(*input.CausationSequence))
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+		limit int
+	}{
+		{name: "listener_id", value: input.ListenerID, limit: 128},
+		{name: "agent_id", value: input.AgentID, limit: 128},
+		{name: "task_id", value: input.TaskID, limit: 128},
+		{name: "payload_build_id", value: input.PayloadBuildID, limit: 128},
+		{name: "file_name", value: input.FileName, limit: 255},
+		{name: "terminal_session_id", value: input.TerminalSessionID, limit: 128},
+	} {
+		if field.value == "" {
+			continue
+		}
+		if err := validateText(field.name, field.value, field.limit, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCode(field, value string, limit int) error {
+	if err := validateText(field, value, limit, false); err != nil {
+		return err
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' ||
+			character >= '0' && character <= '9' ||
+			character == '.' || character == '_' ||
+			character == ':' || character == '-' {
+			continue
+		}
+		return invalidField(field, value)
+	}
+	return nil
+}
+
+func validateText(field, value string, limit int, optional bool) error {
+	if value == "" {
+		if optional {
+			return nil
+		}
+		return invalidField(field, value)
+	}
+	if len(value) > limit || value != strings.TrimSpace(value) {
+		return invalidField(field, value)
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return invalidField(field, value)
+		}
+	}
+	return nil
+}
+
+func invalidField(field, value string) error {
+	return fmt.Errorf("%w: %s has an unsupported value %q", ErrInvalidEvent, field, value)
+}

--- a/server/internal/audit/store.go
+++ b/server/internal/audit/store.go
@@ -1,0 +1,293 @@
+package audit
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"microc2/server/internal/persistence"
+)
+
+const auditTimeLayout = time.RFC3339Nano
+
+// Store appends and queries structured audit events in the process-wide
+// durable database.
+type Store struct {
+	database *persistence.Database
+	now      func() time.Time
+}
+
+func NewStore(database *persistence.Database) (*Store, error) {
+	return newStoreWithClock(database, time.Now)
+}
+
+func newStoreWithClock(
+	database *persistence.Database,
+	now func() time.Time,
+) (*Store, error) {
+	if database == nil || database.SQL() == nil {
+		return nil, errors.New("audit store requires an open database")
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{database: database, now: now}, nil
+}
+
+// Append records an event in its own transaction.
+func (s *Store) Append(ctx context.Context, input Input) (Event, error) {
+	if s == nil || s.database == nil || s.database.SQL() == nil {
+		return Event{}, errors.New("audit store is unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := s.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin audit append: %w", err)
+	}
+	defer tx.Rollback()
+	event, err := s.AppendTx(ctx, tx, input)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit audit append: %w", err)
+	}
+	return event, nil
+}
+
+// AppendTx records an event within an existing durable state transaction.
+func (s *Store) AppendTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	input Input,
+) (Event, error) {
+	if s == nil || tx == nil {
+		return Event{}, errors.New("audit transaction is unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	contextActor, hasContextActor := ActorFromContext(ctx)
+	switch {
+	case input.Actor == (Actor{}) && hasContextActor:
+		input.Actor = contextActor
+	case input.Actor != (Actor{}) &&
+		hasContextActor &&
+		input.Actor != contextActor:
+		return Event{}, fmt.Errorf(
+			"%w: explicit actor does not match trusted context actor",
+			ErrInvalidEvent,
+		)
+	}
+	if err := input.validate(); err != nil {
+		return Event{}, err
+	}
+	occurredAt := s.now().UTC().Round(0)
+	result, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO audit_events (
+			schema_version, occurred_at, actor_kind, actor_id,
+			action, route, target_kind, target_id, outcome, reason_code,
+			causation_sequence, listener_id, agent_id, task_id,
+			payload_build_id, file_name, terminal_session_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		SchemaVersion,
+		occurredAt.Format(auditTimeLayout),
+		string(input.Actor.Kind),
+		input.Actor.ID,
+		input.Action,
+		input.Route,
+		input.Target.Kind,
+		input.Target.ID,
+		string(input.Outcome),
+		nullableString(input.ReasonCode),
+		input.CausationSequence,
+		nullableString(input.ListenerID),
+		nullableString(input.AgentID),
+		nullableString(input.TaskID),
+		nullableString(input.PayloadBuildID),
+		nullableString(input.FileName),
+		nullableString(input.TerminalSessionID),
+	)
+	if err != nil {
+		return Event{}, fmt.Errorf("insert audit event: %w", err)
+	}
+	sequence, err := result.LastInsertId()
+	if err != nil {
+		return Event{}, fmt.Errorf("read audit sequence: %w", err)
+	}
+	return eventFromInput(sequence, occurredAt, input), nil
+}
+
+// Page returns one consistent newest-first snapshot.
+func (s *Store) Page(ctx context.Context, options PageOptions) (Page, error) {
+	if s == nil || s.database == nil || s.database.SQL() == nil {
+		return Page{}, errors.New("audit store is unavailable")
+	}
+	if options.Limit < 1 || options.Limit > MaxPageLimit {
+		return Page{}, fmt.Errorf(
+			"audit page limit must be between 1 and %d",
+			MaxPageLimit,
+		)
+	}
+	if options.Offset < 0 {
+		return Page{}, errors.New("audit page offset must not be negative")
+	}
+	if options.Offset > MaxPageOffset {
+		return Page{}, fmt.Errorf(
+			"audit page offset must not exceed %d",
+			MaxPageOffset,
+		)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := s.database.SQL().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return Page{}, fmt.Errorf("begin audit page: %w", err)
+	}
+	defer tx.Rollback()
+
+	var total int
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM audit_events`,
+	).Scan(&total); err != nil {
+		return Page{}, fmt.Errorf("count audit events: %w", err)
+	}
+	rows, err := tx.QueryContext(
+		ctx,
+		`SELECT
+			seq, schema_version, occurred_at, actor_kind, actor_id,
+			action, route, target_kind, target_id, outcome, reason_code,
+			causation_sequence, listener_id, agent_id, task_id,
+			payload_build_id, file_name, terminal_session_id
+		 FROM audit_events
+		 ORDER BY seq DESC
+		 LIMIT ? OFFSET ?`,
+		options.Limit,
+		options.Offset,
+	)
+	if err != nil {
+		return Page{}, fmt.Errorf("query audit events: %w", err)
+	}
+	events := make([]Event, 0, options.Limit)
+	for rows.Next() {
+		event, err := scanEvent(rows)
+		if err != nil {
+			_ = rows.Close()
+			return Page{}, fmt.Errorf("scan audit event: %w", err)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return Page{}, fmt.Errorf("iterate audit events: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return Page{}, fmt.Errorf("close audit events: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return Page{}, fmt.Errorf("commit audit page: %w", err)
+	}
+
+	var nextOffset *int
+	if next := options.Offset + len(events); next < total {
+		nextOffset = &next
+	}
+	return Page{
+		SchemaVersion: SchemaVersion,
+		Events:        events,
+		Limit:         options.Limit,
+		Offset:        options.Offset,
+		Total:         total,
+		NextOffset:    nextOffset,
+	}, nil
+}
+
+type eventScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanEvent(scanner eventScanner) (Event, error) {
+	var event Event
+	var occurredAt, actorKind, outcome string
+	var reasonCode sql.NullString
+	var causationSequence sql.NullInt64
+	var listenerID, agentID, taskID sql.NullString
+	var payloadBuildID, fileName, terminalSessionID sql.NullString
+	if err := scanner.Scan(
+		&event.Sequence,
+		&event.SchemaVersion,
+		&occurredAt,
+		&actorKind,
+		&event.Actor.ID,
+		&event.Action,
+		&event.Route,
+		&event.Target.Kind,
+		&event.Target.ID,
+		&outcome,
+		&reasonCode,
+		&causationSequence,
+		&listenerID,
+		&agentID,
+		&taskID,
+		&payloadBuildID,
+		&fileName,
+		&terminalSessionID,
+	); err != nil {
+		return Event{}, err
+	}
+	parsedTime, err := time.Parse(auditTimeLayout, occurredAt)
+	if err != nil {
+		return Event{}, fmt.Errorf("parse occurred_at: %w", err)
+	}
+	event.OccurredAt = parsedTime
+	event.Actor.Kind = ActorKind(actorKind)
+	event.Outcome = Outcome(outcome)
+	event.ReasonCode = reasonCode.String
+	if causationSequence.Valid {
+		value := causationSequence.Int64
+		event.CausationSequence = &value
+	}
+	event.ListenerID = listenerID.String
+	event.AgentID = agentID.String
+	event.TaskID = taskID.String
+	event.PayloadBuildID = payloadBuildID.String
+	event.FileName = fileName.String
+	event.TerminalSessionID = terminalSessionID.String
+	return event, nil
+}
+
+func eventFromInput(sequence int64, occurredAt time.Time, input Input) Event {
+	event := Event{
+		SchemaVersion:     SchemaVersion,
+		Sequence:          sequence,
+		OccurredAt:        occurredAt,
+		Actor:             input.Actor,
+		Action:            input.Action,
+		Route:             input.Route,
+		Target:            input.Target,
+		Outcome:           input.Outcome,
+		ReasonCode:        input.ReasonCode,
+		CausationSequence: input.CausationSequence,
+		ListenerID:        input.ListenerID,
+		AgentID:           input.AgentID,
+		TaskID:            input.TaskID,
+		PayloadBuildID:    input.PayloadBuildID,
+		FileName:          input.FileName,
+		TerminalSessionID: input.TerminalSessionID,
+	}
+	return event
+}
+
+func nullableString(value string) interface{} {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/server/internal/audit/store_test.go
+++ b/server/internal/audit/store_test.go
@@ -1,0 +1,468 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"microc2/server/internal/persistence"
+)
+
+func TestStoreAppendResolvesContextActorAndPersistsClosedFields(t *testing.T) {
+	fixedNow := time.Date(
+		2026,
+		time.July,
+		24,
+		14,
+		30,
+		0,
+		123456789,
+		time.FixedZone("test", 2*60*60),
+	)
+	database, store := newAuditTestStore(t, fixedNow)
+	defer database.Close()
+
+	actor := Actor{Kind: ActorOperator, ID: "local-loopback"}
+	ctx := WithActor(context.Background(), actor)
+	root, err := store.Append(ctx, Input{
+		Action:     "task.queued",
+		Route:      "/api/agents/{agent_id}/tasks",
+		Target:     Target{Kind: "task", ID: "task-one"},
+		Outcome:    OutcomeSucceeded,
+		ReasonCode: "operator_request",
+		ListenerID: "listener-one",
+		AgentID:    "agent-one",
+		TaskID:     "task-one",
+	})
+	if err != nil {
+		t.Fatalf("append root event: %v", err)
+	}
+	if root.Sequence != 1 || root.SchemaVersion != SchemaVersion {
+		t.Fatalf("root identity = (%d, %d), want (1, %d)", root.Sequence, root.SchemaVersion, SchemaVersion)
+	}
+	if root.Actor != actor {
+		t.Fatalf("root actor = %#v, want %#v", root.Actor, actor)
+	}
+	wantTime := fixedNow.UTC()
+	if !root.OccurredAt.Equal(wantTime) || root.OccurredAt.Location() != time.UTC {
+		t.Fatalf("root occurred_at = %s, want UTC %s", root.OccurredAt, wantTime)
+	}
+
+	child, err := store.Append(ctx, Input{
+		Actor:             actor,
+		Action:            "task.result_received",
+		Route:             "/api/agent/{agent_id}/results",
+		Target:            Target{Kind: "task", ID: "task-one"},
+		Outcome:           OutcomeFailed,
+		ReasonCode:        "agent_reported_failure",
+		CausationSequence: &root.Sequence,
+		ListenerID:        "listener-one",
+		AgentID:           "agent-one",
+		TaskID:            "task-one",
+		PayloadBuildID:    "payload-one",
+		FileName:          "artifact.bin",
+		TerminalSessionID: "terminal-one",
+	})
+	if err != nil {
+		t.Fatalf("append causal event: %v", err)
+	}
+
+	page, err := store.Page(context.Background(), PageOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("page events: %v", err)
+	}
+	if page.SchemaVersion != SchemaVersion ||
+		page.Total != 2 ||
+		len(page.Events) != 2 ||
+		page.NextOffset != nil {
+		t.Fatalf("unexpected page envelope: %#v", page)
+	}
+	got := page.Events[0]
+	if got.Sequence != child.Sequence ||
+		got.Actor != actor ||
+		got.Action != "task.result_received" ||
+		got.Route != "/api/agent/{agent_id}/results" ||
+		got.Target != (Target{Kind: "task", ID: "task-one"}) ||
+		got.Outcome != OutcomeFailed ||
+		got.ReasonCode != "agent_reported_failure" ||
+		got.CausationSequence == nil ||
+		*got.CausationSequence != root.Sequence ||
+		got.ListenerID != "listener-one" ||
+		got.AgentID != "agent-one" ||
+		got.TaskID != "task-one" ||
+		got.PayloadBuildID != "payload-one" ||
+		got.FileName != "artifact.bin" ||
+		got.TerminalSessionID != "terminal-one" {
+		t.Fatalf("persisted event did not round-trip: %#v", got)
+	}
+}
+
+func TestStoreRejectsActorSpoofingAndMissingActor(t *testing.T) {
+	database, store := newAuditTestStore(t, time.Now())
+	defer database.Close()
+
+	contextActor := Actor{Kind: ActorOperator, ID: "shared-token"}
+	input := validAuditInput()
+	input.Actor = Actor{Kind: ActorSystem, ID: "microc2-server"}
+	if _, err := store.Append(
+		WithActor(context.Background(), contextActor),
+		input,
+	); !errors.Is(err, ErrInvalidEvent) {
+		t.Fatalf("mismatched explicit/context actor error = %v, want ErrInvalidEvent", err)
+	}
+
+	input.Actor = Actor{}
+	if _, err := store.Append(context.Background(), input); !errors.Is(err, ErrInvalidEvent) {
+		t.Fatalf("missing actor error = %v, want ErrInvalidEvent", err)
+	}
+	assertAuditCount(t, database, 0)
+}
+
+func TestStoreAppendTxRollsBackWithCallerTransaction(t *testing.T) {
+	database, store := newAuditTestStore(t, time.Now())
+	defer database.Close()
+
+	tx, err := database.SQL().BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin caller transaction: %v", err)
+	}
+	event, err := store.AppendTx(context.Background(), tx, validAuditInput())
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("append in caller transaction: %v", err)
+	}
+	if event.Sequence < 1 {
+		_ = tx.Rollback()
+		t.Fatalf("transactional event sequence = %d, want positive", event.Sequence)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback caller transaction: %v", err)
+	}
+	assertAuditCount(t, database, 0)
+}
+
+func TestStoreEventsSurviveDatabaseRestart(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "microc2.db")
+	database, err := persistence.Open(databasePath)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	store, err := NewStore(database)
+	if err != nil {
+		t.Fatalf("construct store: %v", err)
+	}
+	written, err := store.Append(context.Background(), validAuditInput())
+	if err != nil {
+		t.Fatalf("append before restart: %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+
+	reopened, err := persistence.Open(databasePath)
+	if err != nil {
+		t.Fatalf("reopen database: %v", err)
+	}
+	defer reopened.Close()
+	restartedStore, err := NewStore(reopened)
+	if err != nil {
+		t.Fatalf("construct restarted store: %v", err)
+	}
+	page, err := restartedStore.Page(context.Background(), PageOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("page after restart: %v", err)
+	}
+	if page.Total != 1 ||
+		len(page.Events) != 1 ||
+		page.Events[0].Sequence != written.Sequence ||
+		page.Events[0].Action != written.Action {
+		t.Fatalf("restarted page = %#v, want written event %#v", page, written)
+	}
+}
+
+func TestStorePageIsNewestFirstAndStableAcrossOffsets(t *testing.T) {
+	database, store := newAuditTestStore(
+		t,
+		time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC),
+	)
+	defer database.Close()
+
+	for index := 1; index <= 5; index++ {
+		input := validAuditInput()
+		input.Action = "audit.test." + strconv.Itoa(index)
+		input.Target.ID = "event-" + strconv.Itoa(index)
+		if _, err := store.Append(context.Background(), input); err != nil {
+			t.Fatalf("append event %d: %v", index, err)
+		}
+	}
+
+	first, err := store.Page(
+		context.Background(),
+		PageOptions{Limit: 2, Offset: 0},
+	)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if first.Total != 5 ||
+		len(first.Events) != 2 ||
+		first.Events[0].Sequence != 5 ||
+		first.Events[1].Sequence != 4 ||
+		first.NextOffset == nil ||
+		*first.NextOffset != 2 {
+		t.Fatalf("unexpected first page: %#v", first)
+	}
+
+	second, err := store.Page(
+		context.Background(),
+		PageOptions{Limit: 2, Offset: *first.NextOffset},
+	)
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if second.Total != 5 ||
+		len(second.Events) != 2 ||
+		second.Events[0].Sequence != 3 ||
+		second.Events[1].Sequence != 2 ||
+		second.NextOffset == nil ||
+		*second.NextOffset != 4 {
+		t.Fatalf("unexpected second page: %#v", second)
+	}
+
+	last, err := store.Page(
+		context.Background(),
+		PageOptions{Limit: 2, Offset: *second.NextOffset},
+	)
+	if err != nil {
+		t.Fatalf("last page: %v", err)
+	}
+	if len(last.Events) != 1 ||
+		last.Events[0].Sequence != 1 ||
+		last.NextOffset != nil {
+		t.Fatalf("unexpected last page: %#v", last)
+	}
+}
+
+func TestStoreValidatesClosedRedactedContract(t *testing.T) {
+	database, store := newAuditTestStore(t, time.Now())
+	defer database.Close()
+
+	zero := int64(0)
+	tests := []struct {
+		name   string
+		mutate func(*Input)
+	}{
+		{
+			name: "actor kind",
+			mutate: func(input *Input) {
+				input.Actor.Kind = ActorKind("guest")
+			},
+		},
+		{
+			name: "actor id",
+			mutate: func(input *Input) {
+				input.Actor.ID = ""
+			},
+		},
+		{
+			name: "dynamic action",
+			mutate: func(input *Input) {
+				input.Action = "Task Queued"
+			},
+		},
+		{
+			name: "route control character",
+			mutate: func(input *Input) {
+				input.Route = "/api/tasks\nX-Secret: value"
+			},
+		},
+		{
+			name: "target kind",
+			mutate: func(input *Input) {
+				input.Target.Kind = ""
+			},
+		},
+		{
+			name: "target id",
+			mutate: func(input *Input) {
+				input.Target.ID = ""
+			},
+		},
+		{
+			name: "outcome",
+			mutate: func(input *Input) {
+				input.Outcome = Outcome("maybe")
+			},
+		},
+		{
+			name: "freeform reason",
+			mutate: func(input *Input) {
+				input.ReasonCode = "raw error text"
+			},
+		},
+		{
+			name: "causation sequence",
+			mutate: func(input *Input) {
+				input.CausationSequence = &zero
+			},
+		},
+		{
+			name: "object control character",
+			mutate: func(input *Input) {
+				input.FileName = "secret\nname"
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			input := validAuditInput()
+			testCase.mutate(&input)
+			if _, err := store.Append(
+				context.Background(),
+				input,
+			); !errors.Is(err, ErrInvalidEvent) {
+				t.Fatalf("Append error = %v, want ErrInvalidEvent", err)
+			}
+		})
+	}
+	assertAuditCount(t, database, 0)
+
+	for _, value := range []interface{}{Input{}, Event{}} {
+		valueType := reflect.TypeOf(value)
+		for index := 0; index < valueType.NumField(); index++ {
+			name := strings.ToLower(valueType.Field(index).Name)
+			for _, forbidden := range []string{
+				"body",
+				"command",
+				"details",
+				"error",
+				"metadata",
+				"output",
+				"secret",
+				"token",
+			} {
+				if strings.Contains(name, forbidden) {
+					t.Fatalf("%s unexpectedly exposes freeform/sensitive field %q", valueType.Name(), name)
+				}
+			}
+		}
+	}
+
+	encoded, err := json.Marshal(Event{
+		SchemaVersion: SchemaVersion,
+		Sequence:      1,
+		OccurredAt:    time.Now().UTC(),
+		Actor:         Actor{Kind: ActorSystem, ID: "microc2-server"},
+		Action:        "audit.test",
+		Route:         "internal:test",
+		Target:        Target{Kind: "audit", ID: "test"},
+		Outcome:       OutcomeSucceeded,
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	for _, forbidden := range []string{
+		`"details"`,
+		`"error"`,
+		`"metadata"`,
+		`"request_body"`,
+	} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("encoded event exposes forbidden field %s: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestStoreRejectsInvalidPagesAndDanglingCausation(t *testing.T) {
+	database, store := newAuditTestStore(t, time.Now())
+	defer database.Close()
+
+	for _, options := range []PageOptions{
+		{Limit: 0},
+		{Limit: -1},
+		{Limit: MaxPageLimit + 1},
+		{Limit: 1, Offset: -1},
+		{Limit: 1, Offset: MaxPageOffset + 1},
+	} {
+		if _, err := store.Page(context.Background(), options); err == nil {
+			t.Fatalf("invalid page %#v unexpectedly succeeded", options)
+		}
+	}
+
+	missing := int64(999)
+	input := validAuditInput()
+	input.CausationSequence = &missing
+	if _, err := store.Append(context.Background(), input); err == nil {
+		t.Fatal("dangling causation unexpectedly inserted")
+	}
+	assertAuditCount(t, database, 0)
+}
+
+func TestActorContextHelpersRejectUnsupportedActors(t *testing.T) {
+	actor := Actor{Kind: ActorAgent, ID: "agent-one"}
+	ctx := WithActor(context.Background(), actor)
+	if got, ok := ActorFromContext(ctx); !ok || got != actor {
+		t.Fatalf("ActorFromContext = (%#v, %t), want (%#v, true)", got, ok, actor)
+	}
+	if got := ActorOr(ctx, DefaultSystemActor()); got != actor {
+		t.Fatalf("ActorOr = %#v, want contextual actor %#v", got, actor)
+	}
+	if _, ok := ActorFromContext(WithActor(
+		context.Background(),
+		Actor{Kind: ActorKind("guest"), ID: "guest"},
+	)); ok {
+		t.Fatal("unsupported contextual actor unexpectedly accepted")
+	}
+	if got := ActorOr(context.Background(), DefaultOperatorActor()); got != DefaultOperatorActor() {
+		t.Fatalf("ActorOr fallback = %#v, want %#v", got, DefaultOperatorActor())
+	}
+}
+
+func newAuditTestStore(
+	t *testing.T,
+	now time.Time,
+) (*persistence.Database, *Store) {
+	t.Helper()
+	database, err := persistence.Open(filepath.Join(t.TempDir(), "microc2.db"))
+	if err != nil {
+		t.Fatalf("open audit test database: %v", err)
+	}
+	store, err := newStoreWithClock(database, func() time.Time { return now })
+	if err != nil {
+		_ = database.Close()
+		t.Fatalf("construct audit test store: %v", err)
+	}
+	return database, store
+}
+
+func validAuditInput() Input {
+	return Input{
+		Actor:   Actor{Kind: ActorSystem, ID: "microc2-server"},
+		Action:  "audit.test",
+		Route:   "internal:test",
+		Target:  Target{Kind: "audit", ID: "test"},
+		Outcome: OutcomeSucceeded,
+	}
+}
+
+func assertAuditCount(
+	t *testing.T,
+	database *persistence.Database,
+	want int,
+) {
+	t.Helper()
+	var got int
+	if err := database.SQL().QueryRow(
+		`SELECT COUNT(*) FROM audit_events`,
+	).Scan(&got); err != nil {
+		t.Fatalf("count audit events: %v", err)
+	}
+	if got != want {
+		t.Fatalf("audit event count = %d, want %d", got, want)
+	}
+}

--- a/server/internal/behaviour/http_polling.go
+++ b/server/internal/behaviour/http_polling.go
@@ -942,7 +942,44 @@ func (p *HTTPPollingProtocol) QueueLegacyShellTask(agentID, command string) (tas
 	return p.taskStore.CreateLegacyShell(agentID, command)
 }
 
+// QueueLegacyShellTaskContext preserves the authenticated operator actor for
+// durable audit records while retaining the legacy adapter surface.
+func (p *HTTPPollingProtocol) QueueLegacyShellTaskContext(
+	ctx context.Context,
+	agentID, command string,
+) (tasks.Task, error) {
+	if store, ok := p.taskStore.(interface {
+		CreateLegacyShellContext(
+			context.Context,
+			string,
+			string,
+		) (tasks.Task, error)
+	}); ok {
+		return store.CreateLegacyShellContext(ctx, agentID, command)
+	}
+	return p.taskStore.CreateLegacyShell(agentID, command)
+}
+
 func (p *HTTPPollingProtocol) CreateTask(agentID string, createRequest tasks.CreateRequest) (tasks.Task, error) {
+	return p.taskStore.Create(agentID, createRequest)
+}
+
+// CreateTaskContext preserves the authenticated operator actor for durable
+// task queue audit records.
+func (p *HTTPPollingProtocol) CreateTaskContext(
+	ctx context.Context,
+	agentID string,
+	createRequest tasks.CreateRequest,
+) (tasks.Task, error) {
+	if store, ok := p.taskStore.(interface {
+		CreateContext(
+			context.Context,
+			string,
+			tasks.CreateRequest,
+		) (tasks.Task, error)
+	}); ok {
+		return store.CreateContext(ctx, agentID, createRequest)
+	}
 	return p.taskStore.Create(agentID, createRequest)
 }
 
@@ -991,6 +1028,24 @@ func (p *HTTPPollingProtocol) ListTaskSummariesPage(
 }
 
 func (p *HTTPPollingProtocol) CancelTask(agentID, taskID string) (tasks.Task, error) {
+	return p.taskStore.Cancel(agentID, taskID)
+}
+
+// CancelTaskContext preserves the authenticated operator actor for durable
+// task cancellation audit records.
+func (p *HTTPPollingProtocol) CancelTaskContext(
+	ctx context.Context,
+	agentID, taskID string,
+) (tasks.Task, error) {
+	if store, ok := p.taskStore.(interface {
+		CancelContext(
+			context.Context,
+			string,
+			string,
+		) (tasks.Task, error)
+	}); ok {
+		return store.CancelContext(ctx, agentID, taskID)
+	}
 	return p.taskStore.Cancel(agentID, taskID)
 }
 

--- a/server/internal/behaviour/http_polling_test.go
+++ b/server/internal/behaviour/http_polling_test.go
@@ -2,9 +2,11 @@ package behaviour
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"microc2/server/internal/audit"
 	"microc2/server/internal/common"
 	"microc2/server/internal/tasks"
 	"net/http"
@@ -758,6 +760,89 @@ func TestHTTPPollingProtocolRejectsTraversalUploadFilename(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected traversal upload filename 400, got %d: %s", rec.Code, rec.Body.String())
 	}
+}
+
+func TestHTTPPollingProtocolContextTaskAdaptersPreserveOperatorActor(t *testing.T) {
+	store := &contextCapturingTaskStore{Store: tasks.NewStore()}
+	protocol := newHTTPPollingProtocol(
+		common.BaseProtocolConfig{UploadDir: t.TempDir(), Port: "0"},
+		store,
+		nil,
+		"",
+	)
+	operator := audit.Actor{Kind: audit.ActorOperator, ID: "operator-test"}
+	ctx := audit.WithActor(context.Background(), operator)
+	expiresIn := tasks.DefaultExpiresIn
+
+	typed, err := protocol.CreateTaskContext(
+		ctx,
+		"agent-one",
+		tasks.CreateRequest{
+			SchemaVersion:    tasks.SchemaVersion,
+			Type:             tasks.TypeShell,
+			Arguments:        tasks.ShellArguments{Command: "whoami"},
+			TimeoutSeconds:   tasks.DefaultTimeoutSeconds,
+			ExpiresInSeconds: &expiresIn,
+		},
+	)
+	if err != nil {
+		t.Fatalf("create context-aware typed task: %v", err)
+	}
+	if store.createActor != operator {
+		t.Fatalf("typed task actor=%#v, want %#v", store.createActor, operator)
+	}
+	if _, err := protocol.QueueLegacyShellTaskContext(
+		ctx,
+		"agent-one",
+		"hostname",
+	); err != nil {
+		t.Fatalf("create context-aware legacy task: %v", err)
+	}
+	if store.legacyActor != operator {
+		t.Fatalf("legacy task actor=%#v, want %#v", store.legacyActor, operator)
+	}
+	if _, err := protocol.CancelTaskContext(
+		ctx,
+		"agent-one",
+		typed.ID,
+	); err != nil {
+		t.Fatalf("cancel context-aware task: %v", err)
+	}
+	if store.cancelActor != operator {
+		t.Fatalf("cancel actor=%#v, want %#v", store.cancelActor, operator)
+	}
+}
+
+type contextCapturingTaskStore struct {
+	*tasks.Store
+	createActor audit.Actor
+	legacyActor audit.Actor
+	cancelActor audit.Actor
+}
+
+func (s *contextCapturingTaskStore) CreateContext(
+	ctx context.Context,
+	agentID string,
+	request tasks.CreateRequest,
+) (tasks.Task, error) {
+	s.createActor, _ = audit.ActorFromContext(ctx)
+	return s.Store.Create(agentID, request)
+}
+
+func (s *contextCapturingTaskStore) CreateLegacyShellContext(
+	ctx context.Context,
+	agentID, command string,
+) (tasks.Task, error) {
+	s.legacyActor, _ = audit.ActorFromContext(ctx)
+	return s.Store.CreateLegacyShell(agentID, command)
+}
+
+func (s *contextCapturingTaskStore) CancelContext(
+	ctx context.Context,
+	agentID, taskID string,
+) (tasks.Task, error) {
+	s.cancelActor, _ = audit.ActorFromContext(ctx)
+	return s.Store.Cancel(agentID, taskID)
 }
 
 func xorHex(data, key string) string {

--- a/server/internal/behaviour/http_polling_test.go
+++ b/server/internal/behaviour/http_polling_test.go
@@ -826,6 +826,9 @@ func (s *contextCapturingTaskStore) CreateContext(
 	request tasks.CreateRequest,
 ) (tasks.Task, error) {
 	s.createActor, _ = audit.ActorFromContext(ctx)
+	// Store.Create inserts a typed task into this test's in-memory map; it
+	// never creates or opens a filesystem path.
+	// foxguard: ignore[go/taint-path-traversal]
 	return s.Store.Create(agentID, request)
 }
 

--- a/server/internal/enrollment/store.go
+++ b/server/internal/enrollment/store.go
@@ -11,14 +11,24 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strings"
 	"time"
+	"unicode"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/persistence"
 )
 
 const maximumIdentifierBytes = 512
+const maximumAuditIdentifierBytes = 128
 
 const sessionIDGenerationAttempts = 8
+
+const (
+	agentSessionRotateAction   = "agent.session.rotate"
+	agentSessionRevokeAction   = "agent.session.revoke"
+	agentSessionReenrollAction = "agent.session.require_reenrollment"
+)
 
 var dummyVerificationValue = sha256.Sum256([]byte("microc2 enrollment dummy verification"))
 
@@ -26,6 +36,7 @@ var dummyVerificationValue = sha256.Sum256([]byte("microc2 enrollment dummy veri
 // persisted HMAC key.
 type Store struct {
 	db     *sql.DB
+	audit  *audit.Store
 	key    [sha256.Size]byte
 	random io.Reader
 	now    func() time.Time
@@ -41,8 +52,13 @@ func NewStore(ctx context.Context, database *persistence.Database) (*Store, erro
 	if err != nil {
 		return nil, err
 	}
+	auditStore, err := audit.NewStore(database)
+	if err != nil {
+		return nil, fmt.Errorf("initialize enrollment audit store: %w", err)
+	}
 	return &Store{
 		db:     database.SQL(),
+		audit:  auditStore,
 		key:    key,
 		random: rand.Reader,
 		now:    time.Now,
@@ -118,7 +134,29 @@ func (s *Store) ActivatePayloadCredential(
 		return fmt.Errorf("begin payload credential activation: %w", err)
 	}
 	defer rollback(tx)
+	if err := s.ActivatePayloadCredentialTx(ctx, tx, activation); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit payload credential activation: %w", err)
+	}
+	return nil
+}
 
+// ActivatePayloadCredentialTx applies bootstrap activation inside a
+// caller-owned transaction so payload completion metadata and its causal audit
+// event can commit atomically with the credential hash.
+func (s *Store) ActivatePayloadCredentialTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	activation PayloadCredentialActivation,
+) error {
+	if err := validateActivation(activation); err != nil {
+		return err
+	}
+	if tx == nil {
+		return ErrInvalidArgument
+	}
 	var listenerID, state string
 	if err := tx.QueryRowContext(
 		ctx,
@@ -145,7 +183,7 @@ func (s *Store) ActivatePayloadCredential(
 		storedMax      int
 		revokedAt      sql.NullString
 	)
-	err = tx.QueryRowContext(
+	err := tx.QueryRowContext(
 		ctx,
 		`SELECT listener_id, bootstrap_sha256, max_sessions, revoked_at
 		 FROM payload_bootstrap_credentials
@@ -159,9 +197,6 @@ func (s *Store) ActivatePayloadCredential(
 			storedMax != activation.MaxSessions ||
 			revokedAt.Valid {
 			return ErrConflict
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit idempotent payload credential activation: %w", err)
 		}
 		return nil
 	case !errors.Is(err, sql.ErrNoRows):
@@ -182,9 +217,6 @@ func (s *Store) ActivatePayloadCredential(
 	); err != nil {
 		return fmt.Errorf("activate payload credential: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit payload credential activation: %w", err)
-	}
 	return nil
 }
 
@@ -199,6 +231,30 @@ func (s *Store) RevokePayloadCredential(ctx context.Context, payloadBuildID stri
 		return fmt.Errorf("begin payload credential revocation: %w", err)
 	}
 	defer rollback(tx)
+	if err := s.RevokePayloadCredentialTx(ctx, tx, payloadBuildID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit payload credential revocation: %w", err)
+	}
+	return nil
+}
+
+// RevokePayloadCredentialTx applies payload bootstrap revocation inside a
+// caller-owned transaction. The caller remains responsible for commit or
+// rollback, allowing the revocation and its structured audit event to share
+// one atomic boundary.
+func (s *Store) RevokePayloadCredentialTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	payloadBuildID string,
+) error {
+	if err := validateIdentifier(payloadBuildID); err != nil {
+		return err
+	}
+	if tx == nil {
+		return ErrInvalidArgument
+	}
 
 	var exists int
 	if err := tx.QueryRowContext(
@@ -224,9 +280,6 @@ func (s *Store) RevokePayloadCredential(ctx context.Context, payloadBuildID stri
 		payloadBuildID,
 	); err != nil {
 		return fmt.Errorf("revoke payload credential: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit payload credential revocation: %w", err)
 	}
 	return nil
 }
@@ -550,7 +603,8 @@ func (s *Store) Rotate(
 	listenerID string,
 	agentID string,
 ) (Rotation, error) {
-	if validateIdentifier(listenerID) != nil || validateIdentifier(agentID) != nil {
+	if validateAuditIdentifier(listenerID) != nil ||
+		validateAuditIdentifier(agentID) != nil {
 		return Rotation{}, ErrInvalidArgument
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -570,6 +624,18 @@ func (s *Store) Rotate(
 		return Rotation{}, ErrConflict
 	}
 	if session.pendingGeneration.Valid {
+		if err := s.appendAgentSessionAuditTx(
+			ctx,
+			tx,
+			listenerID,
+			agentID,
+			agentSessionRotateAction,
+			"POST /api/listeners/{listener_id}/agents/{agent_id}/session/rotate",
+			audit.OutcomeNoop,
+			"rotation_already_pending",
+		); err != nil {
+			return Rotation{}, err
+		}
 		if err := tx.Commit(); err != nil {
 			return Rotation{}, fmt.Errorf("commit existing session rotation: %w", err)
 		}
@@ -594,6 +660,18 @@ func (s *Store) Rotate(
 	); err != nil {
 		return Rotation{}, fmt.Errorf("install pending session rotation: %w", err)
 	}
+	if err := s.appendAgentSessionAuditTx(
+		ctx,
+		tx,
+		listenerID,
+		agentID,
+		agentSessionRotateAction,
+		"POST /api/listeners/{listener_id}/agents/{agent_id}/session/rotate",
+		audit.OutcomeSucceeded,
+		"",
+	); err != nil {
+		return Rotation{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return Rotation{}, fmt.Errorf("commit session rotation: %w", err)
 	}
@@ -607,10 +685,16 @@ func (s *Store) RevokeSession(
 	listenerID string,
 	agentID string,
 ) error {
-	if validateIdentifier(listenerID) != nil || validateIdentifier(agentID) != nil {
+	if validateAuditIdentifier(listenerID) != nil ||
+		validateAuditIdentifier(agentID) != nil {
 		return ErrInvalidArgument
 	}
-	result, err := s.db.ExecContext(
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin agent session revocation: %w", err)
+	}
+	defer rollback(tx)
+	result, err := tx.ExecContext(
 		ctx,
 		`UPDATE agent_enrollment_sessions
 		 SET revoked_at = COALESCE(revoked_at, ?),
@@ -630,6 +714,21 @@ func (s *Store) RevokeSession(
 	if !affectedAny(result) {
 		return ErrNotFound
 	}
+	if err := s.appendAgentSessionAuditTx(
+		ctx,
+		tx,
+		listenerID,
+		agentID,
+		agentSessionRevokeAction,
+		"POST /api/listeners/{listener_id}/agents/{agent_id}/session/revoke",
+		audit.OutcomeSucceeded,
+		"",
+	); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit agent session revocation: %w", err)
+	}
 	return nil
 }
 
@@ -641,11 +740,17 @@ func (s *Store) RequireReenrollment(
 	listenerID string,
 	agentID string,
 ) error {
-	if validateIdentifier(listenerID) != nil || validateIdentifier(agentID) != nil {
+	if validateAuditIdentifier(listenerID) != nil ||
+		validateAuditIdentifier(agentID) != nil {
 		return ErrInvalidArgument
 	}
 	now := formatTimestamp(s.now())
-	result, err := s.db.ExecContext(
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin agent re-enrollment requirement: %w", err)
+	}
+	defer rollback(tx)
+	result, err := tx.ExecContext(
 		ctx,
 		`UPDATE agent_enrollment_sessions
 		 SET reenrollment_required_at = COALESCE(reenrollment_required_at, ?),
@@ -663,6 +768,50 @@ func (s *Store) RequireReenrollment(
 	}
 	if !affectedAny(result) {
 		return ErrNotFound
+	}
+	if err := s.appendAgentSessionAuditTx(
+		ctx,
+		tx,
+		listenerID,
+		agentID,
+		agentSessionReenrollAction,
+		"POST /api/listeners/{listener_id}/agents/{agent_id}/session/re-enroll",
+		audit.OutcomeSucceeded,
+		"",
+	); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit agent re-enrollment requirement: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) appendAgentSessionAuditTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	listenerID string,
+	agentID string,
+	action string,
+	route string,
+	outcome audit.Outcome,
+	reasonCode string,
+) error {
+	if s.audit == nil {
+		return errors.New("agent session audit store is unavailable")
+	}
+	_, err := s.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:      audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		Action:     action,
+		Route:      route,
+		Target:     audit.Target{Kind: "agent", ID: agentID},
+		Outcome:    outcome,
+		ReasonCode: reasonCode,
+		ListenerID: listenerID,
+		AgentID:    agentID,
+	})
+	if err != nil {
+		return fmt.Errorf("record %s audit event: %w", action, err)
 	}
 	return nil
 }
@@ -958,6 +1107,20 @@ func validateActivation(activation PayloadCredentialActivation) error {
 func validateIdentifier(value string) error {
 	if len(value) == 0 || len(value) > maximumIdentifierBytes {
 		return ErrInvalidArgument
+	}
+	return nil
+}
+
+func validateAuditIdentifier(value string) error {
+	if validateIdentifier(value) != nil ||
+		len(value) > maximumAuditIdentifierBytes ||
+		value != strings.TrimSpace(value) {
+		return ErrInvalidArgument
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return ErrInvalidArgument
+		}
 	}
 	return nil
 }

--- a/server/internal/enrollment/store_test.go
+++ b/server/internal/enrollment/store_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"microc2/server/internal/audit"
 )
 
 func TestEnrollResumesAfterLostResponseAndEnforcesBuildCapacity(t *testing.T) {
@@ -462,6 +464,42 @@ func TestRotationIsStableUntilPendingCredentialPromotes(t *testing.T) {
 		!second.AlreadyPending {
 		t.Fatalf("rotation results first=%+v second=%+v", first, second)
 	}
+	page, err := environment.store.audit.Page(
+		context.Background(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page repeated rotation audit events: %v", err)
+	}
+	if page.Total != 2 || len(page.Events) != 2 {
+		t.Fatalf(
+			"rotation audit event count = %d/%d, want 2/2: %#v",
+			page.Total,
+			len(page.Events),
+			page.Events,
+		)
+	}
+	repeatedEvent := page.Events[0]
+	initialEvent := page.Events[1]
+	for name, event := range map[string]audit.Event{
+		"initial":  initialEvent,
+		"repeated": repeatedEvent,
+	} {
+		if event.Action != agentSessionRotateAction ||
+			event.ListenerID != "listener-one" ||
+			event.AgentID != "agent-one" ||
+			event.Target != (audit.Target{Kind: "agent", ID: "agent-one"}) {
+			t.Fatalf("%s rotation audit event has wrong scope: %#v", name, event)
+		}
+	}
+	if initialEvent.Outcome != audit.OutcomeSucceeded ||
+		initialEvent.ReasonCode != "" {
+		t.Fatalf("unexpected initial rotation audit event: %#v", initialEvent)
+	}
+	if repeatedEvent.Outcome != audit.OutcomeNoop ||
+		repeatedEvent.ReasonCode != "rotation_already_pending" {
+		t.Fatalf("unexpected repeated rotation audit event: %#v", repeatedEvent)
+	}
 
 	firstDelivery, err := environment.store.Authenticate(
 		context.Background(),
@@ -512,6 +550,101 @@ func TestRotationIsStableUntilPendingCredentialPromotes(t *testing.T) {
 			again.ReplacementCredential != "",
 			err,
 		)
+	}
+}
+
+func TestAgentSessionAuditFailureRollsBackManagementState(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(context.Context, *Store) error
+		changedSQL string
+	}{
+		{
+			name: "rotate",
+			mutate: func(ctx context.Context, store *Store) error {
+				_, err := store.Rotate(ctx, "listener-one", "agent-one")
+				return err
+			},
+			changedSQL: `SELECT COUNT(*)
+				FROM agent_enrollment_sessions
+				WHERE listener_id = 'listener-one'
+				  AND agent_id = 'agent-one'
+				  AND pending_generation IS NOT NULL`,
+		},
+		{
+			name: "revoke",
+			mutate: func(ctx context.Context, store *Store) error {
+				return store.RevokeSession(ctx, "listener-one", "agent-one")
+			},
+			changedSQL: `SELECT COUNT(*)
+				FROM agent_enrollment_sessions
+				WHERE listener_id = 'listener-one'
+				  AND agent_id = 'agent-one'
+				  AND revoked_at IS NOT NULL`,
+		},
+		{
+			name: "require re-enrollment",
+			mutate: func(ctx context.Context, store *Store) error {
+				return store.RequireReenrollment(
+					ctx,
+					"listener-one",
+					"agent-one",
+				)
+			},
+			changedSQL: `SELECT COUNT(*)
+				FROM agent_enrollment_sessions
+				WHERE listener_id = 'listener-one'
+				  AND agent_id = 'agent-one'
+				  AND reenrollment_required_at IS NOT NULL`,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			environment := newTestEnvironment(t)
+			environment.insertListener(t, "listener-one")
+			bootstrap := environment.readyBuild(
+				t,
+				"build-one",
+				"listener-one",
+				1,
+			)
+			environment.enroll(
+				t,
+				"listener-one",
+				"agent-one",
+				"build-one",
+				bootstrap.Public,
+			)
+			if _, err := environment.database.SQL().Exec(
+				`CREATE TRIGGER reject_agent_session_audit
+				 BEFORE INSERT ON audit_events
+				 BEGIN
+				     SELECT RAISE(ABORT, 'forced audit failure');
+				 END`,
+			); err != nil {
+				t.Fatalf("install rejecting audit trigger: %v", err)
+			}
+
+			err := testCase.mutate(context.Background(), environment.store)
+			if err == nil {
+				t.Fatal("management mutation succeeded despite rejected audit event")
+			}
+			if got := countRows(
+				t,
+				environment.database.SQL(),
+				testCase.changedSQL,
+			); got != 0 {
+				t.Fatalf("management state changed despite audit rollback: %d rows", got)
+			}
+			if got := countRows(
+				t,
+				environment.database.SQL(),
+				`SELECT COUNT(*) FROM audit_events`,
+			); got != 0 {
+				t.Fatalf("rejected audit transaction retained %d events", got)
+			}
+		})
 	}
 }
 
@@ -850,6 +983,174 @@ func TestPayloadCredentialRevocationBlocksBootstrapButNotExistingSession(t *test
 		enrolled.Credential,
 	); err != nil {
 		t.Fatalf("existing session after payload revocation: %v", err)
+	}
+}
+
+func TestActivatePayloadCredentialTxUsesCallerCommitAndRollback(t *testing.T) {
+	environment := newTestEnvironment(t)
+	environment.insertListener(t, "listener-one")
+	environment.insertBuild(t, "build-one", "listener-one", "building")
+	bootstrap, err := GenerateBootstrapCredential()
+	if err != nil {
+		t.Fatalf("generate bootstrap credential: %v", err)
+	}
+	activation := PayloadCredentialActivation{
+		PayloadBuildID:  "build-one",
+		ListenerID:      "listener-one",
+		BootstrapSHA256: bootstrap.SHA256,
+		MaxSessions:     1,
+	}
+	ctx := context.Background()
+
+	rolledBack, err := environment.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin rollback activation transaction: %v", err)
+	}
+	if err := environment.store.ActivatePayloadCredentialTx(
+		ctx,
+		rolledBack,
+		activation,
+	); err != nil {
+		_ = rolledBack.Rollback()
+		t.Fatalf("activate payload credential in rollback transaction: %v", err)
+	}
+	if err := rolledBack.Rollback(); err != nil {
+		t.Fatalf("rollback payload credential activation: %v", err)
+	}
+	if got := countRows(
+		t,
+		environment.database.SQL(),
+		`SELECT COUNT(*)
+		 FROM payload_bootstrap_credentials
+		 WHERE payload_build_id = 'build-one'`,
+	); got != 0 {
+		t.Fatalf("rolled-back activation retained %d credential rows", got)
+	}
+
+	committed, err := environment.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin committed activation transaction: %v", err)
+	}
+	if err := environment.store.ActivatePayloadCredentialTx(
+		ctx,
+		committed,
+		activation,
+	); err != nil {
+		_ = committed.Rollback()
+		t.Fatalf("activate payload credential in committed transaction: %v", err)
+	}
+	if err := committed.Commit(); err != nil {
+		t.Fatalf("commit payload credential activation: %v", err)
+	}
+	if got := countRows(
+		t,
+		environment.database.SQL(),
+		`SELECT COUNT(*)
+		 FROM payload_bootstrap_credentials
+		 WHERE payload_build_id = 'build-one'`,
+	); got != 1 {
+		t.Fatalf("committed activation retained %d credential rows, want 1", got)
+	}
+	if err := environment.store.ActivatePayloadCredentialTx(
+		ctx,
+		nil,
+		activation,
+	); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("nil activation transaction error = %v, want ErrInvalidArgument", err)
+	}
+}
+
+func TestRevokePayloadCredentialTxUsesCallerCommitAndRollback(t *testing.T) {
+	environment := newTestEnvironment(t)
+	environment.insertListener(t, "listener-one")
+	environment.readyBuild(t, "build-one", "listener-one", 1)
+	ctx := context.Background()
+
+	rolledBack, err := environment.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin rollback revocation transaction: %v", err)
+	}
+	if err := environment.store.RevokePayloadCredentialTx(
+		ctx,
+		rolledBack,
+		"build-one",
+	); err != nil {
+		_ = rolledBack.Rollback()
+		t.Fatalf("revoke payload credential in rollback transaction: %v", err)
+	}
+	var revokedInside int
+	if err := rolledBack.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*)
+		 FROM payload_bootstrap_credentials
+		 WHERE payload_build_id = 'build-one'
+		   AND revoked_at IS NOT NULL`,
+	).Scan(&revokedInside); err != nil {
+		_ = rolledBack.Rollback()
+		t.Fatalf("read revocation inside transaction: %v", err)
+	}
+	if revokedInside != 1 {
+		_ = rolledBack.Rollback()
+		t.Fatalf("revoked rows inside transaction = %d, want 1", revokedInside)
+	}
+	if err := rolledBack.Rollback(); err != nil {
+		t.Fatalf("rollback payload credential revocation: %v", err)
+	}
+	if got := countRows(
+		t,
+		environment.database.SQL(),
+		`SELECT COUNT(*)
+		 FROM payload_bootstrap_credentials
+		 WHERE payload_build_id = 'build-one'
+		   AND revoked_at IS NOT NULL`,
+	); got != 0 {
+		t.Fatalf("rolled-back revocation retained %d changed rows", got)
+	}
+
+	committed, err := environment.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin committed revocation transaction: %v", err)
+	}
+	if err := environment.store.RevokePayloadCredentialTx(
+		ctx,
+		committed,
+		"build-one",
+	); err != nil {
+		_ = committed.Rollback()
+		t.Fatalf("revoke payload credential in committed transaction: %v", err)
+	}
+	if err := committed.Commit(); err != nil {
+		t.Fatalf("commit payload credential revocation: %v", err)
+	}
+	if got := countRows(
+		t,
+		environment.database.SQL(),
+		`SELECT COUNT(*)
+		 FROM payload_bootstrap_credentials
+		 WHERE payload_build_id = 'build-one'
+		   AND revoked_at IS NOT NULL`,
+	); got != 1 {
+		t.Fatalf("committed revocation changed %d rows, want 1", got)
+	}
+
+	missing, err := environment.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin missing revocation transaction: %v", err)
+	}
+	defer missing.Rollback()
+	if err := environment.store.RevokePayloadCredentialTx(
+		ctx,
+		missing,
+		"missing-build",
+	); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing transactional revocation error = %v, want ErrNotFound", err)
+	}
+	if err := environment.store.RevokePayloadCredentialTx(
+		ctx,
+		nil,
+		"build-one",
+	); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("nil transaction error = %v, want ErrInvalidArgument", err)
 	}
 }
 

--- a/server/internal/filestore/filestore.go
+++ b/server/internal/filestore/filestore.go
@@ -4,22 +4,32 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // ErrInvalidFileName is returned when a file name is not a plain basename
 // (e.g. contains path separators or traversal segments).
 var ErrInvalidFileName = errors.New("invalid file name")
 
+const (
+	// MaxUploadRequestBytes is a hard cap for the complete multipart request,
+	// including framing overhead. ParseMultipartForm's argument only limits
+	// in-memory buffering and is not a total request-size limit.
+	MaxUploadRequestBytes int64 = 32 << 20
+	maxUploadMemoryBytes        = 32 << 20
+)
+
 // ValidateFileName ensures name is a plain basename that cannot escape the
 // store's base directory. It rejects empty names, "."/"..", path separators
 // (both OS and Windows style), and NUL bytes.
 func ValidateFileName(name string) error {
-	if name == "" || name == "." || name == ".." {
+	if name == "" || name == "." || name == ".." || name != strings.TrimSpace(name) {
 		return fmt.Errorf("%w: %q", ErrInvalidFileName, name)
 	}
 	if strings.ContainsAny(name, "/\\\x00") {
@@ -27,6 +37,11 @@ func ValidateFileName(name string) error {
 	}
 	if filepath.Base(name) != name {
 		return fmt.Errorf("%w: %q", ErrInvalidFileName, name)
+	}
+	for _, character := range name {
+		if unicode.IsControl(character) {
+			return fmt.Errorf("%w: %q", ErrInvalidFileName, name)
+		}
 	}
 	return nil
 }
@@ -57,36 +72,91 @@ func New(baseDir string) (*FileStore, error) {
 //   - Files are saved to the store's base directory
 //   - Returns an error if parsing or file operations fail
 func (fs *FileStore) HandleUpload(r *http.Request) error {
-	err := r.ParseMultipartForm(32 << 20) // 32MB max memory
-	if err != nil {
-		return err
+	_, err := fs.HandleUploadWithInfo(r)
+	return err
+}
+
+// HandleUploadWithInfo stores uploaded files and reports each file that was
+// committed before returning. Returning committed metadata lets the operator
+// layer produce truthful per-file audit events even if a later file fails.
+func (fs *FileStore) HandleUploadWithInfo(r *http.Request) ([]FileInfo, error) {
+	if r.ContentLength > MaxUploadRequestBytes {
+		return nil, &http.MaxBytesError{Limit: MaxUploadRequestBytes}
 	}
+	r.Body = http.MaxBytesReader(nil, r.Body, MaxUploadRequestBytes)
+	err := r.ParseMultipartForm(maxUploadMemoryBytes)
+	if err != nil {
+		return nil, err
+	}
+	defer r.MultipartForm.RemoveAll()
 
 	files := r.MultipartForm.File["files"]
+	committed := make([]FileInfo, 0, len(files))
 	for _, fileHeader := range files {
 		if err := ValidateFileName(fileHeader.Filename); err != nil {
-			return err
+			return committed, err
 		}
-		file, err := fileHeader.Open()
+		info, err := fs.commitUpload(fileHeader)
 		if err != nil {
-			return err
+			return committed, err
 		}
-		defer file.Close()
-
-		// Create the destination file
-		dst, err := os.Create(filepath.Join(fs.baseDir, fileHeader.Filename))
-		if err != nil {
-			return err
-		}
-		defer dst.Close()
-
-		// Copy the uploaded file to the destination
-		if _, err := io.Copy(dst, file); err != nil {
-			return err
-		}
+		committed = append(committed, info)
 	}
 
-	return nil
+	return committed, nil
+}
+
+// commitUpload copies one parsed multipart part into a private same-directory
+// staging file, then atomically replaces the destination name. Opening the
+// destination directly would follow a pre-existing symlink and could overwrite
+// a file outside the store.
+func (fs *FileStore) commitUpload(fileHeader *multipart.FileHeader) (FileInfo, error) {
+	source, err := fileHeader.Open()
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	staged, err := os.CreateTemp(fs.baseDir, ".microc2-upload-*")
+	if err != nil {
+		_ = source.Close()
+		return FileInfo{}, err
+	}
+	stagedPath := staged.Name()
+	keepStaged := false
+	defer func() {
+		if !keepStaged {
+			_ = os.Remove(stagedPath)
+		}
+	}()
+
+	size, copyErr := io.Copy(staged, source)
+	syncErr := staged.Sync()
+	stagedInfo, statErr := staged.Stat()
+	closeStagedErr := staged.Close()
+	closeSourceErr := source.Close()
+	switch {
+	case copyErr != nil:
+		return FileInfo{}, copyErr
+	case syncErr != nil:
+		return FileInfo{}, syncErr
+	case statErr != nil:
+		return FileInfo{}, statErr
+	case closeStagedErr != nil:
+		return FileInfo{}, closeStagedErr
+	case closeSourceErr != nil:
+		return FileInfo{}, closeSourceErr
+	}
+
+	destination := filepath.Join(fs.baseDir, fileHeader.Filename)
+	if err := os.Rename(stagedPath, destination); err != nil {
+		return FileInfo{}, err
+	}
+	keepStaged = true
+	return FileInfo{
+		Name:     fileHeader.Filename,
+		Size:     size,
+		Modified: stagedInfo.ModTime().UTC().Format(time.RFC3339),
+	}, nil
 }
 
 // ListFiles returns a list of files in the store
@@ -109,8 +179,11 @@ func (fs *FileStore) ListFiles() ([]FileInfo, error) {
 
 	fileList := make([]FileInfo, 0)
 	for _, file := range files {
+		if file.Type()&os.ModeSymlink != 0 {
+			continue
+		}
 		info, err := file.Info()
-		if err != nil {
+		if err != nil || !info.Mode().IsRegular() {
 			continue
 		}
 		fileList = append(fileList, FileInfo{
@@ -133,14 +206,52 @@ func (fs *FileStore) ListFiles() ([]FileInfo, error) {
 //   - File is served to the HTTP response writer
 //   - Returns an error if file doesn't exist or path is invalid
 func (fs *FileStore) ServeFile(fileName string, w http.ResponseWriter, r *http.Request) error {
-	// Prevent directory traversal: only plain basenames are served
-	if err := ValidateFileName(fileName); err != nil {
+	file, info, err := fs.OpenFile(fileName)
+	if err != nil {
 		return err
 	}
-
-	filePath := filepath.Join(fs.baseDir, fileName)
-	http.ServeFile(w, r, filePath)
+	defer file.Close()
+	modified, err := time.Parse(time.RFC3339, info.Modified)
+	if err != nil {
+		return err
+	}
+	http.ServeContent(w, r, info.Name, modified, file)
 	return nil
+}
+
+// OpenFile opens one validated regular file and returns its public metadata.
+// Callers own the returned handle. Symlinks and non-regular filesystem
+// objects are rejected so a later stream cannot escape the file-drop root.
+func (fs *FileStore) OpenFile(fileName string) (*os.File, FileInfo, error) {
+	if err := ValidateFileName(fileName); err != nil {
+		return nil, FileInfo{}, err
+	}
+	path := filepath.Join(fs.baseDir, fileName)
+	entryInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, FileInfo{}, err
+	}
+	if entryInfo.Mode()&os.ModeSymlink != 0 || !entryInfo.Mode().IsRegular() {
+		return nil, FileInfo{}, os.ErrNotExist
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, FileInfo{}, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, FileInfo{}, err
+	}
+	if !info.Mode().IsRegular() || !os.SameFile(entryInfo, info) {
+		_ = file.Close()
+		return nil, FileInfo{}, os.ErrNotExist
+	}
+	return file, FileInfo{
+		Name:     info.Name(),
+		Size:     info.Size(),
+		Modified: info.ModTime().UTC().Format(time.RFC3339),
+	}, nil
 }
 
 // DeleteFile deletes a file from the store

--- a/server/internal/filestore/filestore_test.go
+++ b/server/internal/filestore/filestore_test.go
@@ -144,6 +144,172 @@ func TestHandleUploadAcceptsBasename(t *testing.T) {
 	}
 }
 
+func TestHandleUploadWithInfoReportsCommittedFiles(t *testing.T) {
+	fs := newTestStore(t)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for name, content := range map[string]string{
+		"first.txt":  "one",
+		"second.txt": "second",
+	} {
+		part, err := writer.CreateFormFile("files", name)
+		if err != nil {
+			t.Fatalf("create form file %s: %v", name, err)
+		}
+		if _, err := part.Write([]byte(content)); err != nil {
+			t.Fatalf("write form file %s: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/file_drop/upload", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	uploaded, err := fs.HandleUploadWithInfo(req)
+	if err != nil {
+		t.Fatalf("upload with metadata: %v", err)
+	}
+	if len(uploaded) != 2 {
+		t.Fatalf("uploaded metadata count = %d, want 2", len(uploaded))
+	}
+	byName := make(map[string]FileInfo, len(uploaded))
+	for _, info := range uploaded {
+		byName[info.Name] = info
+	}
+	if byName["first.txt"].Size != 3 || byName["second.txt"].Size != 6 {
+		t.Fatalf("unexpected upload metadata: %#v", byName)
+	}
+	stagingFiles, err := filepath.Glob(
+		filepath.Join(fs.baseDir, ".microc2-upload-*"),
+	)
+	if err != nil {
+		t.Fatalf("glob upload staging files: %v", err)
+	}
+	if len(stagingFiles) != 0 {
+		t.Fatalf("upload left staging files behind: %v", stagingFiles)
+	}
+}
+
+func TestHandleUploadAtomicallyReplacesSymlinkWithoutFollowingIt(t *testing.T) {
+	fs := newTestStore(t)
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("keep outside"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	destination := filepath.Join(fs.baseDir, "evidence.txt")
+	if err := os.Symlink(outside, destination); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("files", "evidence.txt")
+	if err != nil {
+		t.Fatalf("create upload part: %v", err)
+	}
+	if _, err := part.Write([]byte("new evidence")); err != nil {
+		t.Fatalf("write upload part: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart body: %v", err)
+	}
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/file_drop/upload",
+		&body,
+	)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	if _, err := fs.HandleUploadWithInfo(request); err != nil {
+		t.Fatalf("upload over destination symlink: %v", err)
+	}
+	outsideContent, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("read outside file: %v", err)
+	}
+	if string(outsideContent) != "keep outside" {
+		t.Fatalf("outside file was overwritten: %q", outsideContent)
+	}
+	destinationInfo, err := os.Lstat(destination)
+	if err != nil {
+		t.Fatalf("inspect uploaded destination: %v", err)
+	}
+	if destinationInfo.Mode()&os.ModeSymlink != 0 ||
+		!destinationInfo.Mode().IsRegular() {
+		t.Fatalf("destination was not replaced by a regular file: %v", destinationInfo.Mode())
+	}
+	destinationContent, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read uploaded destination: %v", err)
+	}
+	if string(destinationContent) != "new evidence" {
+		t.Fatalf("uploaded destination content = %q", destinationContent)
+	}
+}
+
+func TestListFilesOmitsSymlinksAndNonRegularEntries(t *testing.T) {
+	fs := newTestStore(t)
+	if err := os.WriteFile(
+		filepath.Join(fs.baseDir, "regular.txt"),
+		[]byte("data"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(fs.baseDir, "directory"), 0o700); err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	if err := os.Symlink(
+		filepath.Join(fs.baseDir, "regular.txt"),
+		filepath.Join(fs.baseDir, "linked.txt"),
+	); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	files, err := fs.ListFiles()
+	if err != nil {
+		t.Fatalf("list files: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "regular.txt" {
+		t.Fatalf("listed unsafe filesystem entries: %#v", files)
+	}
+}
+
+func TestOpenFileReturnsVerifiedRegularFile(t *testing.T) {
+	fs := newTestStore(t)
+	path := filepath.Join(fs.baseDir, "loot.txt")
+	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	file, info, err := fs.OpenFile("loot.txt")
+	if err != nil {
+		t.Fatalf("open regular file: %v", err)
+	}
+	defer file.Close()
+	if info.Name != "loot.txt" || info.Size != 4 {
+		t.Fatalf("unexpected file info: %#v", info)
+	}
+}
+
+func TestOpenFileRejectsSymlink(t *testing.T) {
+	fs := newTestStore(t)
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	link := filepath.Join(fs.baseDir, "linked.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	if _, _, err := fs.OpenFile("linked.txt"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("open symlink error = %v, want os.ErrNotExist", err)
+	}
+}
+
 func newTestStore(t *testing.T) *FileStore {
 	t.Helper()
 	fs, err := New(t.TempDir())

--- a/server/internal/handlers/api/api_handler.go
+++ b/server/internal/handlers/api/api_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 
 	// Updated from `networking`
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/behaviour"
 	"microc2/server/internal/listeners"
 	"microc2/server/internal/tasks"
@@ -24,13 +26,21 @@ import (
 const scopedAgentKeyDelimiter = "/"
 
 func NewAPIHandler(manager *communication.ServerManager) *APIHandler {
-	return &APIHandler{
+	handler := &APIHandler{
 		serverManager: manager,
 	}
+	if manager != nil && manager.GetDatabase() != nil {
+		handler.audit, handler.auditErr = audit.NewStore(manager.GetDatabase())
+	}
+	return handler
 }
 
 func (h *APIHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	// log.Printf("[DEBUG] HandleRequest called: %s %s", r.Method, r.URL.Path)
+	if r.URL.Path == "/api/audit/events" {
+		h.handleAuditEvents(w, r)
+		return
+	}
 	if r.URL.Path == "/api/agents/list" {
 		h.handleListAgents(w, r)
 		return
@@ -132,6 +142,26 @@ type taskProtocol interface {
 	AgentLastSeen(agentID string) (time.Time, bool)
 }
 
+type taskCreateContextProtocol interface {
+	CreateTaskContext(
+		context.Context,
+		string,
+		tasks.CreateRequest,
+	) (tasks.Task, error)
+}
+
+type taskCancelContextProtocol interface {
+	CancelTaskContext(context.Context, string, string) (tasks.Task, error)
+}
+
+type legacyTaskQueueContextProtocol interface {
+	QueueLegacyShellTaskContext(
+		context.Context,
+		string,
+		string,
+	) (tasks.Task, error)
+}
+
 type taskSummaryProtocol interface {
 	ListTaskSummariesPage(
 		agentID string,
@@ -184,7 +214,12 @@ func (h *APIHandler) handleTasks(w http.ResponseWriter, r *http.Request, agentID
 			writeJSONDecodeError(w, "Invalid task request", err)
 			return
 		}
-		task, err := protocol.CreateTask(agentID, request)
+		var task tasks.Task
+		if actorAware, ok := protocol.(taskCreateContextProtocol); ok {
+			task, err = actorAware.CreateTaskContext(r.Context(), agentID, request)
+		} else {
+			task, err = protocol.CreateTask(agentID, request)
+		}
 		if err != nil {
 			writeTaskError(w, err)
 			return
@@ -246,7 +281,7 @@ func (h *APIHandler) handleCancelTask(w http.ResponseWriter, r *http.Request, ag
 		writeTaskQueryError(w, err)
 		return
 	}
-	task, err := h.cancelAgentTask(agentID, taskID)
+	task, err := h.cancelAgentTask(r.Context(), agentID, taskID)
 	if err != nil {
 		if errors.Is(err, errAmbiguousTaskOwnership) {
 			writeAgentResolutionError(w, err)
@@ -409,12 +444,27 @@ func (p *durableHistoryTaskProtocol) CreateTask(
 	return p.store.Create(agentID, request)
 }
 
+func (p *durableHistoryTaskProtocol) CreateTaskContext(
+	ctx context.Context,
+	agentID string,
+	request tasks.CreateRequest,
+) (tasks.Task, error) {
+	return p.store.CreateContext(ctx, agentID, request)
+}
+
 func (p *durableHistoryTaskProtocol) ListTasks(agentID string) ([]tasks.Task, error) {
 	return p.store.List(agentID)
 }
 
 func (p *durableHistoryTaskProtocol) CancelTask(agentID, taskID string) (tasks.Task, error) {
 	return p.store.Cancel(agentID, taskID)
+}
+
+func (p *durableHistoryTaskProtocol) CancelTaskContext(
+	ctx context.Context,
+	agentID, taskID string,
+) (tasks.Task, error) {
+	return p.store.CancelContext(ctx, agentID, taskID)
 }
 
 func (p *durableHistoryTaskProtocol) GetTask(agentID, taskID string) (tasks.Task, error) {
@@ -445,6 +495,13 @@ func (p *durableHistoryTaskProtocol) QueueLegacyShellTask(
 	agentID, command string,
 ) (tasks.Task, error) {
 	return p.store.CreateLegacyShell(agentID, command)
+}
+
+func (p *durableHistoryTaskProtocol) QueueLegacyShellTaskContext(
+	ctx context.Context,
+	agentID, command string,
+) (tasks.Task, error) {
+	return p.store.CreateLegacyShellContext(ctx, agentID, command)
 }
 
 func (p *durableHistoryTaskProtocol) AgentLastSeen(agentID string) (time.Time, bool) {
@@ -729,7 +786,10 @@ func (h *APIHandler) getAgentTask(agentID, taskID string) (tasks.Task, error) {
 	}
 }
 
-func (h *APIHandler) cancelAgentTask(agentID, taskID string) (tasks.Task, error) {
+func (h *APIHandler) cancelAgentTask(
+	ctx context.Context,
+	agentID, taskID string,
+) (tasks.Task, error) {
 	var owners []taskProtocol
 	refs, err := h.agentTaskProtocolRefs(agentID)
 	if err != nil {
@@ -746,6 +806,9 @@ func (h *APIHandler) cancelAgentTask(agentID, taskID string) (tasks.Task, error)
 	case 0:
 		return tasks.Task{}, tasks.ErrNotFound
 	case 1:
+		if actorAware, ok := owners[0].(taskCancelContextProtocol); ok {
+			return actorAware.CancelTaskContext(ctx, agentID, taskID)
+		}
 		return owners[0].CancelTask(agentID, taskID)
 	default:
 		return tasks.Task{}, errAmbiguousTaskOwnership
@@ -981,7 +1044,7 @@ func (h *APIHandler) handleQueueAgentCommandFromBody(w http.ResponseWriter, r *h
 		return
 	}
 
-	h.queueAgentCommandResponse(w, req.AgentID, req.Command)
+	h.queueAgentCommandResponse(r.Context(), w, req.AgentID, req.Command)
 }
 
 // handleQueueAgentCommand handles POST /api/agents/{AgentID}/command
@@ -999,16 +1062,25 @@ func (h *APIHandler) handleQueueAgentCommand(w http.ResponseWriter, r *http.Requ
 	}
 	// log.Printf("[DEBUG] handleQueueAgentCommand: AgentID=%s, command=%s", AgentID, req.Command)
 
-	h.queueAgentCommandResponse(w, AgentID, req.Command)
+	h.queueAgentCommandResponse(r.Context(), w, AgentID, req.Command)
 }
 
-func (h *APIHandler) queueAgentCommandResponse(w http.ResponseWriter, AgentID, command string) {
+func (h *APIHandler) queueAgentCommandResponse(
+	ctx context.Context,
+	w http.ResponseWriter,
+	AgentID, command string,
+) {
 	protocol, err := h.resolveActiveAgentTaskProtocol(AgentID)
 	if err != nil {
 		writeAgentResolutionError(w, err)
 		return
 	}
-	task, err := protocol.QueueLegacyShellTask(AgentID, command)
+	var task tasks.Task
+	if actorAware, ok := protocol.(legacyTaskQueueContextProtocol); ok {
+		task, err = actorAware.QueueLegacyShellTaskContext(ctx, AgentID, command)
+	} else {
+		task, err = protocol.QueueLegacyShellTask(AgentID, command)
+	}
 	if err != nil {
 		writeTaskError(w, err)
 		return

--- a/server/internal/handlers/api/api_handler_test.go
+++ b/server/internal/handlers/api/api_handler_test.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"microc2/server/internal/audit"
 	"microc2/server/internal/behaviour"
 	"microc2/server/internal/common"
 	"microc2/server/internal/listeners"
@@ -156,6 +158,104 @@ func TestOperatorAPITypedTaskCreateListAndCancel(t *testing.T) {
 	}
 	if cancelled.Status != tasks.StatusCancelled || cancelled.CompletedAt == nil {
 		t.Fatalf("unexpected cancelled task: %#v", cancelled)
+	}
+}
+
+func TestOperatorAPITaskMutationsPreserveRequestAuditActor(t *testing.T) {
+	handler, _ := newTestAPIHandler(t, "agent-one")
+	listenersInManager := handler.serverManager.GetListenerManager().ListListeners()
+	if len(listenersInManager) != 1 {
+		t.Fatalf("initial listener count = %d, want 1", len(listenersInManager))
+	}
+	protocol := &actorCapturingTaskProtocol{
+		staticTaskProtocol: staticTaskProtocol{
+			agentID:  "agent-one",
+			lastSeen: time.Now().UTC(),
+			tasks:    make(map[string]tasks.Task),
+		},
+	}
+	listenersInManager[0].Protocol = protocol
+
+	operator := audit.Actor{
+		Kind: audit.ActorOperator,
+		ID:   "shared-token:test-operator",
+	}
+	withOperator := func(request *http.Request) *http.Request {
+		t.Helper()
+		return request.WithContext(audit.WithActor(request.Context(), operator))
+	}
+
+	createRecorder := httptest.NewRecorder()
+	createRequest := withOperator(jsonRequest(
+		t,
+		http.MethodPost,
+		"/api/agents/agent-one/tasks",
+		validTaskRequestBody("typed-secret"),
+	))
+	handler.HandleRequest(createRecorder, createRequest)
+	if createRecorder.Code != http.StatusAccepted {
+		t.Fatalf(
+			"typed create: expected 202, got %d: %s",
+			createRecorder.Code,
+			createRecorder.Body.String(),
+		)
+	}
+	var created tasks.Task
+	if err := json.Unmarshal(createRecorder.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode typed task: %v", err)
+	}
+
+	legacyRecorder := httptest.NewRecorder()
+	legacyRequest := withOperator(jsonRequest(
+		t,
+		http.MethodPost,
+		"/api/agents/command",
+		map[string]string{
+			"agent_id": "agent-one",
+			"command":  "legacy-secret",
+		},
+	))
+	handler.HandleRequest(legacyRecorder, legacyRequest)
+	if legacyRecorder.Code != http.StatusOK {
+		t.Fatalf(
+			"legacy queue: expected 200, got %d: %s",
+			legacyRecorder.Code,
+			legacyRecorder.Body.String(),
+		)
+	}
+
+	cancelRecorder := httptest.NewRecorder()
+	cancelRequest := withOperator(httptest.NewRequest(
+		http.MethodPost,
+		"/api/agents/agent-one/tasks/"+created.ID+"/cancel",
+		nil,
+	))
+	handler.HandleRequest(cancelRecorder, cancelRequest)
+	if cancelRecorder.Code != http.StatusOK {
+		t.Fatalf(
+			"cancel: expected 200, got %d: %s",
+			cancelRecorder.Code,
+			cancelRecorder.Body.String(),
+		)
+	}
+
+	for operation, captured := range map[string][]audit.Actor{
+		"typed create": protocol.createActors,
+		"legacy queue": protocol.legacyActors,
+		"cancellation": protocol.cancelActors,
+	} {
+		if len(captured) != 1 {
+			t.Fatalf("%s captured %d actors, want 1: %#v", operation, len(captured), captured)
+		}
+		if captured[0] != operator {
+			t.Fatalf("%s actor = %#v, want %#v", operation, captured[0], operator)
+		}
+	}
+	if protocol.fallbackCalls != 0 {
+		t.Fatalf(
+			"context-aware protocol used %d context-free fallbacks, want 0",
+			protocol.fallbackCalls,
+		)
 	}
 }
 
@@ -1804,6 +1904,110 @@ func (p *staticTaskProtocol) QueueLegacyShellTask(string, string) (tasks.Task, e
 
 func (p *staticTaskProtocol) AgentLastSeen(agentID string) (time.Time, bool) {
 	return p.lastSeen, agentID == p.agentID
+}
+
+type actorCapturingTaskProtocol struct {
+	staticTaskProtocol
+	createActors  []audit.Actor
+	legacyActors  []audit.Actor
+	cancelActors  []audit.Actor
+	fallbackCalls int
+	nextID        int
+}
+
+func (p *actorCapturingTaskProtocol) CreateTask(
+	string,
+	tasks.CreateRequest,
+) (tasks.Task, error) {
+	p.fallbackCalls++
+	return tasks.Task{}, errors.New("context-free typed task creation used")
+}
+
+func (p *actorCapturingTaskProtocol) CreateTaskContext(
+	ctx context.Context,
+	agentID string,
+	request tasks.CreateRequest,
+) (tasks.Task, error) {
+	actor, ok := audit.ActorFromContext(ctx)
+	if !ok {
+		return tasks.Task{}, errors.New("typed task creation lost audit actor")
+	}
+	p.createActors = append(p.createActors, actor)
+	return p.captureTask(agentID, request), nil
+}
+
+func (p *actorCapturingTaskProtocol) QueueLegacyShellTask(
+	string,
+	string,
+) (tasks.Task, error) {
+	p.fallbackCalls++
+	return tasks.Task{}, errors.New("context-free legacy task queue used")
+}
+
+func (p *actorCapturingTaskProtocol) QueueLegacyShellTaskContext(
+	ctx context.Context,
+	agentID, command string,
+) (tasks.Task, error) {
+	actor, ok := audit.ActorFromContext(ctx)
+	if !ok {
+		return tasks.Task{}, errors.New("legacy task queue lost audit actor")
+	}
+	p.legacyActors = append(p.legacyActors, actor)
+	return p.captureTask(agentID, tasks.CreateRequest{
+		SchemaVersion:  tasks.SchemaVersion,
+		Type:           tasks.TypeShell,
+		Arguments:      tasks.ShellArguments{Command: command},
+		TimeoutSeconds: tasks.DefaultTimeoutSeconds,
+	}), nil
+}
+
+func (p *actorCapturingTaskProtocol) CancelTask(
+	string,
+	string,
+) (tasks.Task, error) {
+	p.fallbackCalls++
+	return tasks.Task{}, errors.New("context-free task cancellation used")
+}
+
+func (p *actorCapturingTaskProtocol) CancelTaskContext(
+	ctx context.Context,
+	agentID, taskID string,
+) (tasks.Task, error) {
+	actor, ok := audit.ActorFromContext(ctx)
+	if !ok {
+		return tasks.Task{}, errors.New("task cancellation lost audit actor")
+	}
+	task, err := p.GetTask(agentID, taskID)
+	if err != nil {
+		return tasks.Task{}, err
+	}
+	p.cancelActors = append(p.cancelActors, actor)
+	completedAt := time.Now().UTC()
+	task.Status = tasks.StatusCancelled
+	task.CompletedAt = &completedAt
+	p.tasks[taskID] = task
+	return task, nil
+}
+
+func (p *actorCapturingTaskProtocol) captureTask(
+	agentID string,
+	request tasks.CreateRequest,
+) tasks.Task {
+	p.nextID++
+	now := time.Now().UTC()
+	task := tasks.Task{
+		SchemaVersion:  tasks.SchemaVersion,
+		ID:             fmt.Sprintf("captured-task-%d", p.nextID),
+		AgentID:        agentID,
+		Type:           request.Type,
+		Arguments:      request.Arguments,
+		TimeoutSeconds: request.TimeoutSeconds,
+		Status:         tasks.StatusQueued,
+		CreatedAt:      now,
+		QueuedAt:       now,
+	}
+	p.tasks[task.ID] = task
+	return task
 }
 
 func xorHex(data, key string) string {

--- a/server/internal/handlers/api/audit_handler.go
+++ b/server/internal/handlers/api/audit_handler.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+
+	"microc2/server/internal/audit"
+)
+
+const (
+	defaultAuditPageLimit = 50
+	maxAuditPageLimit     = 100
+)
+
+func (h *APIHandler) handleAuditEvents(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	options, err := parseAuditPageOptions(r.URL.RawQuery)
+	if err != nil {
+		http.Error(w, "Invalid audit query: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if h.auditErr != nil || h.audit == nil {
+		http.Error(w, "Audit history is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	page, err := h.audit.Page(r.Context(), options)
+	if err != nil {
+		http.Error(w, "Audit history is unavailable", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func parseAuditPageOptions(rawQuery string) (audit.PageOptions, error) {
+	options := audit.PageOptions{
+		Limit:  defaultAuditPageLimit,
+		Offset: 0,
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return audit.PageOptions{}, fmt.Errorf("malformed query string: %w", err)
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if key != "limit" && key != "offset" {
+			return audit.PageOptions{}, fmt.Errorf(
+				"unknown query parameter %q",
+				key,
+			)
+		}
+		if len(values[key]) != 1 {
+			return audit.PageOptions{}, fmt.Errorf(
+				"query parameter %q must be provided exactly once",
+				key,
+			)
+		}
+	}
+	if values.Has("limit") {
+		limit, err := parseTaskQueryInteger("limit", values.Get("limit"))
+		if err != nil {
+			return audit.PageOptions{}, err
+		}
+		if limit < 1 || limit > maxAuditPageLimit {
+			return audit.PageOptions{}, fmt.Errorf(
+				"query parameter %q must be between 1 and %d",
+				"limit",
+				maxAuditPageLimit,
+			)
+		}
+		options.Limit = limit
+	}
+	if values.Has("offset") {
+		offset, err := parseTaskQueryInteger("offset", values.Get("offset"))
+		if err != nil {
+			return audit.PageOptions{}, err
+		}
+		if offset < 0 || offset > audit.MaxPageOffset {
+			return audit.PageOptions{}, fmt.Errorf(
+				"query parameter %q must be between 0 and %d",
+				"offset",
+				audit.MaxPageOffset,
+			)
+		}
+		options.Offset = offset
+	}
+	return options, nil
+}

--- a/server/internal/handlers/api/audit_handler.go
+++ b/server/internal/handlers/api/audit_handler.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"sort"
@@ -35,7 +37,11 @@ func (h *APIHandler) handleAuditEvents(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Audit history is unavailable", http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, http.StatusOK, page)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(page); err != nil {
+		log.Print("[ERROR] Failed to encode audit page")
+	}
 }
 
 func parseAuditPageOptions(rawQuery string) (audit.PageOptions, error) {

--- a/server/internal/handlers/api/audit_handler_test.go
+++ b/server/internal/handlers/api/audit_handler_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"microc2/server/internal/audit"
+	"microc2/server/internal/persistence"
+)
+
+func TestAuditAPIIsBoundedNewestFirstAndNoStore(t *testing.T) {
+	database, err := persistence.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+	store, err := audit.NewStore(database)
+	if err != nil {
+		t.Fatalf("create audit store: %v", err)
+	}
+	for _, action := range []string{"listener.create", "task.queued", "task.dispatched"} {
+		if _, err := store.Append(context.Background(), audit.Input{
+			Actor:   audit.Actor{Kind: audit.ActorSystem, ID: "test"},
+			Action:  action,
+			Route:   "internal:test",
+			Target:  audit.Target{Kind: "test", ID: action},
+			Outcome: audit.OutcomeSucceeded,
+		}); err != nil {
+			t.Fatalf("append %s: %v", action, err)
+		}
+	}
+	handler := &APIHandler{audit: store}
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/api/audit/events?limit=2&offset=0",
+		nil,
+	)
+	response := httptest.NewRecorder()
+	handler.HandleRequest(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("audit page status = %d: %s", response.Code, response.Body.String())
+	}
+	if response.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", response.Header().Get("Cache-Control"))
+	}
+	var page audit.Page
+	if err := json.Unmarshal(response.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode audit page: %v", err)
+	}
+	if page.SchemaVersion != audit.SchemaVersion ||
+		page.Limit != 2 ||
+		page.Offset != 0 ||
+		page.Total != 3 ||
+		page.NextOffset == nil ||
+		*page.NextOffset != 2 ||
+		len(page.Events) != 2 {
+		t.Fatalf("unexpected audit page: %#v", page)
+	}
+	if page.Events[0].Action != "task.dispatched" ||
+		page.Events[1].Action != "task.queued" ||
+		page.Events[0].Sequence <= page.Events[1].Sequence {
+		t.Fatalf("audit page is not newest-first: %#v", page.Events)
+	}
+}
+
+func TestAuditAPIRejectsUnboundedAndAmbiguousQueries(t *testing.T) {
+	handler := &APIHandler{}
+	for _, path := range []string{
+		"/api/audit/events?limit=0",
+		"/api/audit/events?limit=101",
+		"/api/audit/events?offset=-1",
+		"/api/audit/events?offset=1000001",
+		"/api/audit/events?limit=1&limit=2",
+		"/api/audit/events?unknown=1",
+	} {
+		t.Run(path, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, path, nil)
+			response := httptest.NewRecorder()
+			handler.HandleRequest(response, request)
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf(
+					"GET %s status = %d, want 400: %s",
+					path,
+					response.Code,
+					response.Body.String(),
+				)
+			}
+			if response.Header().Get("Cache-Control") != "no-store" {
+				t.Fatalf("GET %s omitted no-store", path)
+			}
+		})
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/audit/events", nil)
+	response := httptest.NewRecorder()
+	handler.HandleRequest(response, request)
+	if response.Code != http.StatusMethodNotAllowed ||
+		response.Header().Get("Allow") != http.MethodGet {
+		t.Fatalf("POST audit response = %d headers=%v", response.Code, response.Header())
+	}
+}

--- a/server/internal/handlers/api/file_handlers.go
+++ b/server/internal/handlers/api/file_handlers.go
@@ -1,12 +1,19 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log"
+	"mime"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/common"
 	"microc2/server/internal/filestore"
 	"microc2/server/internal/handlers/api/payload"
@@ -22,8 +29,19 @@ import (
 // Post-conditions:
 //   - Returns a configured FileHandlers instance ready to handle HTTP requests
 func NewFileHandlers(fileStore *filestore.FileStore) *FileHandlers {
+	return NewAuditedFileHandlers(fileStore, nil)
+}
+
+// NewAuditedFileHandlers creates file-drop handlers that fail closed before
+// external side effects when the durable audit authorization cannot be
+// recorded.
+func NewAuditedFileHandlers(
+	fileStore *filestore.FileStore,
+	auditStore *audit.Store,
+) *FileHandlers {
 	return &FileHandlers{
 		fileStore: fileStore,
+		audit:     auditStore,
 	}
 }
 
@@ -43,13 +61,67 @@ func (h *FileHandlers) HandleFileUpload(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	err := h.fileStore.HandleUpload(r)
+	requested, err := h.appendFileAudit(r, audit.Input{
+		Action:  "file.upload.requested",
+		Route:   "POST /api/file_drop/upload",
+		Target:  audit.Target{Kind: "file_drop", ID: "upload"},
+		Outcome: audit.OutcomeSucceeded,
+	})
 	if err != nil {
-		if errors.Is(err, filestore.ErrInvalidFileName) {
-			http.Error(w, "Invalid file name", http.StatusBadRequest)
+		http.Error(w, "File upload audit is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	files, uploadErr := h.fileStore.HandleUploadWithInfo(r)
+	for _, file := range files {
+		causation := requested.Sequence
+		if _, err := h.appendFileAudit(r, audit.Input{
+			Action:            "file.upload",
+			Route:             "POST /api/file_drop/upload",
+			Target:            audit.Target{Kind: "file", ID: file.Name},
+			Outcome:           audit.OutcomeSucceeded,
+			CausationSequence: optionalAuditSequence(causation),
+			FileName:          file.Name,
+		}); err != nil {
+			log.Printf("[ERROR] Failed to record committed file upload")
+			http.Error(w, "File upload audit is unavailable", http.StatusInternalServerError)
 			return
 		}
-		http.Error(w, "Failed to upload file: "+err.Error(), http.StatusInternalServerError)
+	}
+	if uploadErr != nil {
+		causation := requested.Sequence
+		reason := "upload_failed"
+		status := http.StatusInternalServerError
+		var maxBytesError *http.MaxBytesError
+		switch {
+		case errors.As(uploadErr, &maxBytesError):
+			reason = "request_too_large"
+			status = http.StatusRequestEntityTooLarge
+		case errors.Is(uploadErr, filestore.ErrInvalidFileName):
+			reason = "invalid_file_name"
+			status = http.StatusBadRequest
+		}
+		if _, auditErr := h.appendFileAudit(r, audit.Input{
+			Action:            "file.upload",
+			Route:             "POST /api/file_drop/upload",
+			Target:            audit.Target{Kind: "file_drop", ID: "upload"},
+			Outcome:           audit.OutcomeFailed,
+			ReasonCode:        reason,
+			CausationSequence: optionalAuditSequence(causation),
+		}); auditErr != nil {
+			log.Printf("[ERROR] Failed to record rejected file upload")
+			http.Error(w, "File upload audit is unavailable", http.StatusInternalServerError)
+			return
+		}
+		if status == http.StatusBadRequest {
+			http.Error(w, "Invalid file name", status)
+			return
+		}
+		if status == http.StatusRequestEntityTooLarge {
+			http.Error(w, "Upload request is too large", status)
+			return
+		}
+		http.Error(w, "Failed to upload file", status)
 		return
 	}
 
@@ -73,7 +145,17 @@ func (h *FileHandlers) HandleFileList(w http.ResponseWriter, r *http.Request) {
 
 	files, err := h.fileStore.ListFiles()
 	if err != nil {
-		http.Error(w, "Failed to list files: "+err.Error(), http.StatusInternalServerError)
+		log.Print("[ERROR] Failed to list file-drop contents")
+		http.Error(w, "Failed to list files", http.StatusInternalServerError)
+		return
+	}
+	if _, err := h.appendFileAudit(r, audit.Input{
+		Action:  "file.list",
+		Route:   "GET /api/file_drop/list",
+		Target:  audit.Target{Kind: "file_drop", ID: "collection"},
+		Outcome: audit.OutcomeSucceeded,
+	}); err != nil {
+		http.Error(w, "File list audit is unavailable", http.StatusServiceUnavailable)
 		return
 	}
 
@@ -104,7 +186,7 @@ func (h *FileHandlers) HandleFileDownload(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	err := h.fileStore.ServeFile(fileName, w, r)
+	file, info, err := h.fileStore.OpenFile(fileName)
 	if err != nil {
 		if errors.Is(err, filestore.ErrInvalidFileName) {
 			http.Error(w, "Invalid file name", http.StatusBadRequest)
@@ -112,6 +194,53 @@ func (h *FileHandlers) HandleFileDownload(w http.ResponseWriter, r *http.Request
 		}
 		http.Error(w, "File not found", http.StatusNotFound)
 		return
+	}
+	defer file.Close()
+	modified, err := time.Parse(time.RFC3339, info.Modified)
+	if err != nil {
+		http.Error(w, "File metadata is invalid", http.StatusInternalServerError)
+		return
+	}
+	requested, err := h.appendFileAudit(r, audit.Input{
+		Action:   "file.download.requested",
+		Route:    "GET /api/file_drop/download/{file_name}",
+		Target:   audit.Target{Kind: "file", ID: info.Name},
+		Outcome:  audit.OutcomeSucceeded,
+		FileName: info.Name,
+	})
+	if err != nil {
+		http.Error(w, "File download audit is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	disposition := mime.FormatMediaType(
+		"attachment",
+		map[string]string{"filename": info.Name},
+	)
+	w.Header().Set("Content-Disposition", disposition)
+	w.Header().Set("Content-Length", strconv.FormatInt(info.Size, 10))
+	trackedWriter := &fileDownloadResponseWriter{ResponseWriter: w}
+	http.ServeContent(trackedWriter, r, info.Name, modified, file)
+
+	outcome := audit.OutcomeSucceeded
+	reasonCode := ""
+	switch {
+	case trackedWriter.writeErr != nil:
+		outcome = audit.OutcomeFailed
+		reasonCode = "response_write_failed"
+	case trackedWriter.statusCode >= http.StatusBadRequest:
+		outcome = audit.OutcomeFailed
+		reasonCode = "response_rejected"
+	}
+	if _, err := h.appendFileAudit(r, audit.Input{
+		Action:            "file.download",
+		Route:             "GET /api/file_drop/download/{file_name}",
+		Target:            audit.Target{Kind: "file", ID: info.Name},
+		Outcome:           outcome,
+		ReasonCode:        reasonCode,
+		CausationSequence: optionalAuditSequence(requested.Sequence),
+		FileName:          info.Name,
+	}); err != nil {
+		log.Printf("[ERROR] Failed to record completed file download")
 	}
 }
 
@@ -137,20 +266,110 @@ func (h *FileHandlers) HandleFileDelete(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "File name is required", http.StatusBadRequest)
 		return
 	}
-
-	err := h.fileStore.DeleteFile(fileName)
+	if err := filestore.ValidateFileName(fileName); err != nil {
+		http.Error(w, "Invalid file name", http.StatusBadRequest)
+		return
+	}
+	requested, err := h.appendFileAudit(r, audit.Input{
+		Action:   "file.delete.requested",
+		Route:    "DELETE /api/file_drop/delete/{file_name}",
+		Target:   audit.Target{Kind: "file", ID: fileName},
+		Outcome:  audit.OutcomeSucceeded,
+		FileName: fileName,
+	})
 	if err != nil {
+		http.Error(w, "File delete audit is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	err = h.fileStore.DeleteFile(fileName)
+	if err != nil {
+		reason := "delete_failed"
+		if errors.Is(err, filestore.ErrInvalidFileName) {
+			reason = "invalid_file_name"
+		} else if errors.Is(err, os.ErrNotExist) {
+			reason = "not_found"
+		}
+		if _, auditErr := h.appendFileAudit(r, audit.Input{
+			Action:            "file.delete",
+			Route:             "DELETE /api/file_drop/delete/{file_name}",
+			Target:            audit.Target{Kind: "file", ID: fileName},
+			Outcome:           audit.OutcomeFailed,
+			ReasonCode:        reason,
+			CausationSequence: optionalAuditSequence(requested.Sequence),
+			FileName:          fileName,
+		}); auditErr != nil {
+			http.Error(w, "File delete audit is unavailable", http.StatusInternalServerError)
+			return
+		}
 		if errors.Is(err, filestore.ErrInvalidFileName) {
 			http.Error(w, "Invalid file name", http.StatusBadRequest)
-		} else if err == os.ErrNotExist {
+		} else if errors.Is(err, os.ErrNotExist) {
 			http.Error(w, "File not found", http.StatusNotFound)
 		} else {
-			http.Error(w, "Failed to delete file: "+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "Failed to delete file", http.StatusInternalServerError)
 		}
+		return
+	}
+	if _, err := h.appendFileAudit(r, audit.Input{
+		Action:            "file.delete",
+		Route:             "DELETE /api/file_drop/delete/{file_name}",
+		Target:            audit.Target{Kind: "file", ID: fileName},
+		Outcome:           audit.OutcomeSucceeded,
+		CausationSequence: optionalAuditSequence(requested.Sequence),
+		FileName:          fileName,
+	}); err != nil {
+		http.Error(w, "File delete audit is unavailable", http.StatusInternalServerError)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func (h *FileHandlers) appendFileAudit(
+	r *http.Request,
+	input audit.Input,
+) (audit.Event, error) {
+	if h.audit == nil {
+		return audit.Event{}, nil
+	}
+	input.Actor = audit.ActorOr(r.Context(), audit.DefaultOperatorActor())
+	return h.audit.Append(context.WithoutCancel(r.Context()), input)
+}
+
+type fileDownloadResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	writeErr   error
+}
+
+func (w *fileDownloadResponseWriter) WriteHeader(statusCode int) {
+	if w.statusCode == 0 {
+		w.statusCode = statusCode
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *fileDownloadResponseWriter) Write(content []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+	written, err := w.ResponseWriter.Write(content)
+	if err == nil && written != len(content) {
+		err = io.ErrShortWrite
+	}
+	if err != nil && w.writeErr == nil {
+		w.writeErr = err
+	}
+	return written, err
+}
+
+func optionalAuditSequence(sequence int64) *int64 {
+	if sequence <= 0 {
+		return nil
+	}
+	value := sequence
+	return &value
 }
 
 // PayloadHandlerSetup creates and initializes a new payload handler

--- a/server/internal/handlers/api/file_handlers.go
+++ b/server/internal/handlers/api/file_handlers.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"microc2/server/internal/audit"
 	"microc2/server/internal/common"
@@ -196,7 +195,7 @@ func (h *FileHandlers) HandleFileDownload(w http.ResponseWriter, r *http.Request
 		return
 	}
 	defer file.Close()
-	modified, err := time.Parse(time.RFC3339, info.Modified)
+	fileStat, err := file.Stat()
 	if err != nil {
 		http.Error(w, "File metadata is invalid", http.StatusInternalServerError)
 		return
@@ -219,7 +218,13 @@ func (h *FileHandlers) HandleFileDownload(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Disposition", disposition)
 	w.Header().Set("Content-Length", strconv.FormatInt(info.Size, 10))
 	trackedWriter := &fileDownloadResponseWriter{ResponseWriter: w}
-	http.ServeContent(trackedWriter, r, info.Name, modified, file)
+	http.ServeContent(
+		trackedWriter,
+		r,
+		info.Name,
+		fileStat.ModTime(),
+		file,
+	)
 
 	outcome := audit.OutcomeSucceeded
 	reasonCode := ""

--- a/server/internal/handlers/api/file_handlers_test.go
+++ b/server/internal/handlers/api/file_handlers_test.go
@@ -1,0 +1,297 @@
+package api
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"microc2/server/internal/audit"
+	"microc2/server/internal/filestore"
+	"microc2/server/internal/persistence"
+)
+
+func TestAuditedFileLifecycleRecordsTargetsWithoutContent(t *testing.T) {
+	root := t.TempDir()
+	database, err := persistence.Open(filepath.Join(root, "state.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+	auditStore, err := audit.NewStore(database)
+	if err != nil {
+		t.Fatalf("create audit store: %v", err)
+	}
+	fileStore, err := filestore.New(filepath.Join(root, "files"))
+	if err != nil {
+		t.Fatalf("create file store: %v", err)
+	}
+	handler := NewAuditedFileHandlers(fileStore, auditStore)
+
+	const secretContent = "file-content-canary-must-not-be-audited"
+	uploadRequest := auditedMultipartRequest(
+		t,
+		"/api/file_drop/upload",
+		"evidence.txt",
+		secretContent,
+	)
+	uploadResponse := httptest.NewRecorder()
+	handler.HandleFileUpload(uploadResponse, uploadRequest)
+	if uploadResponse.Code != http.StatusOK {
+		t.Fatalf(
+			"upload status = %d: %s",
+			uploadResponse.Code,
+			uploadResponse.Body.String(),
+		)
+	}
+
+	downloadRequest := auditedFileRequest(
+		http.MethodGet,
+		"/api/file_drop/download/evidence.txt",
+	)
+	downloadResponse := httptest.NewRecorder()
+	handler.HandleFileDownload(downloadResponse, downloadRequest)
+	if downloadResponse.Code != http.StatusOK ||
+		downloadResponse.Body.String() != secretContent {
+		t.Fatalf(
+			"download response = %d %q",
+			downloadResponse.Code,
+			downloadResponse.Body.String(),
+		)
+	}
+
+	deleteRequest := auditedFileRequest(
+		http.MethodDelete,
+		"/api/file_drop/delete/evidence.txt",
+	)
+	deleteResponse := httptest.NewRecorder()
+	handler.HandleFileDelete(deleteResponse, deleteRequest)
+	if deleteResponse.Code != http.StatusOK {
+		t.Fatalf(
+			"delete status = %d: %s",
+			deleteResponse.Code,
+			deleteResponse.Body.String(),
+		)
+	}
+
+	page, err := auditStore.Page(
+		uploadRequest.Context(),
+		audit.PageOptions{Limit: 20},
+	)
+	if err != nil {
+		t.Fatalf("list audit page: %v", err)
+	}
+	var actions []string
+	for index := len(page.Events) - 1; index >= 0; index-- {
+		event := page.Events[index]
+		actions = append(actions, event.Action)
+		if event.Actor != (audit.Actor{
+			Kind: audit.ActorOperator,
+			ID:   "loopback",
+		}) {
+			t.Fatalf("unexpected file actor: %#v", event.Actor)
+		}
+	}
+	gotActions := strings.Join(actions, ",")
+	if gotActions != strings.Join([]string{
+		"file.upload.requested",
+		"file.upload",
+		"file.download.requested",
+		"file.download",
+		"file.delete.requested",
+		"file.delete",
+	}, ",") {
+		t.Fatalf("file audit actions = %q", gotActions)
+	}
+
+	var leaked int
+	if err := database.SQL().QueryRow(
+		`SELECT COUNT(*)
+		 FROM audit_events
+		 WHERE actor_id LIKE '%' || ? || '%'
+		    OR action LIKE '%' || ? || '%'
+		    OR route LIKE '%' || ? || '%'
+		    OR target_id LIKE '%' || ? || '%'
+		    OR COALESCE(reason_code, '') LIKE '%' || ? || '%'`,
+		secretContent,
+		secretContent,
+		secretContent,
+		secretContent,
+		secretContent,
+	).Scan(&leaked); err != nil {
+		t.Fatalf("search audit rows for file content: %v", err)
+	}
+	if leaked != 0 {
+		t.Fatal("file content leaked into structured audit fields")
+	}
+}
+
+func TestAuditedFileUploadRejectsOversizedMultipartRequest(t *testing.T) {
+	root := t.TempDir()
+	database, err := persistence.Open(filepath.Join(root, "state.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+	auditStore, err := audit.NewStore(database)
+	if err != nil {
+		t.Fatalf("create audit store: %v", err)
+	}
+	fileStore, err := filestore.New(filepath.Join(root, "files"))
+	if err != nil {
+		t.Fatalf("create file store: %v", err)
+	}
+	handler := NewAuditedFileHandlers(fileStore, auditStore)
+
+	request := auditedFileRequest(
+		http.MethodPost,
+		"/api/file_drop/upload",
+	)
+	request.Body = io.NopCloser(strings.NewReader("oversized"))
+	request.ContentLength = filestore.MaxUploadRequestBytes + 1
+	request.Header.Set("Content-Type", "multipart/form-data; boundary=test")
+	response := httptest.NewRecorder()
+	handler.HandleFileUpload(response, request)
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf(
+			"oversized upload status = %d, want 413: %s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+
+	page, err := auditStore.Page(
+		request.Context(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page oversized upload audit: %v", err)
+	}
+	if page.Total != 2 ||
+		page.Events[0].Action != "file.upload" ||
+		page.Events[0].Outcome != audit.OutcomeFailed ||
+		page.Events[0].ReasonCode != "request_too_large" ||
+		page.Events[1].Action != "file.upload.requested" ||
+		page.Events[0].CausationSequence == nil ||
+		*page.Events[0].CausationSequence != page.Events[1].Sequence {
+		t.Fatalf("unexpected oversized upload audit chain: %#v", page.Events)
+	}
+}
+
+func TestAuditedFileDownloadRecordsResponseWriteFailure(t *testing.T) {
+	root := t.TempDir()
+	database, err := persistence.Open(filepath.Join(root, "state.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+	auditStore, err := audit.NewStore(database)
+	if err != nil {
+		t.Fatalf("create audit store: %v", err)
+	}
+	filesDir := filepath.Join(root, "files")
+	fileStore, err := filestore.New(filesDir)
+	if err != nil {
+		t.Fatalf("create file store: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(filesDir, "evidence.txt"),
+		[]byte("evidence"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	handler := NewAuditedFileHandlers(fileStore, auditStore)
+	request := auditedFileRequest(
+		http.MethodGet,
+		"/api/file_drop/download/evidence.txt",
+	)
+	response := &failingFileResponseWriter{header: make(http.Header)}
+	handler.HandleFileDownload(response, request)
+
+	page, err := auditStore.Page(
+		request.Context(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page failed download audit: %v", err)
+	}
+	if page.Total != 2 ||
+		page.Events[0].Action != "file.download" ||
+		page.Events[0].Outcome != audit.OutcomeFailed ||
+		page.Events[0].ReasonCode != "response_write_failed" ||
+		page.Events[1].Action != "file.download.requested" ||
+		page.Events[0].CausationSequence == nil ||
+		*page.Events[0].CausationSequence != page.Events[1].Sequence {
+		t.Fatalf("unexpected failed download audit chain: %#v", page.Events)
+	}
+}
+
+type failingFileResponseWriter struct {
+	header http.Header
+	status int
+}
+
+func (w *failingFileResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingFileResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *failingFileResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("injected client write failure")
+}
+
+func auditedMultipartRequest(
+	t *testing.T,
+	path string,
+	name string,
+	content string,
+) *http.Request {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("files", name)
+	if err != nil {
+		t.Fatalf("create multipart file: %v", err)
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		t.Fatalf("write multipart file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart body: %v", err)
+	}
+	request := auditedFileRequest(http.MethodPost, path)
+	request.Body = io.NopCloser(bytes.NewReader(body.Bytes()))
+	request.ContentLength = int64(body.Len())
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	return request
+}
+
+func auditedFileRequest(method, path string) *http.Request {
+	request := httptest.NewRequest(method, path, nil)
+	return request.WithContext(audit.WithActor(
+		request.Context(),
+		audit.Actor{Kind: audit.ActorOperator, ID: "loopback"},
+	))
+}

--- a/server/internal/handlers/api/listener_handlers.go
+++ b/server/internal/handlers/api/listener_handlers.go
@@ -41,7 +41,7 @@ func (h *ListenerHandlers) HandleCreateListener(w http.ResponseWriter, r *http.R
 	// Trim whitespace from bind host to avoid invalid addresses
 	config.BindHost = strings.TrimSpace(config.BindHost)
 
-	listener, err := h.manager.CreateListener(config)
+	listener, err := h.manager.CreateListenerWithContext(r.Context(), config)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -130,7 +130,7 @@ func (h *ListenerHandlers) HandleStopListener(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := h.manager.StopListener(id); err != nil {
+	if err := h.manager.StopListenerWithContext(r.Context(), id); err != nil {
 		sendJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -153,7 +153,7 @@ func (h *ListenerHandlers) HandleDeleteListener(w http.ResponseWriter, r *http.R
 	}
 
 	// Now using DeleteListener which completely removes the listener
-	if err := h.manager.DeleteListener(id); err != nil {
+	if err := h.manager.DeleteListenerWithContext(r.Context(), id); err != nil {
 		sendJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -190,7 +190,7 @@ func (h *ListenerHandlers) HandleStartListener(w http.ResponseWriter, r *http.Re
 	}
 
 	// Start the listener
-	if err := h.manager.StartListener(id); err != nil {
+	if err := h.manager.StartListenerWithContext(r.Context(), id); err != nil {
 		sendJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/internal/handlers/api/listener_handlers_test.go
+++ b/server/internal/handlers/api/listener_handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/enrollment"
 	"microc2/server/internal/persistence"
 )
@@ -50,8 +51,14 @@ func TestAgentSessionManagementRoutesNeverExposeCredentials(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.RegisterRoutes(mux)
 	path := "/api/listeners/listener-one/agents/agent-one/session/"
+	operator := audit.Actor{
+		Kind: audit.ActorOperator,
+		ID:   "shared-token:session-operator",
+	}
+	operatorContext := audit.WithActor(context.Background(), operator)
 
-	response := serveListenerManagementRequest(
+	response := serveListenerManagementRequestWithContext(
+		operatorContext,
 		mux,
 		http.MethodPost,
 		path+"rotate",
@@ -86,7 +93,8 @@ func TestAgentSessionManagementRoutesNeverExposeCredentials(t *testing.T) {
 		t.Fatal("agent authentication did not receive pending replacement")
 	}
 
-	response = serveListenerManagementRequest(
+	response = serveListenerManagementRequestWithContext(
+		operatorContext,
 		mux,
 		http.MethodPost,
 		path+"revoke",
@@ -104,7 +112,8 @@ func TestAgentSessionManagementRoutesNeverExposeCredentials(t *testing.T) {
 		t.Fatal("revoked credential remained authenticated")
 	}
 
-	response = serveListenerManagementRequest(
+	response = serveListenerManagementRequestWithContext(
+		operatorContext,
 		mux,
 		http.MethodPost,
 		path+"re-enroll",
@@ -127,6 +136,68 @@ func TestAgentSessionManagementRoutesNeverExposeCredentials(t *testing.T) {
 	}
 	if reenrolled.Credential == enrolled.Credential {
 		t.Fatal("re-enrollment reused the revoked session credential")
+	}
+
+	auditStore, err := audit.NewStore(database)
+	if err != nil {
+		t.Fatalf("create audit reader: %v", err)
+	}
+	page, err := auditStore.Page(
+		context.Background(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page agent-session audit events: %v", err)
+	}
+	if page.Total != 3 || len(page.Events) != 3 {
+		t.Fatalf(
+			"agent-session audit event count = %d/%d, want 3/3: %#v",
+			page.Total,
+			len(page.Events),
+			page.Events,
+		)
+	}
+	for index, want := range []struct {
+		action string
+		route  string
+	}{
+		{
+			action: "agent.session.require_reenrollment",
+			route:  "POST /api/listeners/{listener_id}/agents/{agent_id}/session/re-enroll",
+		},
+		{
+			action: "agent.session.revoke",
+			route:  "POST /api/listeners/{listener_id}/agents/{agent_id}/session/revoke",
+		},
+		{
+			action: "agent.session.rotate",
+			route:  "POST /api/listeners/{listener_id}/agents/{agent_id}/session/rotate",
+		},
+	} {
+		event := page.Events[index]
+		if event.Actor != operator ||
+			event.Action != want.action ||
+			event.Route != want.route ||
+			event.Target != (audit.Target{Kind: "agent", ID: "agent-one"}) ||
+			event.Outcome != audit.OutcomeSucceeded ||
+			event.ListenerID != "listener-one" ||
+			event.AgentID != "agent-one" {
+			t.Fatalf("unexpected agent-session audit event %d: %#v", index, event)
+		}
+	}
+	serialized, err := json.Marshal(page.Events)
+	if err != nil {
+		t.Fatalf("marshal agent-session audit events: %v", err)
+	}
+	for name, secret := range map[string]string{
+		"bootstrap credential":       bootstrap.Public,
+		"session credential":         enrolled.Credential,
+		"pending session credential": authentication.ReplacementCredential,
+		"session id":                 enrolled.SessionID,
+	} {
+		if bytes.Contains(serialized, []byte(secret)) {
+			t.Fatalf("agent-session audit events exposed %s: %s", name, serialized)
+		}
 	}
 }
 
@@ -247,7 +318,24 @@ func serveListenerManagementRequest(
 	path string,
 	body string,
 ) *httptest.ResponseRecorder {
+	return serveListenerManagementRequestWithContext(
+		context.Background(),
+		handler,
+		method,
+		path,
+		body,
+	)
+}
+
+func serveListenerManagementRequestWithContext(
+	ctx context.Context,
+	handler http.Handler,
+	method string,
+	path string,
+	body string,
+) *httptest.ResponseRecorder {
 	request := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	request = request.WithContext(ctx)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	return response

--- a/server/internal/handlers/api/payload/payload_handler.go
+++ b/server/internal/handlers/api/payload/payload_handler.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/common"
 	"microc2/server/internal/enrollment"
 	"microc2/server/internal/listeners"
@@ -37,27 +38,31 @@ const (
 	payloadStateMissing     = "missing"
 	payloadStateCorrupt     = "corrupt"
 
-	payloadFailedDetail       = "payload build failed before completion"
-	payloadInterruptedDetail  = "server restarted before payload build completed"
-	defaultPayloadMaxSessions = 1
-	maxPayloadRequestBytes    = 64 << 10
-	maxPayloadRevokeBodyBytes = 1
-	privateCargoBuildRoot     = ".microc2-build"
+	payloadFailedDetail          = "payload build failed before completion"
+	payloadInterruptedDetail     = "server restarted before payload build completed"
+	payloadDownloadRoute         = "GET /api/payload/download/{payload_id}"
+	payloadEnrollmentRevokeRoute = "POST /api/payload/{payload_id}/enrollment/revoke"
+	payloadReconciliationRoute   = "internal:payload_reconciliation"
+	defaultPayloadMaxSessions    = 1
+	maxPayloadRequestBytes       = 64 << 10
+	maxPayloadRevokeBodyBytes    = 1
+	privateCargoBuildRoot        = ".microc2-build"
 )
 
 type payloadBuildRecord struct {
-	ID             string
-	PayloadID      string
-	ListenerID     string
-	MutationSeed   string
-	Filename       string
-	RelativePath   string
-	Size           int64
-	SHA256         string
-	CreatedAt      string
-	State          string
-	StateDetail    string
-	ProvenanceJSON []byte
+	ID                        string
+	PayloadID                 string
+	ListenerID                string
+	MutationSeed              string
+	Filename                  string
+	RelativePath              string
+	Size                      int64
+	SHA256                    string
+	CreatedAt                 string
+	State                     string
+	StateDetail               string
+	ProvenanceJSON            []byte
+	CreatedAuditEventSequence int64
 }
 
 // NewPayloadHandler creates a non-durable handler with the production-safe
@@ -217,7 +222,12 @@ func newPayloadHandler(
 		}
 	}
 	var enrollmentStore *enrollment.Store
+	var auditStore *audit.Store
 	if database != nil {
+		auditStore, err = audit.NewStore(database)
+		if err != nil {
+			return nil, fmt.Errorf("initialize payload audit store: %w", err)
+		}
 		enrollmentStore, err = enrollment.NewStore(context.Background(), database)
 		if err != nil {
 			return nil, fmt.Errorf("initialize payload enrollment store: %w", err)
@@ -228,6 +238,7 @@ func newPayloadHandler(
 		agentSourceDir:           agentSourceDir,
 		listenerLookup:           lookup,
 		database:                 database,
+		audit:                    auditStore,
 		enrollment:               enrollmentStore,
 		allowInsecureIsolatedLab: allowInsecureIsolatedLab,
 		payloads:                 make(map[string]PayloadResult),
@@ -353,9 +364,10 @@ func (h *PayloadHandler) HandleGeneratePayload(w http.ResponseWriter, r *http.Re
 	}
 
 	// Generate payload
-	result, err := h.GeneratePayload(config)
+	result, err := h.GeneratePayloadWithContext(r.Context(), config)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Print("[ERROR] Payload generation failed")
+		http.Error(w, "Payload generation failed", http.StatusInternalServerError)
 		return
 	}
 
@@ -386,13 +398,6 @@ func resolvedPayloadMaxSessions(configured int) (int, error) {
 		)
 	}
 	return configured, nil
-}
-
-func redactBuildDiagnostic(value string, bootstrapCredential string) string {
-	if value == "" || bootstrapCredential == "" {
-		return value
-	}
-	return strings.ReplaceAll(value, bootstrapCredential, "[REDACTED]")
 }
 
 func decodePayloadRequest(
@@ -610,6 +615,70 @@ func parsePayloadEnrollmentRevokePath(
 	return payloadID, true, true
 }
 
+func (h *PayloadHandler) writePayloadEnrollmentRejection(
+	w http.ResponseWriter,
+	r *http.Request,
+	payloadID string,
+	record *payloadBuildRecord,
+	outcome audit.Outcome,
+	reasonCode string,
+	status int,
+	message string,
+) {
+	if err := h.appendPayloadEnrollmentRejection(
+		r.Context(),
+		payloadID,
+		record,
+		outcome,
+		reasonCode,
+	); err != nil {
+		log.Print("[ERROR] Failed to record rejected payload enrollment revocation")
+		http.Error(
+			w,
+			"Payload enrollment audit is unavailable",
+			http.StatusServiceUnavailable,
+		)
+		return
+	}
+	http.Error(w, message, status)
+}
+
+func (h *PayloadHandler) appendPayloadEnrollmentRejection(
+	ctx context.Context,
+	payloadID string,
+	record *payloadBuildRecord,
+	outcome audit.Outcome,
+	reasonCode string,
+) error {
+	if h.audit == nil {
+		return errors.New("payload audit store is unavailable")
+	}
+	targetID := payloadID
+	buildID := payloadID
+	if !validPayloadID(payloadID) {
+		targetID = "invalid-request"
+		buildID = ""
+	}
+	input := audit.Input{
+		Actor:          audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		Action:         "payload.enrollment.revoke.rejected",
+		Route:          payloadEnrollmentRevokeRoute,
+		Target:         audit.Target{Kind: "payload_build", ID: targetID},
+		Outcome:        outcome,
+		ReasonCode:     reasonCode,
+		PayloadBuildID: buildID,
+	}
+	if record != nil {
+		input.ListenerID = record.ListenerID
+		if record.CreatedAuditEventSequence > 0 {
+			causation := record.CreatedAuditEventSequence
+			input.CausationSequence = &causation
+		}
+	}
+	_, err := h.audit.Append(context.WithoutCancel(ctx), input)
+	return err
+}
+
 // HandleRevokePayloadEnrollment retires a build's embedded bootstrap while
 // preserving sessions that were already issued. Production registers this
 // route only on the operator mux, outside the listener-owned agent surface.
@@ -625,19 +694,42 @@ func (h *PayloadHandler) HandleRevokePayloadEnrollment(
 		return
 	}
 	if !valid {
-		http.Error(w, "Invalid payload enrollment path", http.StatusBadRequest)
+		h.writePayloadEnrollmentRejection(
+			w,
+			r,
+			payloadID,
+			nil,
+			audit.OutcomeDenied,
+			"invalid_path",
+			http.StatusBadRequest,
+			"Invalid payload enrollment path",
+		)
 		return
 	}
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		h.writePayloadEnrollmentRejection(
+			w,
+			r,
+			payloadID,
+			nil,
+			audit.OutcomeDenied,
+			"method_not_allowed",
+			http.StatusMethodNotAllowed,
+			"Method not allowed",
+		)
 		return
 	}
 	if r.URL.RawQuery != "" {
-		http.Error(
+		h.writePayloadEnrollmentRejection(
 			w,
-			"Payload enrollment revocation does not accept query parameters",
+			r,
+			payloadID,
+			nil,
+			audit.OutcomeDenied,
+			"query_not_allowed",
 			http.StatusBadRequest,
+			"Payload enrollment revocation does not accept query parameters",
 		)
 		return
 	}
@@ -647,52 +739,146 @@ func (h *PayloadHandler) HandleRevokePayloadEnrollment(
 	if err != nil {
 		var maxBytesError *http.MaxBytesError
 		if errors.As(err, &maxBytesError) {
-			http.Error(
+			h.writePayloadEnrollmentRejection(
 				w,
-				"Payload enrollment revocation body is too large",
+				r,
+				payloadID,
+				nil,
+				audit.OutcomeDenied,
+				"body_too_large",
 				http.StatusRequestEntityTooLarge,
+				"Payload enrollment revocation body is too large",
 			)
 			return
 		}
-		http.Error(
+		h.writePayloadEnrollmentRejection(
 			w,
-			"Invalid payload enrollment revocation body",
+			r,
+			payloadID,
+			nil,
+			audit.OutcomeDenied,
+			"invalid_body",
 			http.StatusBadRequest,
+			"Invalid payload enrollment revocation body",
 		)
 		return
 	}
 	if len(body) != 0 {
-		http.Error(
+		h.writePayloadEnrollmentRejection(
 			w,
-			"Payload enrollment revocation requires an empty body",
+			r,
+			payloadID,
+			nil,
+			audit.OutcomeDenied,
+			"body_not_empty",
 			http.StatusBadRequest,
+			"Payload enrollment revocation requires an empty body",
 		)
 		return
 	}
-	if h.initErr != nil || h.enrollment == nil {
-		http.Error(
+	if h.initErr != nil ||
+		h.enrollment == nil ||
+		h.database == nil ||
+		h.audit == nil {
+		h.writePayloadEnrollmentRejection(
 			w,
-			"Payload enrollment management is unavailable",
+			r,
+			payloadID,
+			nil,
+			audit.OutcomeFailed,
+			"management_unavailable",
 			http.StatusServiceUnavailable,
+			"Payload enrollment management is unavailable",
 		)
 		return
 	}
-	if err := h.enrollment.RevokePayloadCredential(
-		r.Context(),
+	record, err := h.lookupPayload(payloadID)
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			h.writePayloadEnrollmentRejection(
+				w,
+				r,
+				payloadID,
+				nil,
+				audit.OutcomeFailed,
+				"not_found",
+				http.StatusNotFound,
+				"Payload enrollment credential not found",
+			)
+		default:
+			log.Print("[ERROR] Failed to load payload enrollment metadata")
+			h.writePayloadEnrollmentRejection(
+				w,
+				r,
+				payloadID,
+				nil,
+				audit.OutcomeFailed,
+				"metadata_unavailable",
+				http.StatusInternalServerError,
+				"Payload enrollment revocation failed",
+			)
+		}
+		return
+	}
+	if record.CreatedAuditEventSequence <= 0 {
+		h.writePayloadEnrollmentRejection(
+			w,
+			r,
+			payloadID,
+			&record,
+			audit.OutcomeFailed,
+			"audit_root_missing",
+			http.StatusServiceUnavailable,
+			"Payload enrollment audit is unavailable",
+		)
+		return
+	}
+
+	ctx := context.WithoutCancel(r.Context())
+	tx, err := h.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		h.writePayloadEnrollmentRejection(
+			w,
+			r,
+			payloadID,
+			&record,
+			audit.OutcomeFailed,
+			"transaction_unavailable",
+			http.StatusInternalServerError,
+			"Payload enrollment revocation failed",
+		)
+		return
+	}
+	defer tx.Rollback()
+	if err := h.enrollment.RevokePayloadCredentialTx(
+		ctx,
+		tx,
 		payloadID,
 	); err != nil {
+		_ = tx.Rollback()
 		switch {
 		case errors.Is(err, enrollment.ErrNotFound):
-			http.Error(
+			h.writePayloadEnrollmentRejection(
 				w,
-				"Payload enrollment credential not found",
+				r,
+				payloadID,
+				&record,
+				audit.OutcomeFailed,
+				"credential_not_found",
 				http.StatusNotFound,
+				"Payload enrollment credential not found",
 			)
 		case errors.Is(err, enrollment.ErrInvalidArgument):
-			http.Error(
+			h.writePayloadEnrollmentRejection(
 				w,
-				"Invalid payload enrollment request",
+				r,
+				payloadID,
+				&record,
+				audit.OutcomeDenied,
+				"invalid_request",
 				http.StatusBadRequest,
+				"Invalid payload enrollment request",
 			)
 		default:
 			// parsePayloadEnrollmentRevokePath restricts payloadID to the
@@ -703,12 +889,54 @@ func (h *PayloadHandler) HandleRevokePayloadEnrollment(
 				payloadID,
 				err,
 			)
-			http.Error(
+			h.writePayloadEnrollmentRejection(
 				w,
-				"Payload enrollment revocation failed",
+				r,
+				payloadID,
+				&record,
+				audit.OutcomeFailed,
+				"revocation_failed",
 				http.StatusInternalServerError,
+				"Payload enrollment revocation failed",
 			)
 		}
+		return
+	}
+	causation := record.CreatedAuditEventSequence
+	if _, err := h.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:             audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		Action:            "payload.enrollment.revoke",
+		Route:             payloadEnrollmentRevokeRoute,
+		Target:            audit.Target{Kind: "payload_build", ID: payloadID},
+		Outcome:           audit.OutcomeSucceeded,
+		CausationSequence: &causation,
+		ListenerID:        record.ListenerID,
+		PayloadBuildID:    payloadID,
+	}); err != nil {
+		_ = tx.Rollback()
+		h.writePayloadEnrollmentRejection(
+			w,
+			r,
+			payloadID,
+			&record,
+			audit.OutcomeFailed,
+			"audit_append_failed",
+			http.StatusInternalServerError,
+			"Payload enrollment audit is unavailable",
+		)
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		h.writePayloadEnrollmentRejection(
+			w,
+			r,
+			payloadID,
+			&record,
+			audit.OutcomeFailed,
+			"commit_failed",
+			http.StatusInternalServerError,
+			"Payload enrollment revocation failed",
+		)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -748,6 +976,19 @@ func (h *PayloadHandler) HandleDownloadPayload(w http.ResponseWriter, r *http.Re
 	record, err := h.lookupPayload(id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			if auditErr := h.appendPayloadDownloadRejection(
+				r.Context(),
+				payloadBuildRecord{ID: id, PayloadID: id},
+				audit.OutcomeFailed,
+				"not_found",
+			); auditErr != nil {
+				http.Error(
+					w,
+					"Payload download audit is unavailable",
+					http.StatusServiceUnavailable,
+				)
+				return
+			}
 			http.Error(w, "Payload not found", http.StatusNotFound)
 			return
 		}
@@ -758,6 +999,20 @@ func (h *PayloadHandler) HandleDownloadPayload(w http.ResponseWriter, r *http.Re
 
 	switch record.State {
 	case payloadStateBuilding, payloadStateFailed, payloadStateInterrupted:
+		outcome, reasonCode := payloadDownloadUnavailableDescriptor(record.State)
+		if err := h.appendPayloadDownloadRejection(
+			r.Context(),
+			record,
+			outcome,
+			reasonCode,
+		); err != nil {
+			http.Error(
+				w,
+				"Payload download audit is unavailable",
+				http.StatusServiceUnavailable,
+			)
+			return
+		}
 		http.Error(w, "Payload artifact is unavailable", http.StatusGone)
 		return
 	}
@@ -766,19 +1021,28 @@ func (h *PayloadHandler) HandleDownloadPayload(w http.ResponseWriter, r *http.Re
 	if file != nil {
 		defer file.Close()
 	}
-	if h.database != nil {
-		if err := h.updatePayloadState(record, state, detail, actualHash); err != nil {
-			log.Print("[ERROR] Failed to update payload state")
-			http.Error(w, "Failed to update payload metadata", http.StatusInternalServerError)
-			return
-		}
+	if state == payloadStateCompleted && h.afterVerified != nil {
+		h.afterVerified()
+	}
+	decision := payloadDownloadDecision(record, state)
+	authorized, err := h.reconcilePayloadStateAndAudit(
+		r.Context(),
+		record,
+		state,
+		detail,
+		actualHash,
+		payloadDownloadRoute,
+		audit.DefaultOperatorActor(),
+		&decision,
+	)
+	if err != nil {
+		log.Print("[ERROR] Failed to reconcile and audit payload download")
+		http.Error(w, "Payload download audit is unavailable", http.StatusServiceUnavailable)
+		return
 	}
 	if state != payloadStateCompleted {
 		http.Error(w, "Payload artifact is unavailable", http.StatusGone)
 		return
-	}
-	if h.afterVerified != nil {
-		h.afterVerified()
 	}
 
 	// Set appropriate headers
@@ -794,7 +1058,123 @@ func (h *PayloadHandler) HandleDownloadPayload(w http.ResponseWriter, r *http.Re
 	// Stream file to response
 	if _, err := io.Copy(w, file); err != nil {
 		log.Print("[ERROR] Failed to stream payload file")
+		if auditErr := h.appendPayloadDownloadResult(
+			r.Context(),
+			record,
+			authorized.Sequence,
+			audit.OutcomeFailed,
+			"stream_failed",
+		); auditErr != nil {
+			log.Print("[ERROR] Failed to audit payload download stream failure")
+		}
+		return
 	}
+	if err := h.appendPayloadDownloadResult(
+		r.Context(),
+		record,
+		authorized.Sequence,
+		audit.OutcomeSucceeded,
+		"",
+	); err != nil {
+		log.Print("[ERROR] Failed to audit completed payload download")
+	}
+}
+
+func (h *PayloadHandler) appendPayloadDownloadResult(
+	ctx context.Context,
+	record payloadBuildRecord,
+	authorizedSequence int64,
+	outcome audit.Outcome,
+	reasonCode string,
+) error {
+	if h.audit == nil {
+		return nil
+	}
+	causation := authorizedSequence
+	_, err := h.appendPayloadAudit(ctx, audit.Input{
+		Action:            "payload.download.completed",
+		Route:             payloadDownloadRoute,
+		Target:            audit.Target{Kind: "payload_build", ID: record.ID},
+		Outcome:           outcome,
+		ReasonCode:        reasonCode,
+		CausationSequence: &causation,
+		ListenerID:        record.ListenerID,
+		PayloadBuildID:    record.ID,
+	})
+	return err
+}
+
+func payloadDownloadDecision(
+	record payloadBuildRecord,
+	state string,
+) audit.Input {
+	input := audit.Input{
+		Action:         "payload.download.authorized",
+		Route:          payloadDownloadRoute,
+		Target:         audit.Target{Kind: "payload_build", ID: record.ID},
+		Outcome:        audit.OutcomeSucceeded,
+		ListenerID:     record.ListenerID,
+		PayloadBuildID: record.ID,
+	}
+	if state != payloadStateCompleted {
+		input.Action = "payload.download.rejected"
+		input.Outcome, input.ReasonCode =
+			payloadDownloadUnavailableDescriptor(state)
+	}
+	return input
+}
+
+func payloadDownloadUnavailableDescriptor(
+	state string,
+) (audit.Outcome, string) {
+	switch state {
+	case payloadStateBuilding:
+		return audit.OutcomeDenied, "build_in_progress"
+	case payloadStateFailed:
+		return audit.OutcomeDenied, "build_failed"
+	case payloadStateInterrupted:
+		return audit.OutcomeDenied, "build_interrupted"
+	case payloadStateMissing:
+		return audit.OutcomeFailed, "artifact_missing"
+	case payloadStateCorrupt:
+		return audit.OutcomeFailed, "artifact_corrupt"
+	default:
+		return audit.OutcomeFailed, "metadata_invalid"
+	}
+}
+
+func (h *PayloadHandler) appendPayloadDownloadRejection(
+	ctx context.Context,
+	record payloadBuildRecord,
+	outcome audit.Outcome,
+	reasonCode string,
+) error {
+	input := audit.Input{
+		Action:         "payload.download.rejected",
+		Route:          payloadDownloadRoute,
+		Target:         audit.Target{Kind: "payload_build", ID: record.ID},
+		Outcome:        outcome,
+		ReasonCode:     reasonCode,
+		ListenerID:     record.ListenerID,
+		PayloadBuildID: record.ID,
+	}
+	if record.CreatedAuditEventSequence > 0 {
+		causation := record.CreatedAuditEventSequence
+		input.CausationSequence = &causation
+	}
+	_, err := h.appendPayloadAudit(ctx, input)
+	return err
+}
+
+func (h *PayloadHandler) appendPayloadAudit(
+	ctx context.Context,
+	input audit.Input,
+) (audit.Event, error) {
+	if h.audit == nil {
+		return audit.Event{}, nil
+	}
+	input.Actor = audit.ActorOr(ctx, audit.DefaultOperatorActor())
+	return h.audit.Append(context.WithoutCancel(ctx), input)
 }
 
 // GeneratePayload creates a payload based on the provided configuration
@@ -811,7 +1191,27 @@ func (h *PayloadHandler) HandleDownloadPayload(w http.ResponseWriter, r *http.Re
 func (h *PayloadHandler) GeneratePayload(
 	config PayloadConfig,
 ) (result PayloadResult, returnErr error) {
+	return h.GeneratePayloadWithContext(
+		audit.WithActor(
+			context.Background(),
+			audit.DefaultOperatorActor(),
+		),
+		config,
+	)
+}
+
+// GeneratePayloadWithContext preserves the authenticated operator actor across
+// the long-running build and its durable audit transitions.
+func (h *PayloadHandler) GeneratePayloadWithContext(
+	ctx context.Context,
+	config PayloadConfig,
+) (result PayloadResult, returnErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = context.WithoutCancel(ctx)
 	var durableBuildID string
+	var durableBuildAuditSequence int64
 	durableBuildStarted := false
 	durableBuildCompleted := false
 	defer func() {
@@ -821,7 +1221,11 @@ func (h *PayloadHandler) GeneratePayload(
 			returnErr == nil {
 			return
 		}
-		if err := h.failPayloadBuild(durableBuildID); err != nil {
+		if err := h.failPayloadBuild(
+			ctx,
+			durableBuildID,
+			durableBuildAuditSequence,
+		); err != nil {
 			returnErr = errors.Join(
 				returnErr,
 				fmt.Errorf("persist failed payload state: %w", err),
@@ -891,6 +1295,34 @@ func (h *PayloadHandler) GeneratePayload(
 
 	payloadFileName := payloadFilename(config.Format)
 	log.Printf("[INFO] Payload filename: %s", payloadFileName)
+
+	plannedRelativePath := filepath.ToSlash(filepath.Join(
+		buildType,
+		payloadID,
+		payloadFileName,
+	))
+	if h.database != nil {
+		buildAudit, err := h.beginPayloadBuild(ctx, payloadBuildRecord{
+			ID:             payloadID,
+			PayloadID:      payloadID,
+			ListenerID:     listener.ID,
+			MutationSeed:   mutationSeed,
+			Filename:       payloadFileName,
+			RelativePath:   plannedRelativePath,
+			Size:           0,
+			SHA256:         "",
+			CreatedAt:      buildStartedAt.Format(time.RFC3339Nano),
+			State:          payloadStateBuilding,
+			StateDetail:    "",
+			ProvenanceJSON: []byte("{}"),
+		})
+		if err != nil {
+			return PayloadResult{}, fmt.Errorf("persist building payload state: %w", err)
+		}
+		durableBuildID = payloadID
+		durableBuildAuditSequence = buildAudit.Sequence
+		durableBuildStarted = true
+	}
 
 	// Create a directory for build artifacts
 	outputDir := filepath.Join(h.payloadsDir, buildType, payloadID)
@@ -1093,31 +1525,6 @@ func (h *PayloadHandler) GeneratePayload(
 	log.Printf("[INFO] Environment variables set: TARGET=%s, OUTPUT_DIR=%s, BUILD_TYPE=%s, SLEEP_INTERVAL=%d, SOCKS5_ENABLED=%t, SOCKS5_PORT=%d",
 		buildTarget, outputDir, buildType, config.Sleep, config.Socks5Enabled, config.Socks5Port)
 
-	plannedRelativePath, err := h.plannedRelativeArtifactPath(payloadPath)
-	if err != nil {
-		return PayloadResult{}, err
-	}
-	if h.database != nil {
-		if err := h.beginPayloadBuild(payloadBuildRecord{
-			ID:             payloadID,
-			PayloadID:      payloadID,
-			ListenerID:     listener.ID,
-			MutationSeed:   mutationSeed,
-			Filename:       payloadFileName,
-			RelativePath:   plannedRelativePath,
-			Size:           0,
-			SHA256:         "",
-			CreatedAt:      buildStartedAt.Format(time.RFC3339Nano),
-			State:          payloadStateBuilding,
-			StateDetail:    "",
-			ProvenanceJSON: []byte("{}"),
-		}); err != nil {
-			return PayloadResult{}, fmt.Errorf("persist building payload state: %w", err)
-		}
-		durableBuildID = payloadID
-		durableBuildStarted = true
-	}
-
 	log.Printf("[INFO] Starting build process...")
 	if err := ensurePrivateCargoBuildDirectories(
 		cargoBuildRoot,
@@ -1126,7 +1533,7 @@ func (h *PayloadHandler) GeneratePayload(
 	); err != nil {
 		return PayloadResult{}, err
 	}
-	output, err := h.runSerializedBuild(cmd)
+	_, err = h.runSerializedBuild(cmd)
 	if cleanupErr := removePrivateCargoBuildDirectory(
 		cargoBuildRoot,
 		cargoBuildDir,
@@ -1142,42 +1549,13 @@ func (h *PayloadHandler) GeneratePayload(
 			err = errors.Join(err, cleanupErr)
 		}
 	}
-	// Build scripts and dependencies are not allowed to turn the bootstrap
-	// credential into a log, error, or operator-facing diagnostic. Scrub the
-	// exact secret immediately after the child exits, before using either
-	// output stream or the returned error anywhere.
-	safeOutput := redactBuildDiagnostic(string(output), bootstrap.Public)
 	if err != nil {
-		safeBuildError := redactBuildDiagnostic(err.Error(), bootstrap.Public)
-		log.Printf(
-			"[ERROR] Build command failed: %s\nOutput: %s",
-			safeBuildError,
-			safeOutput,
-		)
-
-		// Log each line of the output separately for better visibility in logs
-		outputLines := strings.Split(safeOutput, "\n")
-		for _, line := range outputLines {
-			if line != "" {
-				log.Printf("[ERROR] Build output: %s", line)
-			}
-		}
-
-		return PayloadResult{}, fmt.Errorf(
-			"build failed: %s - %s",
-			safeBuildError,
-			safeOutput,
-		)
+		// Child output is untrusted and can contain injected credentials or
+		// other secrets. Keep both logs and operator responses constant.
+		log.Printf("[ERROR] Payload build command failed")
+		return PayloadResult{}, errors.New("payload build failed")
 	}
-
-	// Log the first few lines of the output and summarize the rest
-	outputLines := strings.Split(safeOutput, "\n")
-	// Log ALL lines, not just the first 10
-	for _, line := range outputLines {
-		if line != "" {
-			log.Printf("[INFO] Build output: %s", line)
-		}
-	}
+	log.Printf("[INFO] Payload build command completed")
 
 	// Find the generated payload
 	log.Printf("[INFO] Checking for payload at: %s", payloadPath)
@@ -1288,26 +1666,19 @@ func (h *PayloadHandler) GeneratePayload(
 			json.RawMessage(nil),
 			provenanceJSON...,
 		),
+		createdAuditEventSequence: durableBuildAuditSequence,
 	}
 	if durableBuildStarted {
 		if h.enrollment == nil {
 			return PayloadResult{}, errors.New("payload enrollment store is unavailable")
 		}
-		if err := h.enrollment.ActivatePayloadCredential(
-			context.Background(),
-			enrollment.PayloadCredentialActivation{
-				PayloadBuildID:  payloadID,
-				ListenerID:      listener.ID,
-				BootstrapSHA256: bootstrap.SHA256,
-				MaxSessions:     maxSessions,
-			},
-		); err != nil {
-			return PayloadResult{}, fmt.Errorf(
-				"activate payload enrollment credential: %w",
-				err,
-			)
+		activation := enrollment.PayloadCredentialActivation{
+			PayloadBuildID:  payloadID,
+			ListenerID:      listener.ID,
+			BootstrapSHA256: bootstrap.SHA256,
+			MaxSessions:     maxSessions,
 		}
-		if err := h.completePayloadBuild(result); err != nil {
+		if err := h.completePayloadBuild(ctx, result, activation); err != nil {
 			return PayloadResult{}, fmt.Errorf("persist completed payload state: %w", err)
 		}
 		durableBuildCompleted = true
@@ -1326,23 +1697,50 @@ func (h *PayloadHandler) loadListenerConfig(listenerID string) (listeners.Listen
 	return h.listenerLookup.LookupListener(listenerID)
 }
 
-func (h *PayloadHandler) beginPayloadBuild(record payloadBuildRecord) error {
+func (h *PayloadHandler) beginPayloadBuild(
+	ctx context.Context,
+	record payloadBuildRecord,
+) (audit.Event, error) {
 	if h.database == nil {
-		return errors.New("payload persistence database is unavailable")
+		return audit.Event{}, errors.New("payload persistence database is unavailable")
+	}
+	if h.audit == nil {
+		return audit.Event{}, errors.New("payload audit store is unavailable")
 	}
 	if record.State != payloadStateBuilding {
-		return fmt.Errorf("initial payload state must be %q", payloadStateBuilding)
+		return audit.Event{}, fmt.Errorf(
+			"initial payload state must be %q",
+			payloadStateBuilding,
+		)
 	}
 	if len(record.ProvenanceJSON) == 0 || !json.Valid(record.ProvenanceJSON) {
-		return errors.New("initial payload provenance is invalid")
+		return audit.Event{}, errors.New("initial payload provenance is invalid")
 	}
 
-	_, err := h.database.SQL().Exec(
+	tx, err := h.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		return audit.Event{}, fmt.Errorf("begin payload build: %w", err)
+	}
+	defer tx.Rollback()
+	buildAudit, err := h.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:          audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		Action:         "payload.build.requested",
+		Route:          "POST /api/payload/generate",
+		Target:         audit.Target{Kind: "payload_build", ID: record.ID},
+		Outcome:        audit.OutcomeSucceeded,
+		ListenerID:     record.ListenerID,
+		PayloadBuildID: record.ID,
+	})
+	if err != nil {
+		return audit.Event{}, fmt.Errorf("audit requested payload build: %w", err)
+	}
+	_, err = tx.ExecContext(
+		ctx,
 		`INSERT INTO payload_builds (
 			id, payload_id, listener_id, mutation_seed, filename,
 			relative_path, size, sha256, created_at, state,
-			state_detail, provenance_json
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			state_detail, provenance_json, created_audit_event_seq
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		record.ID,
 		record.PayloadID,
 		record.ListenerID,
@@ -1355,16 +1753,27 @@ func (h *PayloadHandler) beginPayloadBuild(record payloadBuildRecord) error {
 		record.State,
 		record.StateDetail,
 		record.ProvenanceJSON,
+		buildAudit.Sequence,
 	)
 	if err != nil {
-		return fmt.Errorf("insert building payload metadata: %w", err)
+		return audit.Event{}, fmt.Errorf("insert building payload metadata: %w", err)
 	}
-	return nil
+	if err := tx.Commit(); err != nil {
+		return audit.Event{}, fmt.Errorf("commit requested payload build: %w", err)
+	}
+	return buildAudit, nil
 }
 
-func (h *PayloadHandler) completePayloadBuild(result PayloadResult) error {
+func (h *PayloadHandler) completePayloadBuild(
+	ctx context.Context,
+	result PayloadResult,
+	activation enrollment.PayloadCredentialActivation,
+) error {
 	if h.database == nil {
 		return errors.New("payload persistence database is unavailable")
+	}
+	if h.audit == nil || result.createdAuditEventSequence <= 0 {
+		return errors.New("payload audit root is unavailable")
 	}
 	if result.relativePath == "" ||
 		result.sha256 == "" ||
@@ -1372,7 +1781,13 @@ func (h *PayloadHandler) completePayloadBuild(result PayloadResult) error {
 		!json.Valid(result.provenanceJSON) {
 		return errors.New("completed payload metadata is incomplete")
 	}
-	sqlResult, err := h.database.SQL().Exec(
+	tx, err := h.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin completed payload transition: %w", err)
+	}
+	defer tx.Rollback()
+	sqlResult, err := tx.ExecContext(
+		ctx,
 		`UPDATE payload_builds
 		 SET relative_path = ?,
 		     size = ?,
@@ -1401,14 +1816,53 @@ func (h *PayloadHandler) completePayloadBuild(result PayloadResult) error {
 	if affected != 1 {
 		return fmt.Errorf("completed payload transition affected %d rows, want 1", affected)
 	}
+	if h.enrollment == nil {
+		return errors.New("payload enrollment store is unavailable")
+	}
+	if err := h.enrollment.ActivatePayloadCredentialTx(
+		ctx,
+		tx,
+		activation,
+	); err != nil {
+		return fmt.Errorf("activate payload enrollment credential: %w", err)
+	}
+	causation := result.createdAuditEventSequence
+	if _, err := h.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:             audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		Action:            "payload.build.completed",
+		Route:             "POST /api/payload/generate",
+		Target:            audit.Target{Kind: "payload_build", ID: result.ID},
+		Outcome:           audit.OutcomeSucceeded,
+		CausationSequence: &causation,
+		ListenerID:        result.ListenerID,
+		PayloadBuildID:    result.ID,
+	}); err != nil {
+		return fmt.Errorf("audit completed payload build: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit completed payload transition: %w", err)
+	}
 	return nil
 }
 
-func (h *PayloadHandler) failPayloadBuild(payloadID string) error {
+func (h *PayloadHandler) failPayloadBuild(
+	ctx context.Context,
+	payloadID string,
+	createdAuditEventSequence int64,
+) error {
 	if h.database == nil {
 		return nil
 	}
-	sqlResult, err := h.database.SQL().Exec(
+	if h.audit == nil || createdAuditEventSequence <= 0 {
+		return errors.New("payload audit root is unavailable")
+	}
+	tx, err := h.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin failed payload transition: %w", err)
+	}
+	defer tx.Rollback()
+	sqlResult, err := tx.ExecContext(
+		ctx,
 		`UPDATE payload_builds
 		 SET state = ?, state_detail = ?
 		 WHERE id = ? AND state = ?`,
@@ -1427,20 +1881,86 @@ func (h *PayloadHandler) failPayloadBuild(payloadID string) error {
 	if affected != 1 {
 		return fmt.Errorf("failed payload transition affected %d rows, want 1", affected)
 	}
+	causation := createdAuditEventSequence
+	if _, err := h.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:             audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		Action:            "payload.build.failed",
+		Route:             "POST /api/payload/generate",
+		Target:            audit.Target{Kind: "payload_build", ID: payloadID},
+		Outcome:           audit.OutcomeFailed,
+		ReasonCode:        "build_failed",
+		CausationSequence: &causation,
+		PayloadBuildID:    payloadID,
+	}); err != nil {
+		return fmt.Errorf("audit failed payload build: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit failed payload transition: %w", err)
+	}
 	return nil
 }
 
-func (h *PayloadHandler) interruptPayloadBuild(payloadID string) error {
+func (h *PayloadHandler) interruptPayloadBuild(
+	record payloadBuildRecord,
+) error {
 	if h.database == nil {
 		return nil
 	}
-	sqlResult, err := h.database.SQL().Exec(
+	if h.audit == nil {
+		return errors.New("payload audit root is unavailable")
+	}
+	ctx := audit.WithActor(context.Background(), audit.DefaultSystemActor())
+	tx, err := h.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin interrupted payload transition: %w", err)
+	}
+	defer tx.Rollback()
+	causation := record.CreatedAuditEventSequence
+	if causation <= 0 {
+		recoveryEvent, err := h.audit.AppendTx(ctx, tx, audit.Input{
+			Actor:          audit.DefaultSystemActor(),
+			Action:         "payload.build.recovered",
+			Route:          "internal:payload_recovery",
+			Target:         audit.Target{Kind: "payload_build", ID: record.ID},
+			Outcome:        audit.OutcomeSucceeded,
+			ReasonCode:     "missing_audit_root",
+			ListenerID:     record.ListenerID,
+			PayloadBuildID: record.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("audit recovered payload build: %w", err)
+		}
+		sqlResult, err := tx.ExecContext(
+			ctx,
+			`UPDATE payload_builds
+			 SET created_audit_event_seq = ?
+			 WHERE id = ? AND created_audit_event_seq IS NULL`,
+			recoveryEvent.Sequence,
+			record.ID,
+		)
+		if err != nil {
+			return fmt.Errorf("link recovered payload audit root: %w", err)
+		}
+		affected, err := sqlResult.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("read recovered payload audit link result: %w", err)
+		}
+		if affected != 1 {
+			return fmt.Errorf(
+				"recovered payload audit link affected %d rows, want 1",
+				affected,
+			)
+		}
+		causation = recoveryEvent.Sequence
+	}
+	sqlResult, err := tx.ExecContext(
+		ctx,
 		`UPDATE payload_builds
 		 SET state = ?, state_detail = ?
 		 WHERE id = ? AND state = ?`,
 		payloadStateInterrupted,
 		payloadInterruptedDetail,
-		payloadID,
+		record.ID,
 		payloadStateBuilding,
 	)
 	if err != nil {
@@ -1452,6 +1972,22 @@ func (h *PayloadHandler) interruptPayloadBuild(payloadID string) error {
 	}
 	if affected != 1 {
 		return fmt.Errorf("interrupted payload transition affected %d rows, want 1", affected)
+	}
+	if _, err := h.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:             audit.DefaultSystemActor(),
+		Action:            "payload.build.interrupted",
+		Route:             "internal:payload_recovery",
+		Target:            audit.Target{Kind: "payload_build", ID: record.ID},
+		Outcome:           audit.OutcomeFailed,
+		ReasonCode:        "server_restart",
+		CausationSequence: &causation,
+		ListenerID:        record.ListenerID,
+		PayloadBuildID:    record.ID,
+	}); err != nil {
+		return fmt.Errorf("audit interrupted payload build: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit interrupted payload transition: %w", err)
 	}
 	return nil
 }
@@ -1465,17 +2001,18 @@ func (h *PayloadHandler) lookupPayload(id string) (payloadBuildRecord, error) {
 			return payloadBuildRecord{}, sql.ErrNoRows
 		}
 		record := payloadBuildRecord{
-			ID:             result.ID,
-			PayloadID:      result.PayloadID,
-			ListenerID:     result.ListenerID,
-			MutationSeed:   result.MutationSeed,
-			Filename:       result.Filename,
-			RelativePath:   result.relativePath,
-			Size:           result.Size,
-			SHA256:         result.sha256,
-			CreatedAt:      result.Created,
-			State:          payloadStateCompleted,
-			ProvenanceJSON: append([]byte(nil), result.provenanceJSON...),
+			ID:                        result.ID,
+			PayloadID:                 result.PayloadID,
+			ListenerID:                result.ListenerID,
+			MutationSeed:              result.MutationSeed,
+			Filename:                  result.Filename,
+			RelativePath:              result.relativePath,
+			Size:                      result.Size,
+			SHA256:                    result.sha256,
+			CreatedAt:                 result.Created,
+			State:                     payloadStateCompleted,
+			ProvenanceJSON:            append([]byte(nil), result.provenanceJSON...),
+			CreatedAuditEventSequence: result.createdAuditEventSequence,
 		}
 		if record.RelativePath == "" {
 			relativePath, err := h.relativeArtifactPath(result.Path)
@@ -1495,11 +2032,12 @@ func (h *PayloadHandler) lookupPayload(id string) (payloadBuildRecord, error) {
 	}
 
 	record := payloadBuildRecord{}
+	var createdAuditEventSequence sql.NullInt64
 	err := h.database.SQL().QueryRow(
 		`SELECT
 			id, payload_id, listener_id, mutation_seed, filename,
 			relative_path, size, sha256, created_at, state,
-			state_detail, provenance_json
+			state_detail, provenance_json, created_audit_event_seq
 		FROM payload_builds
 		WHERE id = ?`,
 		id,
@@ -1516,10 +2054,12 @@ func (h *PayloadHandler) lookupPayload(id string) (payloadBuildRecord, error) {
 		&record.State,
 		&record.StateDetail,
 		&record.ProvenanceJSON,
+		&createdAuditEventSequence,
 	)
 	if err != nil {
 		return payloadBuildRecord{}, err
 	}
+	record.CreatedAuditEventSequence = createdAuditEventSequence.Int64
 	return record, nil
 }
 
@@ -1528,10 +2068,11 @@ func (h *PayloadHandler) reconcilePayloads() error {
 	if err != nil {
 		return err
 	}
+	ctx := audit.WithActor(context.Background(), audit.DefaultSystemActor())
 	for _, record := range records {
 		switch record.State {
 		case payloadStateBuilding:
-			if err := h.interruptPayloadBuild(record.ID); err != nil {
+			if err := h.interruptPayloadBuild(record); err != nil {
 				return fmt.Errorf("interrupt payload %s after restart: %w", record.ID, err)
 			}
 			continue
@@ -1539,7 +2080,16 @@ func (h *PayloadHandler) reconcilePayloads() error {
 			continue
 		}
 		_, state, detail, actualHash := h.revalidatePayload(record)
-		if err := h.updatePayloadState(record, state, detail, actualHash); err != nil {
+		if _, err := h.reconcilePayloadStateAndAudit(
+			ctx,
+			record,
+			state,
+			detail,
+			actualHash,
+			payloadReconciliationRoute,
+			audit.DefaultSystemActor(),
+			nil,
+		); err != nil {
 			return fmt.Errorf("reconcile payload %s: %w", record.ID, err)
 		}
 	}
@@ -1551,7 +2101,7 @@ func (h *PayloadHandler) listPayloadRecords() ([]payloadBuildRecord, error) {
 		`SELECT
 			id, payload_id, listener_id, mutation_seed, filename,
 			relative_path, size, sha256, created_at, state,
-			state_detail, provenance_json
+			state_detail, provenance_json, created_audit_event_seq
 		FROM payload_builds
 		ORDER BY id`,
 	)
@@ -1563,6 +2113,7 @@ func (h *PayloadHandler) listPayloadRecords() ([]payloadBuildRecord, error) {
 	records := make([]payloadBuildRecord, 0)
 	for rows.Next() {
 		record := payloadBuildRecord{}
+		var createdAuditEventSequence sql.NullInt64
 		if err := rows.Scan(
 			&record.ID,
 			&record.PayloadID,
@@ -1576,9 +2127,11 @@ func (h *PayloadHandler) listPayloadRecords() ([]payloadBuildRecord, error) {
 			&record.State,
 			&record.StateDetail,
 			&record.ProvenanceJSON,
+			&createdAuditEventSequence,
 		); err != nil {
 			return nil, fmt.Errorf("scan payload metadata: %w", err)
 		}
+		record.CreatedAuditEventSequence = createdAuditEventSequence.Int64
 		records = append(records, record)
 	}
 	if err := rows.Err(); err != nil {
@@ -1587,37 +2140,214 @@ func (h *PayloadHandler) listPayloadRecords() ([]payloadBuildRecord, error) {
 	return records, nil
 }
 
-func (h *PayloadHandler) updatePayloadState(
+func (h *PayloadHandler) reconcilePayloadStateAndAudit(
+	ctx context.Context,
 	record payloadBuildRecord,
 	state string,
 	detail string,
 	actualHash string,
-) error {
+	route string,
+	fallbackActor audit.Actor,
+	followup *audit.Input,
+) (audit.Event, error) {
 	if h.database == nil {
-		return nil
+		if followup == nil {
+			return audit.Event{}, nil
+		}
+		return h.appendPayloadAudit(ctx, *followup)
+	}
+	if h.audit == nil {
+		return audit.Event{}, errors.New("payload audit store is unavailable")
 	}
 	if state != payloadStateCompleted &&
 		state != payloadStateMissing &&
 		state != payloadStateCorrupt {
-		return fmt.Errorf("unsupported reconciled payload state %q", state)
+		return audit.Event{}, fmt.Errorf(
+			"unsupported reconciled payload state %q",
+			state,
+		)
 	}
-	hash := record.SHA256
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = context.WithoutCancel(ctx)
+	tx, err := h.database.SQL().BeginTx(ctx, nil)
+	if err != nil {
+		return audit.Event{}, fmt.Errorf(
+			"begin reconciled payload transition: %w",
+			err,
+		)
+	}
+	defer tx.Rollback()
+
+	var currentState, currentDetail, currentHash string
+	var rootSequence sql.NullInt64
+	if err := tx.QueryRowContext(
+		ctx,
+		`SELECT state, state_detail, sha256, created_audit_event_seq
+		 FROM payload_builds
+		 WHERE id = ?`,
+		record.ID,
+	).Scan(
+		&currentState,
+		&currentDetail,
+		&currentHash,
+		&rootSequence,
+	); err != nil {
+		return audit.Event{}, fmt.Errorf(
+			"read reconciled payload state: %w",
+			err,
+		)
+	}
+	if !rootSequence.Valid || rootSequence.Int64 <= 0 {
+		systemCtx := audit.WithActor(ctx, audit.DefaultSystemActor())
+		recoveryEvent, err := h.audit.AppendTx(systemCtx, tx, audit.Input{
+			Actor:          audit.DefaultSystemActor(),
+			Action:         "payload.build.recovered",
+			Route:          "internal:payload_recovery",
+			Target:         audit.Target{Kind: "payload_build", ID: record.ID},
+			Outcome:        audit.OutcomeSucceeded,
+			ReasonCode:     "missing_audit_root",
+			ListenerID:     record.ListenerID,
+			PayloadBuildID: record.ID,
+		})
+		if err != nil {
+			return audit.Event{}, fmt.Errorf(
+				"audit recovered payload build: %w",
+				err,
+			)
+		}
+		result, err := tx.ExecContext(
+			systemCtx,
+			`UPDATE payload_builds
+			 SET created_audit_event_seq = ?
+			 WHERE id = ?
+			   AND (
+			       created_audit_event_seq IS NULL
+			       OR created_audit_event_seq <= 0
+			   )`,
+			recoveryEvent.Sequence,
+			record.ID,
+		)
+		if err != nil {
+			return audit.Event{}, fmt.Errorf(
+				"link recovered payload audit root: %w",
+				err,
+			)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return audit.Event{}, fmt.Errorf(
+				"read recovered payload audit link result: %w",
+				err,
+			)
+		}
+		if affected != 1 {
+			return audit.Event{}, fmt.Errorf(
+				"recovered payload audit link affected %d rows, want 1",
+				affected,
+			)
+		}
+		rootSequence = sql.NullInt64{
+			Int64: recoveryEvent.Sequence,
+			Valid: true,
+		}
+	}
+	hash := currentHash
 	if state == payloadStateCompleted && hash == "" {
 		hash = actualHash
 	}
-	_, err := h.database.SQL().Exec(
-		`UPDATE payload_builds
-		 SET state = ?, state_detail = ?, sha256 = ?
-		 WHERE id = ?`,
-		state,
-		detail,
-		hash,
-		record.ID,
-	)
-	if err != nil {
-		return fmt.Errorf("update payload state: %w", err)
+
+	causation := rootSequence.Int64
+	actor := audit.ActorOr(ctx, fallbackActor)
+	changed := currentState != state ||
+		currentDetail != detail ||
+		currentHash != hash
+	if changed {
+		result, err := tx.ExecContext(
+			ctx,
+			`UPDATE payload_builds
+			 SET state = ?, state_detail = ?, sha256 = ?
+			 WHERE id = ?`,
+			state,
+			detail,
+			hash,
+			record.ID,
+		)
+		if err != nil {
+			return audit.Event{}, fmt.Errorf("update payload state: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return audit.Event{}, fmt.Errorf(
+				"read reconciled payload transition result: %w",
+				err,
+			)
+		}
+		if affected != 1 {
+			return audit.Event{}, fmt.Errorf(
+				"reconciled payload transition affected %d rows, want 1",
+				affected,
+			)
+		}
+		outcome, reasonCode := payloadReconciliationDescriptor(state)
+		if _, err := h.audit.AppendTx(ctx, tx, audit.Input{
+			Actor:             actor,
+			Action:            "payload.artifact.reconciled",
+			Route:             route,
+			Target:            audit.Target{Kind: "payload_build", ID: record.ID},
+			Outcome:           outcome,
+			ReasonCode:        reasonCode,
+			CausationSequence: &causation,
+			ListenerID:        record.ListenerID,
+			PayloadBuildID:    record.ID,
+		}); err != nil {
+			return audit.Event{}, fmt.Errorf(
+				"audit reconciled payload state: %w",
+				err,
+			)
+		}
 	}
-	return nil
+
+	var followupEvent audit.Event
+	if followup != nil {
+		input := *followup
+		input.Actor = actor
+		input.CausationSequence = &causation
+		if input.ListenerID == "" {
+			input.ListenerID = record.ListenerID
+		}
+		if input.PayloadBuildID == "" {
+			input.PayloadBuildID = record.ID
+		}
+		followupEvent, err = h.audit.AppendTx(ctx, tx, input)
+		if err != nil {
+			return audit.Event{}, fmt.Errorf(
+				"audit reconciled payload followup: %w",
+				err,
+			)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return audit.Event{}, fmt.Errorf(
+			"commit reconciled payload transition: %w",
+			err,
+		)
+	}
+	return followupEvent, nil
+}
+
+func payloadReconciliationDescriptor(
+	state string,
+) (audit.Outcome, string) {
+	switch state {
+	case payloadStateCompleted:
+		return audit.OutcomeSucceeded, "artifact_verified"
+	case payloadStateMissing:
+		return audit.OutcomeFailed, "artifact_missing"
+	default:
+		return audit.OutcomeFailed, "artifact_corrupt"
+	}
 }
 
 func (h *PayloadHandler) revalidatePayload(
@@ -1710,30 +2440,6 @@ func payloadFilename(format string) string {
 	default:
 		return "agent"
 	}
-}
-
-func (h *PayloadHandler) plannedRelativeArtifactPath(artifactPath string) (string, error) {
-	absoluteArtifactPath, err := filepath.Abs(artifactPath)
-	if err != nil {
-		return "", fmt.Errorf("resolve planned artifact path: %w", err)
-	}
-	relativePath, err := filepath.Rel(h.payloadsDir, absoluteArtifactPath)
-	if err != nil || !isContainedRelativePath(relativePath) {
-		return "", errors.New("planned payload artifact is outside the configured payload root")
-	}
-	resolvedRoot, err := filepath.EvalSymlinks(h.payloadsDir)
-	if err != nil {
-		return "", fmt.Errorf("resolve payload root: %w", err)
-	}
-	resolvedParent, err := filepath.EvalSymlinks(filepath.Dir(absoluteArtifactPath))
-	if err != nil {
-		return "", fmt.Errorf("resolve planned artifact directory: %w", err)
-	}
-	resolvedRelative, err := filepath.Rel(resolvedRoot, resolvedParent)
-	if err != nil || (resolvedRelative != "." && !isContainedRelativePath(resolvedRelative)) {
-		return "", errors.New("planned payload artifact resolves outside the configured payload root")
-	}
-	return filepath.ToSlash(relativePath), nil
 }
 
 func (h *PayloadHandler) relativeArtifactPath(artifactPath string) (string, error) {

--- a/server/internal/handlers/api/payload/payload_handler_test.go
+++ b/server/internal/handlers/api/payload/payload_handler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/common"
 	"microc2/server/internal/enrollment"
 	"microc2/server/internal/listeners"
@@ -525,8 +526,8 @@ func TestPersistentPayloadEnrollmentCredentialIsHashOnlyAndNotProjected(
 			t.Fatalf("%s exposed the bootstrap credential", name)
 		}
 	}
-	if !bytes.Contains(logOutput.Bytes(), []byte("[REDACTED]")) {
-		t.Fatal("server logs did not retain a redacted build diagnostic")
+	if bytes.Contains(logOutput.Bytes(), []byte("hook build complete")) {
+		t.Fatal("server logs exposed untrusted child build output")
 	}
 	if bytes.Contains(configBytes, []byte("enrollment_credential")) {
 		t.Fatal("ordinary payload config contains an enrollment credential field")
@@ -609,8 +610,61 @@ func TestPayloadBuildFailureRedactsEnrollmentCredentialFromLogsAndResponse(
 		if strings.Contains(content, bootstrapCredential) {
 			t.Fatalf("%s exposed the bootstrap credential", name)
 		}
-		if !strings.Contains(content, "[REDACTED]") {
-			t.Fatalf("%s omitted the redaction marker: %q", name, content)
+		for _, forbidden := range []string{
+			"child output leaked",
+			"compiler error leaked",
+		} {
+			if strings.Contains(content, forbidden) {
+				t.Fatalf("%s exposed untrusted build diagnostic %q", name, forbidden)
+			}
+		}
+	}
+	if !strings.Contains(response.Body.String(), "Payload generation failed") {
+		t.Fatalf("operator response omitted generic build failure: %q", response.Body.String())
+	}
+
+	page, err := handler.audit.Page(
+		context.Background(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page failed-build audit events: %v", err)
+	}
+	if page.Total != 2 || len(page.Events) != 2 {
+		t.Fatalf(
+			"failed-build audit event count = %d/%d, want 2/2: %#v",
+			page.Total,
+			len(page.Events),
+			page.Events,
+		)
+	}
+	failed := page.Events[0]
+	requested := page.Events[1]
+	if requested.Action != "payload.build.requested" ||
+		requested.CausationSequence != nil ||
+		failed.Action != "payload.build.failed" ||
+		failed.Outcome != audit.OutcomeFailed ||
+		failed.ReasonCode != "build_failed" ||
+		failed.CausationSequence == nil ||
+		*failed.CausationSequence != requested.Sequence ||
+		failed.PayloadBuildID != requested.PayloadBuildID {
+		t.Fatalf(
+			"failed payload audit chain is not causal: requested=%#v failed=%#v",
+			requested,
+			failed,
+		)
+	}
+	serialized, err := json.Marshal(page.Events)
+	if err != nil {
+		t.Fatalf("marshal failed-build audit events: %v", err)
+	}
+	for name, forbidden := range map[string]string{
+		"bootstrap credential": bootstrapCredential,
+		"child build output":   "child output leaked",
+		"child build error":    "compiler error leaked",
+	} {
+		if bytes.Contains(serialized, []byte(forbidden)) {
+			t.Fatalf("failed-build audit events exposed %s: %s", name, serialized)
 		}
 	}
 }
@@ -1167,6 +1221,10 @@ func TestPayloadEnrollmentRevokeOperatorRoute(t *testing.T) {
 	mux := http.NewServeMux()
 	handler.RegisterRoutes(mux)
 	revokePath := "/api/payload/" + result.ID + "/enrollment/revoke"
+	operator := audit.Actor{
+		Kind: audit.ActorOperator,
+		ID:   "payload-revocation-test",
+	}
 	serve := func(
 		t *testing.T,
 		method string,
@@ -1175,6 +1233,9 @@ func TestPayloadEnrollmentRevokeOperatorRoute(t *testing.T) {
 	) *httptest.ResponseRecorder {
 		t.Helper()
 		request := httptest.NewRequest(method, path, strings.NewReader(body))
+		request = request.WithContext(
+			audit.WithActor(request.Context(), operator),
+		)
 		response := httptest.NewRecorder()
 		mux.ServeHTTP(response, request)
 		if response.Header().Get("Cache-Control") != "no-store" {
@@ -1268,6 +1329,70 @@ func TestPayloadEnrollmentRevokeOperatorRoute(t *testing.T) {
 			}
 		})
 	}
+	var rejectedBeforeMutation int
+	if err := database.SQL().QueryRow(
+		`SELECT COUNT(*)
+		 FROM audit_events
+		 WHERE action = 'payload.enrollment.revoke.rejected'`,
+	).Scan(&rejectedBeforeMutation); err != nil {
+		t.Fatalf("count rejected payload revocation events: %v", err)
+	}
+	if rejectedBeforeMutation != 6 {
+		t.Fatalf(
+			"rejected payload revocation event count = %d, want 6",
+			rejectedBeforeMutation,
+		)
+	}
+
+	if _, err := database.SQL().Exec(
+		`CREATE TRIGGER reject_payload_enrollment_revoke_audit
+		 BEFORE INSERT ON audit_events
+		 WHEN NEW.action = 'payload.enrollment.revoke'
+		 BEGIN
+		     SELECT RAISE(ABORT, 'injected payload revocation audit failure');
+		 END`,
+	); err != nil {
+		t.Fatalf("create payload revocation audit failure trigger: %v", err)
+	}
+	response := serve(t, http.MethodPost, revokePath, "")
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf(
+			"audit-failed revocation status = %d, want 500: %s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var revokedCount int
+	if err := database.SQL().QueryRow(
+		`SELECT COUNT(*)
+		 FROM payload_bootstrap_credentials
+		 WHERE payload_build_id = ? AND revoked_at IS NOT NULL`,
+		result.ID,
+	).Scan(&revokedCount); err != nil {
+		t.Fatalf("inspect rolled-back payload revocation: %v", err)
+	}
+	if revokedCount != 0 {
+		t.Fatal("payload credential revocation survived failed audit append")
+	}
+	var rejectedAfterAuditFailure int
+	if err := database.SQL().QueryRow(
+		`SELECT COUNT(*)
+		 FROM audit_events
+		 WHERE action = 'payload.enrollment.revoke.rejected'`,
+	).Scan(&rejectedAfterAuditFailure); err != nil {
+		t.Fatalf("count audit-failed payload revocation event: %v", err)
+	}
+	if rejectedAfterAuditFailure != 7 {
+		t.Fatalf(
+			"rejected payload revocation event count after audit failure = %d, want 7",
+			rejectedAfterAuditFailure,
+		)
+	}
+	if _, err := database.SQL().Exec(
+		`DROP TRIGGER reject_payload_enrollment_revoke_audit`,
+	); err != nil {
+		t.Fatalf("drop payload revocation audit failure trigger: %v", err)
+	}
 
 	for attempt := 0; attempt < 2; attempt++ {
 		response := serve(t, http.MethodPost, revokePath, "")
@@ -1286,6 +1411,69 @@ func TestPayloadEnrollmentRevokeOperatorRoute(t *testing.T) {
 				response.Body.String(),
 			)
 		}
+	}
+
+	var rootSequence int64
+	if err := database.SQL().QueryRow(
+		`SELECT created_audit_event_seq
+		 FROM payload_builds
+		 WHERE id = ?`,
+		result.ID,
+	).Scan(&rootSequence); err != nil {
+		t.Fatalf("read revoked payload audit root: %v", err)
+	}
+	rows, err := database.SQL().Query(
+		`SELECT
+		     actor_kind, actor_id, outcome, causation_sequence,
+		     listener_id, payload_build_id
+		 FROM audit_events
+		 WHERE action = 'payload.enrollment.revoke'
+		 ORDER BY seq`,
+	)
+	if err != nil {
+		t.Fatalf("query payload revocation audit events: %v", err)
+	}
+	defer rows.Close()
+	revocationEvents := 0
+	for rows.Next() {
+		var actorKind, actorID, outcome, listenerID, payloadBuildID string
+		var causation int64
+		if err := rows.Scan(
+			&actorKind,
+			&actorID,
+			&outcome,
+			&causation,
+			&listenerID,
+			&payloadBuildID,
+		); err != nil {
+			t.Fatalf("scan payload revocation audit event: %v", err)
+		}
+		revocationEvents++
+		if actorKind != string(operator.Kind) ||
+			actorID != operator.ID ||
+			outcome != string(audit.OutcomeSucceeded) ||
+			causation != rootSequence ||
+			listenerID != "listener-one" ||
+			payloadBuildID != result.ID {
+			t.Fatalf(
+				"unexpected payload revocation audit event: actor=%s/%s outcome=%s cause=%d listener=%s payload=%s",
+				actorKind,
+				actorID,
+				outcome,
+				causation,
+				listenerID,
+				payloadBuildID,
+			)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate payload revocation audit events: %v", err)
+	}
+	if revocationEvents != 2 {
+		t.Fatalf(
+			"payload revocation audit event count = %d, want 2",
+			revocationEvents,
+		)
 	}
 
 	for _, agentID := range []string{"agent-one", "agent-two"} {
@@ -1409,6 +1597,334 @@ func TestGeneratePayloadHonoursSuppliedMutationSeed(t *testing.T) {
 	if _, err := handler.GeneratePayload(config); err == nil {
 		t.Fatalf("invalid mutation seed should be rejected")
 	}
+}
+
+func TestPayloadBuildAuditRootPrecedesBuildFilesystemSideEffects(t *testing.T) {
+	tempDir := t.TempDir()
+	payloadsDir := filepath.Join(tempDir, "payload-root")
+	agentDir := filepath.Join(tempDir, "agent")
+	writePlaceholderBuildScript(t, agentDir)
+	database, err := persistence.Open(filepath.Join(tempDir, "state.db"))
+	if err != nil {
+		t.Fatalf("open persistence database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close persistence database: %v", err)
+		}
+	})
+	handler, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
+		payloadsDir,
+		agentDir,
+		testListenerLookup(),
+		database,
+	)
+	if err != nil {
+		t.Fatalf("create persistent payload handler: %v", err)
+	}
+	if _, err := database.SQL().Exec(
+		`CREATE TRIGGER reject_payload_build_requested_audit
+		 BEFORE INSERT ON audit_events
+		 WHEN NEW.action = 'payload.build.requested'
+		 BEGIN
+		     SELECT RAISE(ABORT, 'injected requested audit failure');
+		 END`,
+	); err != nil {
+		t.Fatalf("create requested audit failure trigger: %v", err)
+	}
+	buildInvoked := false
+	handler.runBuild = func(*exec.Cmd) ([]byte, error) {
+		buildInvoked = true
+		return nil, errors.New("build must not run")
+	}
+
+	if _, err := handler.GeneratePayload(testPayloadConfig()); err == nil {
+		t.Fatal("payload generation succeeded despite rejected audit root")
+	}
+	if buildInvoked {
+		t.Fatal("payload build ran before its durable audit root")
+	}
+	var buildCount int
+	if err := database.SQL().QueryRow(
+		`SELECT COUNT(*) FROM payload_builds`,
+	).Scan(&buildCount); err != nil {
+		t.Fatalf("count payload builds: %v", err)
+	}
+	if buildCount != 0 {
+		t.Fatalf("rejected audit root retained %d payload build rows", buildCount)
+	}
+	entries, err := os.ReadDir(filepath.Join(payloadsDir, "debug"))
+	if err != nil {
+		t.Fatalf("read debug payload root: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rejected audit root created build filesystem entries: %v", entries)
+	}
+}
+
+func TestPayloadCompletionAuditFailureRollsBackCredentialActivation(t *testing.T) {
+	tempDir := t.TempDir()
+	payloadsDir := filepath.Join(tempDir, "payload-root")
+	agentDir := filepath.Join(tempDir, "agent")
+	writePlaceholderBuildScript(t, agentDir)
+	database, err := persistence.Open(filepath.Join(tempDir, "state.db"))
+	if err != nil {
+		t.Fatalf("open persistence database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close persistence database: %v", err)
+		}
+	})
+	handler, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
+		payloadsDir,
+		agentDir,
+		testListenerLookup(),
+		database,
+	)
+	if err != nil {
+		t.Fatalf("create persistent payload handler: %v", err)
+	}
+	if _, err := database.SQL().Exec(
+		`CREATE TRIGGER reject_payload_build_completed_audit
+		 BEFORE INSERT ON audit_events
+		 WHEN NEW.action = 'payload.build.completed'
+		 BEGIN
+		     SELECT RAISE(ABORT, 'injected completed audit failure');
+		 END`,
+	); err != nil {
+		t.Fatalf("create completed audit failure trigger: %v", err)
+	}
+	handler.runBuild = func(command *exec.Cmd) ([]byte, error) {
+		for index := 0; index+1 < len(command.Args); index++ {
+			if command.Args[index] != "--output" {
+				continue
+			}
+			return []byte("untrusted compiler output"), os.WriteFile(
+				filepath.Join(command.Args[index+1], "agent"),
+				[]byte("fake agent"),
+				0o600,
+			)
+		}
+		return nil, errors.New("build command omitted --output")
+	}
+
+	if _, err := handler.GeneratePayload(testPayloadConfig()); err == nil {
+		t.Fatal("payload generation succeeded despite rejected completion audit")
+	}
+	var buildID, state string
+	if err := database.SQL().QueryRow(
+		`SELECT id, state
+		 FROM payload_builds
+		 ORDER BY rowid DESC
+		 LIMIT 1`,
+	).Scan(&buildID, &state); err != nil {
+		t.Fatalf("read failed payload build: %v", err)
+	}
+	if state != payloadStateFailed {
+		t.Fatalf("payload state = %q, want %q", state, payloadStateFailed)
+	}
+	var credentialCount int
+	if err := database.SQL().QueryRow(
+		`SELECT COUNT(*)
+		 FROM payload_bootstrap_credentials
+		 WHERE payload_build_id = ?`,
+		buildID,
+	).Scan(&credentialCount); err != nil {
+		t.Fatalf("count payload credentials: %v", err)
+	}
+	if credentialCount != 0 {
+		t.Fatalf(
+			"failed completion retained %d activated payload credentials",
+			credentialCount,
+		)
+	}
+	page, err := handler.audit.Page(
+		context.Background(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page completion failure audit: %v", err)
+	}
+	if page.Total != 2 ||
+		page.Events[0].Action != "payload.build.failed" ||
+		page.Events[1].Action != "payload.build.requested" ||
+		page.Events[0].CausationSequence == nil ||
+		*page.Events[0].CausationSequence != page.Events[1].Sequence {
+		t.Fatalf("unexpected completion failure audit chain: %#v", page.Events)
+	}
+}
+
+func TestPayloadBuildAuditRootCompletionAndRedactionSurviveRestart(
+	t *testing.T,
+) {
+	tempDir := t.TempDir()
+	payloadsDir := filepath.Join(tempDir, "payload-root")
+	agentDir := filepath.Join(tempDir, "agent")
+	writePlaceholderBuildScript(t, agentDir)
+	databasePath := filepath.Join(tempDir, "state.db")
+	firstDatabase, err := persistence.Open(databasePath)
+	if err != nil {
+		t.Fatalf("open first persistence database: %v", err)
+	}
+	firstHandler, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
+		payloadsDir,
+		agentDir,
+		testListenerLookup(),
+		firstDatabase,
+	)
+	if err != nil {
+		_ = firstDatabase.Close()
+		t.Fatalf("create first persistent handler: %v", err)
+	}
+
+	const buildOutputMarker = "sensitive-build-output-marker"
+	var bootstrapCredential string
+	var buildOutput []byte
+	firstHandler.runBuild = func(command *exec.Cmd) ([]byte, error) {
+		outputDir := ""
+		for _, entry := range command.Env {
+			name, value, found := strings.Cut(entry, "=")
+			if found && name == "ENROLLMENT_CREDENTIAL" {
+				bootstrapCredential = value
+			}
+		}
+		for index := 0; index+1 < len(command.Args); index++ {
+			if command.Args[index] == "--output" {
+				outputDir = command.Args[index+1]
+				break
+			}
+		}
+		if outputDir == "" {
+			return nil, errors.New("build command omitted --output")
+		}
+		if err := os.WriteFile(
+			filepath.Join(outputDir, "agent"),
+			[]byte("fake agent"),
+			0o600,
+		); err != nil {
+			return nil, fmt.Errorf("write hooked payload artifact: %w", err)
+		}
+		buildOutput = []byte(
+			buildOutputMarker + "; credential=" + bootstrapCredential,
+		)
+		return buildOutput, nil
+	}
+
+	operator := audit.Actor{
+		Kind: audit.ActorOperator,
+		ID:   "payload-audit-test-operator",
+	}
+	result, err := firstHandler.GeneratePayloadWithContext(
+		audit.WithActor(context.Background(), operator),
+		testPayloadConfig(),
+	)
+	if err != nil {
+		_ = firstDatabase.Close()
+		t.Fatalf("generate persistent payload: %v", err)
+	}
+	if bootstrapCredential == "" ||
+		!bytes.Contains(buildOutput, []byte(bootstrapCredential)) {
+		_ = firstDatabase.Close()
+		t.Fatal("test build did not exercise secret-bearing build output")
+	}
+
+	var rootSequence int64
+	if err := firstDatabase.SQL().QueryRow(
+		`SELECT created_audit_event_seq
+		 FROM payload_builds
+		 WHERE id = ?`,
+		result.ID,
+	).Scan(&rootSequence); err != nil {
+		_ = firstDatabase.Close()
+		t.Fatalf("read payload audit root: %v", err)
+	}
+	if rootSequence <= 0 {
+		_ = firstDatabase.Close()
+		t.Fatalf("payload audit root sequence = %d, want positive", rootSequence)
+	}
+
+	assertLifecycle := func(t *testing.T, store *audit.Store) {
+		t.Helper()
+		page, err := store.Page(
+			context.Background(),
+			audit.PageOptions{Limit: 10},
+		)
+		if err != nil {
+			t.Fatalf("page payload audit events: %v", err)
+		}
+		if page.Total != 2 || len(page.Events) != 2 {
+			t.Fatalf(
+				"payload audit event count = %d/%d, want 2/2: %#v",
+				page.Total,
+				len(page.Events),
+				page.Events,
+			)
+		}
+		completed := page.Events[0]
+		requested := page.Events[1]
+		wantTarget := audit.Target{Kind: "payload_build", ID: result.ID}
+		if requested.Sequence != rootSequence ||
+			requested.Actor != operator ||
+			requested.Action != "payload.build.requested" ||
+			requested.Route != "POST /api/payload/generate" ||
+			requested.Target != wantTarget ||
+			requested.Outcome != audit.OutcomeSucceeded ||
+			requested.CausationSequence != nil ||
+			requested.ListenerID != "listener-one" ||
+			requested.PayloadBuildID != result.ID {
+			t.Fatalf("unexpected requested payload audit root: %#v", requested)
+		}
+		if completed.Sequence <= requested.Sequence ||
+			completed.Actor != operator ||
+			completed.Action != "payload.build.completed" ||
+			completed.Route != "POST /api/payload/generate" ||
+			completed.Target != wantTarget ||
+			completed.Outcome != audit.OutcomeSucceeded ||
+			completed.CausationSequence == nil ||
+			*completed.CausationSequence != rootSequence ||
+			completed.ListenerID != "listener-one" ||
+			completed.PayloadBuildID != result.ID {
+			t.Fatalf("unexpected completed payload audit event: %#v", completed)
+		}
+
+		serialized, err := json.Marshal(page.Events)
+		if err != nil {
+			t.Fatalf("marshal payload audit events: %v", err)
+		}
+		for name, forbidden := range map[string]string{
+			"build output":         buildOutputMarker,
+			"bootstrap credential": bootstrapCredential,
+		} {
+			if bytes.Contains(serialized, []byte(forbidden)) {
+				t.Fatalf("payload audit events exposed %s: %s", name, serialized)
+			}
+		}
+	}
+	assertLifecycle(t, firstHandler.audit)
+
+	if err := firstDatabase.Close(); err != nil {
+		t.Fatalf("close first persistence database: %v", err)
+	}
+	secondDatabase, err := persistence.Open(databasePath)
+	if err != nil {
+		t.Fatalf("reopen persistence database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := secondDatabase.Close(); err != nil {
+			t.Errorf("close restarted persistence database: %v", err)
+		}
+	})
+	secondHandler, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
+		payloadsDir,
+		agentDir,
+		testListenerLookup(),
+		secondDatabase,
+	)
+	if err != nil {
+		t.Fatalf("create restarted persistent handler: %v", err)
+	}
+	assertLifecycle(t, secondHandler.audit)
 }
 
 func TestPayloadMetadataAndDownloadSurviveRestartWithCustomRoot(t *testing.T) {
@@ -1845,12 +2361,13 @@ func TestBuildingPayloadBecomesInterruptedExactlyOnceOnRestart(t *testing.T) {
 		t.Fatalf("insert building payload metadata: %v", err)
 	}
 
-	if _, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
+	firstRestartHandler, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
 		payloadsDir,
 		filepath.Join(tempDir, "agent"),
 		testListenerLookup(),
 		database,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("reconcile first restart: %v", err)
 	}
 	var state, detail string
@@ -1869,6 +2386,60 @@ func TestBuildingPayloadBecomesInterruptedExactlyOnceOnRestart(t *testing.T) {
 			payloadInterruptedDetail,
 		)
 	}
+	var rootSequence int64
+	if err := database.SQL().QueryRow(
+		`SELECT created_audit_event_seq
+		 FROM payload_builds
+		 WHERE id = ?`,
+		payloadID,
+	).Scan(&rootSequence); err != nil {
+		t.Fatalf("read recovered payload audit root: %v", err)
+	}
+	firstPage, err := firstRestartHandler.audit.Page(
+		context.Background(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page first-restart payload audit events: %v", err)
+	}
+	if firstPage.Total != 2 || len(firstPage.Events) != 2 {
+		t.Fatalf(
+			"first-restart audit event count = %d/%d, want 2/2: %#v",
+			firstPage.Total,
+			len(firstPage.Events),
+			firstPage.Events,
+		)
+	}
+	interrupted := firstPage.Events[0]
+	recovered := firstPage.Events[1]
+	systemActor := audit.DefaultSystemActor()
+	wantTarget := audit.Target{Kind: "payload_build", ID: payloadID}
+	if rootSequence <= 0 ||
+		recovered.Sequence != rootSequence ||
+		recovered.Actor != systemActor ||
+		recovered.Action != "payload.build.recovered" ||
+		recovered.Route != "internal:payload_recovery" ||
+		recovered.Target != wantTarget ||
+		recovered.Outcome != audit.OutcomeSucceeded ||
+		recovered.ReasonCode != "missing_audit_root" ||
+		recovered.CausationSequence != nil ||
+		recovered.ListenerID != "listener-one" ||
+		recovered.PayloadBuildID != payloadID {
+		t.Fatalf("unexpected recovered payload audit root: %#v", recovered)
+	}
+	if interrupted.Sequence <= recovered.Sequence ||
+		interrupted.Actor != systemActor ||
+		interrupted.Action != "payload.build.interrupted" ||
+		interrupted.Route != "internal:payload_recovery" ||
+		interrupted.Target != wantTarget ||
+		interrupted.Outcome != audit.OutcomeFailed ||
+		interrupted.ReasonCode != "server_restart" ||
+		interrupted.CausationSequence == nil ||
+		*interrupted.CausationSequence != rootSequence ||
+		interrupted.ListenerID != "listener-one" ||
+		interrupted.PayloadBuildID != payloadID {
+		t.Fatalf("unexpected interrupted payload audit event: %#v", interrupted)
+	}
 
 	const sentinelDetail = "already reconciled"
 	if _, err := database.SQL().Exec(
@@ -1878,12 +2449,13 @@ func TestBuildingPayloadBecomesInterruptedExactlyOnceOnRestart(t *testing.T) {
 	); err != nil {
 		t.Fatalf("set interrupted sentinel detail: %v", err)
 	}
-	if _, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
+	secondRestartHandler, err := NewPayloadHandlerWithPersistenceForIsolatedLab(
 		payloadsDir,
 		filepath.Join(tempDir, "agent"),
 		testListenerLookup(),
 		database,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("reconcile second restart: %v", err)
 	}
 	if err := database.SQL().QueryRow(
@@ -1897,6 +2469,22 @@ func TestBuildingPayloadBecomesInterruptedExactlyOnceOnRestart(t *testing.T) {
 			"second restart changed terminal state/detail to %q/%q",
 			state,
 			detail,
+		)
+	}
+	secondPage, err := secondRestartHandler.audit.Page(
+		context.Background(),
+		audit.PageOptions{Limit: 10},
+	)
+	if err != nil {
+		t.Fatalf("page second-restart payload audit events: %v", err)
+	}
+	if secondPage.Total != 2 ||
+		len(secondPage.Events) != 2 ||
+		secondPage.Events[0].Sequence != interrupted.Sequence ||
+		secondPage.Events[1].Sequence != recovered.Sequence {
+		t.Fatalf(
+			"second restart duplicated or changed payload audit events: %#v",
+			secondPage,
 		)
 	}
 }

--- a/server/internal/handlers/api/payload/types.go
+++ b/server/internal/handlers/api/payload/types.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"sync"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/enrollment"
 	"microc2/server/internal/listeners"
 	"microc2/server/internal/persistence"
@@ -61,9 +62,10 @@ type PayloadResult struct {
 	Size         int64  `json:"size"`
 	Created      string `json:"created"`
 
-	relativePath   string
-	sha256         string
-	provenanceJSON json.RawMessage
+	relativePath              string
+	sha256                    string
+	provenanceJSON            json.RawMessage
+	createdAuditEventSequence int64
 }
 
 // ListenerLookup resolves the authoritative listener configuration used for a
@@ -79,6 +81,7 @@ type PayloadHandler struct {
 	agentSourceDir           string
 	listenerLookup           ListenerLookup
 	database                 *persistence.Database
+	audit                    *audit.Store
 	enrollment               *enrollment.Store
 	allowInsecureIsolatedLab bool
 	initErr                  error

--- a/server/internal/handlers/api/types.go
+++ b/server/internal/handlers/api/types.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"microc2/server/internal/audit"
 	"microc2/server/internal/enrollment"
 	"microc2/server/internal/filestore"
 	"microc2/server/internal/listeners" // Updated from `networking`
@@ -11,6 +12,8 @@ import (
 // APIHandler handles API requests and responses
 type APIHandler struct {
 	serverManager *communication.ServerManager
+	audit         *audit.Store
+	auditErr      error
 }
 
 // FileHandlers manages HTTP endpoints for file operations
@@ -18,6 +21,7 @@ type APIHandler struct {
 // using the underlying filestore system.
 type FileHandlers struct {
 	fileStore *filestore.FileStore
+	audit     *audit.Store
 }
 
 // ListenerHandlers manages HTTP handlers for listener operations

--- a/server/internal/handlers/operator_guard.go
+++ b/server/internal/handlers/operator_guard.go
@@ -5,11 +5,17 @@ import (
 	"log"
 	"net/http"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/common"
 )
 
 // OperatorTokenHeader is the HTTP header used to present the operator token.
 const OperatorTokenHeader = "X-Operator-Token"
+
+const (
+	loopbackOperatorActorID    = "loopback"
+	sharedTokenOperatorActorID = "shared-token"
+)
 
 // OperatorGuard restricts access to operator-facing routes (web UI, operator
 // API, file drop, log stream, and server terminal).
@@ -32,7 +38,8 @@ func NewOperatorGuard(token string, allowedOrigins []string) *OperatorGuard {
 // Wrap returns middleware that enforces the guard on every request.
 func (g *OperatorGuard) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !g.Authorized(r) {
+		actor, authorized := g.authorizedActor(r)
+		if !authorized {
 			log.Printf("[SECURITY] Denied unauthorized operator request")
 			http.Error(w, "Forbidden: operator access requires a loopback client or a valid operator token", http.StatusForbidden)
 			return
@@ -42,23 +49,40 @@ func (g *OperatorGuard) Wrap(next http.Handler) http.Handler {
 			http.Error(w, "Forbidden: operator origin is not allowed", http.StatusForbidden)
 			return
 		}
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(
+			w,
+			r.WithContext(audit.WithActor(r.Context(), actor)),
+		)
 	})
 }
 
 // Authorized reports whether the request may reach operator routes.
 func (g *OperatorGuard) Authorized(r *http.Request) bool {
+	_, authorized := g.authorizedActor(r)
+	return authorized
+}
+
+func (g *OperatorGuard) authorizedActor(r *http.Request) (audit.Actor, bool) {
 	if common.IsLoopbackHost(r.RemoteAddr) {
-		return true
+		return audit.Actor{
+			Kind: audit.ActorOperator,
+			ID:   loopbackOperatorActorID,
+		}, true
 	}
 	if g.token == "" {
-		return false
+		return audit.Actor{}, false
 	}
 	provided := r.Header.Get(OperatorTokenHeader)
 	if provided == "" {
-		return false
+		return audit.Actor{}, false
 	}
-	return subtle.ConstantTimeCompare([]byte(provided), []byte(g.token)) == 1
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(g.token)) != 1 {
+		return audit.Actor{}, false
+	}
+	return audit.Actor{
+		Kind: audit.ActorOperator,
+		ID:   sharedTokenOperatorActorID,
+	}, true
 }
 
 // CheckOrigin validates the Origin header for operator WebSocket upgrades

--- a/server/internal/handlers/operator_guard_test.go
+++ b/server/internal/handlers/operator_guard_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"microc2/server/internal/audit"
 )
 
 const testOperatorToken = "test-token"
@@ -54,6 +56,81 @@ func TestOperatorGuardAllowsRemoteWithToken(t *testing.T) {
 
 	if !called || rec.Code != http.StatusOK {
 		t.Fatalf("expected remote request with valid token to pass, called=%v code=%d", called, rec.Code)
+	}
+}
+
+func TestOperatorGuardPropagatesTrustedLoopbackActor(t *testing.T) {
+	guard := NewOperatorGuard(testOperatorToken, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/list", nil)
+	req.RemoteAddr = "127.0.0.1:55555"
+	req.Header.Set(OperatorTokenHeader, "wrong-token")
+	req = req.WithContext(audit.WithActor(req.Context(), audit.Actor{
+		Kind: audit.ActorSystem,
+		ID:   "forged-caller-context",
+	}))
+
+	var got audit.Actor
+	guard.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+		got, ok = audit.ActorFromContext(r.Context())
+		if !ok {
+			t.Fatal("guard did not propagate an audit actor")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(httptest.NewRecorder(), req)
+
+	want := audit.Actor{
+		Kind: audit.ActorOperator,
+		ID:   loopbackOperatorActorID,
+	}
+	if got != want {
+		t.Fatalf("loopback audit actor = %#v, want %#v", got, want)
+	}
+}
+
+func TestOperatorGuardPropagatesTrustedSharedTokenActor(t *testing.T) {
+	guard := NewOperatorGuard(testOperatorToken, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/list", nil)
+	req.RemoteAddr = "192.168.1.20:55555"
+	req.Header.Set(OperatorTokenHeader, testOperatorToken)
+
+	var got audit.Actor
+	guard.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
+		got, ok = audit.ActorFromContext(r.Context())
+		if !ok {
+			t.Fatal("guard did not propagate an audit actor")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(httptest.NewRecorder(), req)
+
+	want := audit.Actor{
+		Kind: audit.ActorOperator,
+		ID:   sharedTokenOperatorActorID,
+	}
+	if got != want {
+		t.Fatalf("shared-token audit actor = %#v, want %#v", got, want)
+	}
+	if got.ID == testOperatorToken {
+		t.Fatal("operator credential was reused as the audit actor ID")
+	}
+}
+
+func TestOperatorGuardDoesNotPropagateActorWhenAuthorizationFails(t *testing.T) {
+	guard := NewOperatorGuard(testOperatorToken, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/agents/list", nil)
+	req.RemoteAddr = "192.168.1.20:55555"
+	req.Header.Set(OperatorTokenHeader, "wrong-token")
+
+	called := false
+	guard.Wrap(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	})).ServeHTTP(httptest.NewRecorder(), req)
+	if called {
+		t.Fatal("unauthorized request reached the guarded handler")
+	}
+	if actor, ok := guard.authorizedActor(req); ok || actor != (audit.Actor{}) {
+		t.Fatalf("unauthorized request resolved actor %#v, authorized=%v", actor, ok)
 	}
 }
 

--- a/server/internal/handlers/ws/types.go
+++ b/server/internal/handlers/ws/types.go
@@ -1,10 +1,15 @@
 package ws
 
-import "microc2/server/internal/websocket"
+import (
+	"microc2/server/internal/audit"
+	"microc2/server/internal/websocket"
+)
 
 // Handler manages websocket connections for the server application
 // It provides handlers for log streaming and terminal sessions.
 type Handler struct {
 	logStreamer     *websocket.LogStreamer
 	terminalHandler *websocket.TerminalHandler
+	terminalEnabled bool
+	terminalAuditor *audit.Store
 }

--- a/server/internal/handlers/ws/websocket_handlers.go
+++ b/server/internal/handlers/ws/websocket_handlers.go
@@ -1,9 +1,23 @@
 package ws
 
 import (
+	"context"
+	"log"
 	"net/http"
 
+	"github.com/google/uuid"
+
+	"microc2/server/internal/audit"
 	"microc2/server/internal/websocket"
+)
+
+const (
+	terminalRoute          = "/ws/terminal"
+	terminalTargetKind     = "terminal_session"
+	terminalAccessAction   = "terminal.access.requested"
+	terminalOpenAction     = "terminal.session.opened"
+	terminalCloseAction    = "terminal.session.closed"
+	terminalDisabledReason = "feature_disabled"
 )
 
 // New creates a new websocket handler with the provided log streamer
@@ -15,11 +29,25 @@ import (
 //
 // Post-conditions:
 //   - Returns a configured websocket Handler instance
-//   - Terminal handler is initialized
+//   - Terminal handler is initialized but disabled
 func New(logStreamer *websocket.LogStreamer, checkOrigin func(*http.Request) bool) *Handler {
+	return NewWithTerminalPolicy(logStreamer, checkOrigin, false, nil)
+}
+
+// NewWithTerminalPolicy creates a WebSocket handler with an explicit server
+// terminal policy and durable audit store. An enabled terminal without a
+// working auditor fails closed before WebSocket upgrade.
+func NewWithTerminalPolicy(
+	logStreamer *websocket.LogStreamer,
+	checkOrigin func(*http.Request) bool,
+	enableTerminal bool,
+	auditor *audit.Store,
+) *Handler {
 	return &Handler{
 		logStreamer:     logStreamer,
 		terminalHandler: websocket.NewTerminalHandler(checkOrigin),
+		terminalEnabled: enableTerminal,
+		terminalAuditor: auditor,
 	}
 }
 
@@ -49,5 +77,92 @@ func (h *Handler) HandleLogStream(w http.ResponseWriter, r *http.Request) {
 //   - Terminal session is maintained until connection closed
 //   - Resources are properly cleaned up on disconnect
 func (h *Handler) HandleTerminal(w http.ResponseWriter, r *http.Request) {
-	h.terminalHandler.HandleConnection(w, r)
+	w.Header().Set("Cache-Control", "no-store")
+	actor, ok := audit.ActorFromContext(r.Context())
+	if !ok {
+		log.Printf("[SECURITY] Denied server terminal request without a trusted operator actor")
+		http.Error(w, "Forbidden: terminal access requires an authenticated operator", http.StatusForbidden)
+		return
+	}
+	if h.terminalAuditor == nil {
+		log.Printf("[ERROR] Server terminal audit store is unavailable")
+		http.Error(w, "Server terminal is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	sessionID := uuid.NewString()
+	auditContext := context.WithoutCancel(r.Context())
+	requestInput := audit.Input{
+		Actor:  actor,
+		Action: terminalAccessAction,
+		Route:  terminalRoute,
+		Target: audit.Target{
+			Kind: terminalTargetKind,
+			ID:   sessionID,
+		},
+		Outcome:           audit.OutcomeSucceeded,
+		TerminalSessionID: sessionID,
+	}
+	if !h.terminalEnabled {
+		requestInput.Outcome = audit.OutcomeDenied
+		requestInput.ReasonCode = terminalDisabledReason
+		if _, err := h.terminalAuditor.Append(auditContext, requestInput); err != nil {
+			log.Printf("[ERROR] Failed to audit denied server terminal access")
+			http.Error(w, "Server terminal is unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		http.Error(w, "Forbidden: server terminal is disabled", http.StatusForbidden)
+		return
+	}
+
+	requested, err := h.terminalAuditor.Append(auditContext, requestInput)
+	if err != nil {
+		log.Printf("[ERROR] Failed to audit server terminal access request")
+		http.Error(w, "Server terminal is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	var openedSequence int64
+	h.terminalHandler.HandleConnectionWithLifecycle(
+		w,
+		r,
+		func() error {
+			causation := requested.Sequence
+			opened, err := h.terminalAuditor.Append(auditContext, audit.Input{
+				Actor:  actor,
+				Action: terminalOpenAction,
+				Route:  terminalRoute,
+				Target: audit.Target{
+					Kind: terminalTargetKind,
+					ID:   sessionID,
+				},
+				Outcome:           audit.OutcomeSucceeded,
+				CausationSequence: &causation,
+				TerminalSessionID: sessionID,
+			})
+			if err != nil {
+				log.Printf("[ERROR] Failed to audit opened server terminal session")
+				return err
+			}
+			openedSequence = opened.Sequence
+			return nil
+		},
+		func() {
+			causation := openedSequence
+			if _, err := h.terminalAuditor.Append(auditContext, audit.Input{
+				Actor:  actor,
+				Action: terminalCloseAction,
+				Route:  terminalRoute,
+				Target: audit.Target{
+					Kind: terminalTargetKind,
+					ID:   sessionID,
+				},
+				Outcome:           audit.OutcomeSucceeded,
+				CausationSequence: &causation,
+				TerminalSessionID: sessionID,
+			}); err != nil {
+				log.Printf("[ERROR] Failed to audit closed server terminal session")
+			}
+		},
+	)
 }

--- a/server/internal/handlers/ws/websocket_handlers_test.go
+++ b/server/internal/handlers/ws/websocket_handlers_test.go
@@ -1,0 +1,357 @@
+package ws
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gorilla "github.com/gorilla/websocket"
+
+	"microc2/server/internal/audit"
+	"microc2/server/internal/persistence"
+)
+
+var testTerminalActor = audit.Actor{
+	Kind: audit.ActorOperator,
+	ID:   "loopback",
+}
+
+func TestNewDefaultsTerminalToDisabled(t *testing.T) {
+	handler := New(nil, func(*http.Request) bool { return true })
+	if handler.terminalEnabled {
+		t.Fatal("legacy WebSocket constructor enabled the server terminal")
+	}
+}
+
+func TestTerminalDisabledByPolicyIsDeniedAndAudited(t *testing.T) {
+	store, _ := newTerminalAuditStore(t)
+	handler := NewWithTerminalPolicy(
+		nil,
+		func(*http.Request) bool { return true },
+		false,
+		store,
+	)
+	recorder := httptest.NewRecorder()
+	request := trustedTerminalRequest(
+		httptest.NewRequest(http.MethodGet, terminalRoute, nil),
+	)
+
+	handler.HandleTerminal(recorder, request)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("disabled terminal status = %d, want 403", recorder.Code)
+	}
+	if recorder.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf(
+			"disabled terminal Cache-Control = %q, want no-store",
+			recorder.Header().Get("Cache-Control"),
+		)
+	}
+	events := terminalAuditEvents(t, store)
+	if len(events) != 1 {
+		t.Fatalf("disabled terminal events = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.Actor != testTerminalActor ||
+		event.Action != terminalAccessAction ||
+		event.Route != terminalRoute ||
+		event.Target.Kind != terminalTargetKind ||
+		event.Target.ID == "" ||
+		event.Outcome != audit.OutcomeDenied ||
+		event.ReasonCode != terminalDisabledReason ||
+		event.TerminalSessionID != event.Target.ID {
+		t.Fatalf("unexpected disabled terminal event: %#v", event)
+	}
+}
+
+func TestTerminalRejectsRequestWithoutTrustedActor(t *testing.T) {
+	store, _ := newTerminalAuditStore(t)
+	handler := NewWithTerminalPolicy(
+		nil,
+		func(*http.Request) bool { return true },
+		true,
+		store,
+	)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, terminalRoute, nil)
+
+	handler.HandleTerminal(recorder, request)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("untrusted terminal status = %d, want 403", recorder.Code)
+	}
+	if events := terminalAuditEvents(t, store); len(events) != 0 {
+		t.Fatalf("untrusted terminal request wrote %d audit events", len(events))
+	}
+}
+
+func TestTerminalAuditsAuthorizedRequestBeforeUpgrade(t *testing.T) {
+	store, _ := newTerminalAuditStore(t)
+	handler := NewWithTerminalPolicy(
+		nil,
+		func(*http.Request) bool { return true },
+		true,
+		store,
+	)
+	recorder := httptest.NewRecorder()
+	request := trustedTerminalRequest(
+		httptest.NewRequest(http.MethodGet, terminalRoute, nil),
+	)
+
+	handler.HandleTerminal(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("non-WebSocket terminal status = %d, want 400", recorder.Code)
+	}
+	events := terminalAuditEvents(t, store)
+	if len(events) != 1 {
+		t.Fatalf("failed-upgrade terminal events = %d, want 1", len(events))
+	}
+	if events[0].Action != terminalAccessAction ||
+		events[0].Outcome != audit.OutcomeSucceeded {
+		t.Fatalf("unexpected access-request event: %#v", events[0])
+	}
+}
+
+func TestTerminalAuditsOpenAndCloseWithoutCommandContent(t *testing.T) {
+	store, _ := newTerminalAuditStore(t)
+	handler := NewWithTerminalPolicy(
+		nil,
+		func(*http.Request) bool { return true },
+		true,
+		store,
+	)
+	connection, serverDone := dialTerminalInMemory(t, http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		handler.HandleTerminal(w, trustedTerminalRequest(r))
+	}))
+	if _, _, err := connection.ReadMessage(); err != nil {
+		connection.Close()
+		t.Fatalf("read terminal greeting: %v", err)
+	}
+	if err := connection.WriteMessage(gorilla.TextMessage, []byte("pwd")); err != nil {
+		connection.Close()
+		t.Fatalf("write terminal command: %v", err)
+	}
+	if _, _, err := connection.ReadMessage(); err != nil {
+		connection.Close()
+		t.Fatalf("read terminal command response: %v", err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("close terminal client: %v", err)
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("serve in-memory terminal: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal handler did not finish after client close")
+	}
+
+	events := terminalAuditEvents(t, store)
+	if len(events) != 3 {
+		t.Fatalf("terminal lifecycle events = %d, want 3: %#v", len(events), events)
+	}
+	closed, opened, requested := events[0], events[1], events[2]
+	if requested.Action != terminalAccessAction ||
+		opened.Action != terminalOpenAction ||
+		closed.Action != terminalCloseAction {
+		t.Fatalf(
+			"terminal actions newest-first = %q, %q, %q",
+			closed.Action,
+			opened.Action,
+			requested.Action,
+		)
+	}
+	if requested.TerminalSessionID == "" ||
+		opened.TerminalSessionID != requested.TerminalSessionID ||
+		closed.TerminalSessionID != requested.TerminalSessionID {
+		t.Fatalf("terminal session correlation is inconsistent: %#v", events)
+	}
+	if opened.CausationSequence == nil ||
+		*opened.CausationSequence != requested.Sequence ||
+		closed.CausationSequence == nil ||
+		*closed.CausationSequence != opened.Sequence {
+		t.Fatalf("terminal causation chain is inconsistent: %#v", events)
+	}
+	for _, event := range events {
+		if event.Actor != testTerminalActor ||
+			event.Route != terminalRoute ||
+			event.Outcome != audit.OutcomeSucceeded {
+			t.Fatalf("unexpected terminal lifecycle event: %#v", event)
+		}
+		encodedFields := event.Action + event.Route + event.Target.ID +
+			event.ReasonCode + event.TerminalSessionID
+		if strings.Contains(encodedFields, "pwd") {
+			t.Fatalf("terminal event retained command content: %#v", event)
+		}
+	}
+}
+
+func TestEnabledTerminalFailsClosedWhenAuditStoreIsUnavailable(t *testing.T) {
+	store, database := newTerminalAuditStore(t)
+	if err := database.Close(); err != nil {
+		t.Fatalf("close audit database: %v", err)
+	}
+	handler := NewWithTerminalPolicy(
+		nil,
+		func(*http.Request) bool { return true },
+		true,
+		store,
+	)
+	recorder := httptest.NewRecorder()
+	request := trustedTerminalRequest(
+		httptest.NewRequest(http.MethodGet, terminalRoute, nil),
+	)
+
+	handler.HandleTerminal(recorder, request)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("terminal audit failure status = %d, want 503", recorder.Code)
+	}
+}
+
+func newTerminalAuditStore(
+	t *testing.T,
+) (*audit.Store, *persistence.Database) {
+	t.Helper()
+	database, err := persistence.Open(
+		filepath.Join(t.TempDir(), "microc2.db"),
+	)
+	if err != nil {
+		t.Fatalf("open audit database: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.Close()
+	})
+	store, err := audit.NewStore(database)
+	if err != nil {
+		t.Fatalf("create audit store: %v", err)
+	}
+	return store, database
+}
+
+func trustedTerminalRequest(r *http.Request) *http.Request {
+	return r.WithContext(audit.WithActor(r.Context(), testTerminalActor))
+}
+
+func terminalAuditEvents(t *testing.T, store *audit.Store) []audit.Event {
+	t.Helper()
+	page, err := store.Page(context.Background(), audit.PageOptions{
+		Limit:  100,
+		Offset: 0,
+	})
+	if err != nil {
+		t.Fatalf("page terminal audit events: %v", err)
+	}
+	return page.Events
+}
+
+type pipeResponseWriter struct {
+	header      http.Header
+	connection  net.Conn
+	reader      *bufio.Reader
+	writer      *bufio.Writer
+	wroteHeader bool
+}
+
+func (w *pipeResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *pipeResponseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	_, _ = fmt.Fprintf(w.writer, "HTTP/1.1 %d %s\r\n", status, http.StatusText(status))
+	for name, values := range w.header {
+		for _, value := range values {
+			_, _ = fmt.Fprintf(w.writer, "%s: %s\r\n", name, value)
+		}
+	}
+	_, _ = w.writer.WriteString("\r\n")
+	_ = w.writer.Flush()
+}
+
+func (w *pipeResponseWriter) Write(body []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.writer.Write(body)
+}
+
+func (w *pipeResponseWriter) Hijack() (
+	net.Conn,
+	*bufio.ReadWriter,
+	error,
+) {
+	return w.connection, bufio.NewReadWriter(w.reader, w.writer), nil
+}
+
+func dialTerminalInMemory(
+	t *testing.T,
+	handler http.Handler,
+) (*gorilla.Conn, <-chan error) {
+	t.Helper()
+	serverConnection, clientConnection := net.Pipe()
+	deadline := time.Now().Add(2 * time.Second)
+	if err := serverConnection.SetDeadline(deadline); err != nil {
+		t.Fatalf("set server pipe deadline: %v", err)
+	}
+	if err := clientConnection.SetDeadline(deadline); err != nil {
+		t.Fatalf("set client pipe deadline: %v", err)
+	}
+	serverDone := make(chan error, 1)
+	go func() {
+		reader := bufio.NewReader(serverConnection)
+		writer := bufio.NewWriter(serverConnection)
+		request, err := http.ReadRequest(reader)
+		if err != nil {
+			_ = serverConnection.Close()
+			serverDone <- fmt.Errorf("read WebSocket request: %w", err)
+			return
+		}
+		request.RemoteAddr = "127.0.0.1:50000"
+		handler.ServeHTTP(&pipeResponseWriter{
+			header:     make(http.Header),
+			connection: serverConnection,
+			reader:     reader,
+			writer:     writer,
+		}, request)
+		_ = serverConnection.Close()
+		serverDone <- nil
+	}()
+
+	target, err := url.Parse("ws://microc2.test" + terminalRoute)
+	if err != nil {
+		t.Fatalf("parse terminal URL: %v", err)
+	}
+	connection, _, err := gorilla.NewClient(
+		clientConnection,
+		target,
+		nil,
+		0,
+		0,
+	)
+	if err != nil {
+		_ = clientConnection.Close()
+		if serverErr := <-serverDone; serverErr != nil {
+			t.Fatalf("dial terminal: %v (server: %v)", err, serverErr)
+		}
+		t.Fatalf("dial terminal: %v", err)
+	}
+	return connection, serverDone
+}

--- a/server/internal/listeners/listener_manager.go
+++ b/server/internal/listeners/listener_manager.go
@@ -1,13 +1,17 @@
 package listeners
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+
+	"microc2/server/internal/audit"
 	"microc2/server/internal/behaviour"
 	"microc2/server/internal/common"
 	"microc2/server/internal/persistence"
+
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,6 +31,7 @@ type ListenerManager struct {
 	protocol         common.Protocol
 	listenersDir     string
 	database         *persistence.Database
+	auditStore       *audit.Store
 	transportPolicy  common.AgentTransportPolicy
 	requireAgentAuth bool
 	now              func() time.Time
@@ -160,11 +165,20 @@ func newListenerManager(
 	if now == nil {
 		now = time.Now
 	}
+	var auditStore *audit.Store
+	if database != nil {
+		var err error
+		auditStore, err = audit.NewStore(database)
+		if err != nil {
+			return nil, fmt.Errorf("initialize listener audit store: %w", err)
+		}
+	}
 	manager := &ListenerManager{
 		listeners:        make(map[string]*Listener),
 		protocol:         proto,
 		listenersDir:     listenersDir,
 		database:         database,
+		auditStore:       auditStore,
 		transportPolicy:  transportPolicy,
 		requireAgentAuth: requireAgentAuth,
 		now:              now,
@@ -318,7 +332,10 @@ func newListenerManager(
 			continue
 		}
 		if database != nil {
-			if err := manager.recordListenerImported(config); err != nil {
+			if err := manager.recordListenerImported(
+				context.Background(),
+				config,
+			); err != nil {
 				return nil, fmt.Errorf("import listener %s: %w", config.ID, err)
 			}
 			if err := writeListenerConfigProjection(
@@ -357,6 +374,21 @@ func (m *ListenerManager) GetProtocol() common.Protocol {
 //   - A new listener is created, started, and added to the manager
 //   - Returns error if the configuration is invalid or the port is already in use
 func (m *ListenerManager) CreateListener(config ListenerConfig) (*Listener, error) {
+	return m.CreateListenerWithContext(
+		audit.WithActor(
+			context.Background(),
+			audit.DefaultOperatorActor(),
+		),
+		config,
+	)
+}
+
+// CreateListenerWithContext preserves the authenticated operator actor for
+// the listener creation and automatic-start audit records.
+func (m *ListenerManager) CreateListenerWithContext(
+	ctx context.Context,
+	config ListenerConfig,
+) (*Listener, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -387,7 +419,7 @@ func (m *ListenerManager) CreateListener(config ListenerConfig) (*Listener, erro
 		return nil, err
 	}
 	m.attachListenerCallbacks(listener)
-	if err := m.recordListenerCreated(config); err != nil {
+	if err := m.recordListenerCreated(ctx, config); err != nil {
 		m.cleanupListenerConfig(config.Name)
 		return nil, fmt.Errorf("persist listener creation: %w", err)
 	}
@@ -403,19 +435,28 @@ func (m *ListenerManager) CreateListener(config ListenerConfig) (*Listener, erro
 			true,
 		); err != nil {
 			return nil, m.failCreatedListener(
+				ctx,
 				listener,
 				fmt.Errorf("write listener compatibility projection: %w", err),
 			)
 		}
 	}
 	if err := listener.Start(); err != nil {
-		return nil, m.failCreatedListener(listener, err)
+		return nil, m.failCreatedListener(ctx, listener, err)
 	}
-	if err := m.recordListenerState(config.ID, StatusActive, "started", "", false); err != nil {
+	if err := m.recordListenerState(
+		ctx,
+		config.ID,
+		StatusActive,
+		"started",
+		"",
+		false,
+	); err != nil {
 		if stopErr := listener.Stop(); stopErr != nil {
 			log.Printf("[WARNING] Failed to stop listener after persistence error: %v", stopErr)
 		}
 		return nil, m.failCreatedListener(
+			ctx,
 			listener,
 			fmt.Errorf("persist listener start: %w", err),
 		)
@@ -430,6 +471,7 @@ func (m *ListenerManager) CreateListener(config ListenerConfig) (*Listener, erro
 //
 // The caller must hold m.mu.
 func (m *ListenerManager) failCreatedListener(
+	ctx context.Context,
 	listener *Listener,
 	cause error,
 ) error {
@@ -439,6 +481,7 @@ func (m *ListenerManager) failCreatedListener(
 
 	if m.database != nil {
 		if err := m.recordListenerState(
+			ctx,
 			listener.Config.ID,
 			StatusError,
 			"creation_failed",
@@ -574,7 +617,14 @@ func (m *ListenerManager) RemoveListener(id string) error {
 	if listener.GetStatus() == StatusActive || listener.GetStatus() == StatusError {
 		if err := listener.Stop(); err != nil {
 			log.Printf("[WARNING] Failed to stop listener %s: %v", id, err)
-		} else if err := m.recordListenerState(id, StatusStopped, "stopped", "", false); err != nil {
+		} else if err := m.recordListenerState(
+			context.Background(),
+			id,
+			StatusStopped,
+			"stopped",
+			"",
+			false,
+		); err != nil {
 			return fmt.Errorf("persist stopped listener: %w", err)
 		}
 	}
@@ -594,6 +644,20 @@ func (m *ListenerManager) RemoveListener(id string) error {
 //   - Listener remains in the registry but with stopped status
 //   - Returns error if the listener doesn't exist or can't be stopped
 func (m *ListenerManager) StopListener(id string) error {
+	return m.StopListenerWithContext(
+		audit.WithActor(
+			context.Background(),
+			audit.DefaultOperatorActor(),
+		),
+		id,
+	)
+}
+
+// StopListenerWithContext stops a listener as the authenticated operator.
+func (m *ListenerManager) StopListenerWithContext(
+	ctx context.Context,
+	id string,
+) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -610,7 +674,14 @@ func (m *ListenerManager) StopListener(id string) error {
 	if err := listener.Stop(); err != nil {
 		return fmt.Errorf("failed to stop listener: %w", err)
 	}
-	if err := m.recordListenerState(id, StatusStopped, "stopped", "", false); err != nil {
+	if err := m.recordListenerState(
+		ctx,
+		id,
+		StatusStopped,
+		"stopped",
+		"",
+		false,
+	); err != nil {
 		return fmt.Errorf("persist stopped listener: %w", err)
 	}
 
@@ -627,6 +698,20 @@ func (m *ListenerManager) StopListener(id string) error {
 //   - Listener is started and its status updated to active
 //   - Returns error if the listener doesn't exist or can't be started
 func (m *ListenerManager) StartListener(id string) error {
+	return m.StartListenerWithContext(
+		audit.WithActor(
+			context.Background(),
+			audit.DefaultOperatorActor(),
+		),
+		id,
+	)
+}
+
+// StartListenerWithContext starts a listener as the authenticated operator.
+func (m *ListenerManager) StartListenerWithContext(
+	ctx context.Context,
+	id string,
+) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -654,6 +739,7 @@ func (m *ListenerManager) StartListener(id string) error {
 	// Start the listener
 	if err := listener.Start(); err != nil {
 		if persistErr := m.recordListenerState(
+			ctx,
 			id,
 			StatusError,
 			"error",
@@ -664,7 +750,14 @@ func (m *ListenerManager) StartListener(id string) error {
 		}
 		return fmt.Errorf("failed to start listener: %w", err)
 	}
-	if err := m.recordListenerState(id, StatusActive, "started", "", false); err != nil {
+	if err := m.recordListenerState(
+		ctx,
+		id,
+		StatusActive,
+		"started",
+		"",
+		false,
+	); err != nil {
 		if stopErr := listener.Stop(); stopErr != nil {
 			log.Printf("[WARNING] Failed to stop listener after persistence error: %v", stopErr)
 		}
@@ -685,6 +778,20 @@ func (m *ListenerManager) StartListener(id string) error {
 //   - Listener is stopped if it was running
 //   - Returns error if the listener doesn't exist
 func (m *ListenerManager) DeleteListener(id string) error {
+	return m.DeleteListenerWithContext(
+		audit.WithActor(
+			context.Background(),
+			audit.DefaultOperatorActor(),
+		),
+		id,
+	)
+}
+
+// DeleteListenerWithContext deletes a listener as the authenticated operator.
+func (m *ListenerManager) DeleteListenerWithContext(
+	ctx context.Context,
+	id string,
+) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -698,12 +805,26 @@ func (m *ListenerManager) DeleteListener(id string) error {
 		if err := listener.Stop(); err != nil {
 			return fmt.Errorf("failed to stop listener before deletion: %v", err)
 		}
-		if err := m.recordListenerState(id, StatusStopped, "stopped", "", false); err != nil {
+		if err := m.recordListenerState(
+			ctx,
+			id,
+			StatusStopped,
+			"stopped",
+			"",
+			false,
+		); err != nil {
 			return fmt.Errorf("persist stopped listener before deletion: %w", err)
 		}
 	}
 
-	if err := m.recordListenerState(id, StatusStopped, "deleted", "", true); err != nil {
+	if err := m.recordListenerState(
+		ctx,
+		id,
+		StatusStopped,
+		"deleted",
+		"",
+		true,
+	); err != nil {
 		return fmt.Errorf("persist deleted listener: %w", err)
 	}
 	// Clean up listener directory after the tombstone commits. If filesystem
@@ -736,7 +857,14 @@ func (m *ListenerManager) StopAll() []error {
 		if listener.GetStatus() == StatusActive || listener.GetStatus() == StatusError {
 			if err := listener.Stop(); err != nil {
 				errors = append(errors, fmt.Errorf("failed to stop listener %s: %v", id, err))
-			} else if err := m.recordListenerState(id, StatusStopped, "stopped", "", false); err != nil {
+			} else if err := m.recordListenerState(
+				context.Background(),
+				id,
+				StatusStopped,
+				"stopped",
+				"",
+				false,
+			); err != nil {
 				errors = append(errors, fmt.Errorf("persist stopped listener %s: %v", id, err))
 			}
 		}
@@ -764,12 +892,26 @@ func (m *ListenerManager) DeleteAll() []error {
 				errors = append(errors, fmt.Errorf("failed to stop listener %s: %v", id, err))
 				continue // Skip deletion if stopping fails
 			}
-			if err := m.recordListenerState(id, StatusStopped, "stopped", "", false); err != nil {
+			if err := m.recordListenerState(
+				context.Background(),
+				id,
+				StatusStopped,
+				"stopped",
+				"",
+				false,
+			); err != nil {
 				errors = append(errors, fmt.Errorf("persist stopped listener %s: %v", id, err))
 				continue
 			}
 		}
-		if err := m.recordListenerState(id, StatusStopped, "deleted", "", true); err != nil {
+		if err := m.recordListenerState(
+			context.Background(),
+			id,
+			StatusStopped,
+			"deleted",
+			"",
+			true,
+		); err != nil {
 			errors = append(errors, fmt.Errorf("persist deleted listener %s: %v", id, err))
 			continue
 		}
@@ -930,6 +1072,7 @@ func (m *ListenerManager) attachListenerCallbacks(listener *Listener) {
 			message = listenerErr.Error()
 		}
 		if err := m.recordListenerState(
+			context.Background(),
 			listenerID,
 			StatusError,
 			"error",

--- a/server/internal/listeners/persistence.go
+++ b/server/internal/listeners/persistence.go
@@ -6,17 +6,19 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"microc2/server/internal/audit"
 )
 
-// ListenerEvent is an append-only record of a listener lifecycle transition.
-// Operator identity and causal audit metadata are intentionally deferred to
-// issue #100.
+// ListenerEvent is the compatibility lifecycle projection. Each new durable
+// row is linked to the richer actor-aware audit event committed with it.
 type ListenerEvent struct {
 	Sequence   int64          `json:"sequence"`
 	ListenerID string         `json:"listener_id"`
@@ -26,16 +28,24 @@ type ListenerEvent struct {
 	OccurredAt time.Time      `json:"occurred_at"`
 }
 
-func (m *ListenerManager) recordListenerCreated(config ListenerConfig) error {
+func (m *ListenerManager) recordListenerCreated(
+	ctx context.Context,
+	config ListenerConfig,
+) error {
 	return m.insertDurableListener(
+		ctx,
 		config,
 		"created",
 		"",
 	)
 }
 
-func (m *ListenerManager) recordListenerImported(config ListenerConfig) error {
+func (m *ListenerManager) recordListenerImported(
+	ctx context.Context,
+	config ListenerConfig,
+) error {
 	return m.insertDurableListener(
+		ctx,
 		config,
 		"imported",
 		"imported saved listener configuration",
@@ -43,6 +53,7 @@ func (m *ListenerManager) recordListenerImported(config ListenerConfig) error {
 }
 
 func (m *ListenerManager) insertDurableListener(
+	ctx context.Context,
 	config ListenerConfig,
 	eventType string,
 	message string,
@@ -55,7 +66,10 @@ func (m *ListenerManager) insertDurableListener(
 		return err
 	}
 	now := m.timestamp()
-	tx, err := m.database.SQL().BeginTx(context.Background(), nil)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := m.database.SQL().BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -76,6 +90,15 @@ func (m *ListenerManager) insertDurableListener(
 	); err != nil {
 		return err
 	}
+	auditEvent, err := m.appendListenerAuditTx(
+		ctx,
+		tx,
+		config.ID,
+		eventType,
+	)
+	if err != nil {
+		return err
+	}
 	if err := insertListenerEvent(
 		tx,
 		config.ID,
@@ -83,6 +106,7 @@ func (m *ListenerManager) insertDurableListener(
 		StatusStopped,
 		message,
 		now,
+		auditEvent.Sequence,
 	); err != nil {
 		return err
 	}
@@ -254,6 +278,19 @@ func (m *ListenerManager) loadAndRecoverDurableListeners() (
 				record.id,
 			)
 		}
+		auditEvent, err := m.appendListenerAuditTx(
+			context.Background(),
+			tx,
+			record.id,
+			"recovered_stopped",
+		)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf(
+				"audit durable listener %s recovery: %w",
+				record.id,
+				err,
+			)
+		}
 		if err := insertListenerEvent(
 			tx,
 			record.id,
@@ -261,6 +298,7 @@ func (m *ListenerManager) loadAndRecoverDurableListeners() (
 			StatusStopped,
 			"listener recovered as stopped after server restart",
 			now,
+			auditEvent.Sequence,
 		); err != nil {
 			return nil, nil, nil, fmt.Errorf(
 				"record durable listener %s recovery: %w",
@@ -282,6 +320,7 @@ func (m *ListenerManager) loadAndRecoverDurableListeners() (
 }
 
 func (m *ListenerManager) recordListenerState(
+	ctx context.Context,
 	listenerID string,
 	status ListenerStatus,
 	eventType string,
@@ -291,8 +330,11 @@ func (m *ListenerManager) recordListenerState(
 	if m.database == nil {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	now := m.timestamp()
-	tx, err := m.database.SQL().BeginTx(context.Background(), nil)
+	tx, err := m.database.SQL().BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -331,6 +373,15 @@ func (m *ListenerManager) recordListenerState(
 	if affected != 1 {
 		return fmt.Errorf("listener %s has no durable record", listenerID)
 	}
+	auditEvent, err := m.appendListenerAuditTx(
+		ctx,
+		tx,
+		listenerID,
+		eventType,
+	)
+	if err != nil {
+		return err
+	}
 	if err := insertListenerEvent(
 		tx,
 		listenerID,
@@ -338,6 +389,7 @@ func (m *ListenerManager) recordListenerState(
 		status,
 		message,
 		now,
+		auditEvent.Sequence,
 	); err != nil {
 		return err
 	}
@@ -432,16 +484,79 @@ func insertListenerEvent(
 	status ListenerStatus,
 	message string,
 	occurredAt string,
+	auditEventSequence int64,
 ) error {
 	_, err := executor.Exec(
 		`INSERT INTO listener_events (
-			listener_id, event_type, status, message, occurred_at
-		) VALUES (?, ?, ?, ?, ?)`,
+			listener_id, event_type, status, message, occurred_at,
+			audit_event_seq
+		) VALUES (?, ?, ?, ?, ?, ?)`,
 		listenerID,
 		eventType,
 		string(status),
 		message,
 		occurredAt,
+		auditEventSequence,
 	)
 	return err
+}
+
+func (m *ListenerManager) appendListenerAuditTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	listenerID string,
+	eventType string,
+) (audit.Event, error) {
+	if m.auditStore == nil {
+		return audit.Event{}, errors.New("listener audit store is unavailable")
+	}
+	actor := audit.ActorOr(ctx, audit.DefaultSystemActor())
+	action, outcome, reasonCode := listenerAuditDescriptor(eventType)
+	route := "internal:listener"
+	if actor.Kind == audit.ActorOperator {
+		switch eventType {
+		case "created":
+			route = "POST /api/listeners/create"
+		case "started":
+			route = "POST /api/listeners/{listener_id}/start"
+		case "stopped":
+			route = "POST /api/listeners/{listener_id}/stop"
+		case "deleted":
+			route = "DELETE /api/listeners/{listener_id}"
+		}
+	}
+	return m.auditStore.AppendTx(ctx, tx, audit.Input{
+		Actor:      actor,
+		Action:     action,
+		Route:      route,
+		Target:     audit.Target{Kind: "listener", ID: listenerID},
+		Outcome:    outcome,
+		ReasonCode: reasonCode,
+		ListenerID: listenerID,
+	})
+}
+
+func listenerAuditDescriptor(
+	eventType string,
+) (string, audit.Outcome, string) {
+	switch eventType {
+	case "created":
+		return "listener.create", audit.OutcomeSucceeded, ""
+	case "imported":
+		return "listener.import", audit.OutcomeSucceeded, ""
+	case "started":
+		return "listener.start", audit.OutcomeSucceeded, ""
+	case "stopped":
+		return "listener.stop", audit.OutcomeSucceeded, ""
+	case "deleted":
+		return "listener.delete", audit.OutcomeSucceeded, ""
+	case "creation_failed":
+		return "listener.create", audit.OutcomeFailed, "creation_failed"
+	case "recovered_stopped":
+		return "listener.recover", audit.OutcomeSucceeded, "server_restart"
+	case "error":
+		return "listener.error", audit.OutcomeFailed, "runtime_error"
+	default:
+		return "listener.lifecycle", audit.OutcomeSucceeded, ""
+	}
 }

--- a/server/internal/listeners/persistence_test.go
+++ b/server/internal/listeners/persistence_test.go
@@ -1,6 +1,7 @@
 package listeners
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/common"
 	"microc2/server/internal/persistence"
 )
@@ -94,12 +96,18 @@ func TestListenerLifecycleEventsSurviveRestartAndRecoverStopped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create durable listener manager: %v", err)
 	}
-	listener, err := manager.CreateListener(ListenerConfig{
-		Name:     "durable-listener",
-		Protocol: "http",
-		BindHost: "127.0.0.1",
-		Port:     freeTCPPort(t),
-	})
+	listener, err := manager.CreateListenerWithContext(
+		audit.WithActor(context.Background(), audit.Actor{
+			Kind: audit.ActorOperator,
+			ID:   "shared-token",
+		}),
+		ListenerConfig{
+			Name:     "durable-listener",
+			Protocol: "http",
+			BindHost: "127.0.0.1",
+			Port:     freeTCPPort(t),
+		},
+	)
 	if err != nil {
 		t.Fatalf("create listener: %v", err)
 	}
@@ -110,6 +118,13 @@ func TestListenerLifecycleEventsSurviveRestartAndRecoverStopped(t *testing.T) {
 		t.Fatalf("list initial listener events: %v", err)
 	}
 	assertListenerEventTypes(t, events, "created", "started")
+	assertListenerAuditLinks(
+		t,
+		database,
+		listenerID,
+		[]string{"listener.create", "listener.start"},
+		[]string{"shared-token", "shared-token"},
+	)
 
 	// Model a process exit: the socket is closed, but the database retains the
 	// last committed ACTIVE state because no graceful manager stop occurred.
@@ -141,6 +156,13 @@ func TestListenerLifecycleEventsSurviveRestartAndRecoverStopped(t *testing.T) {
 		t.Fatalf("list recovered listener events: %v", err)
 	}
 	assertListenerEventTypes(t, events, "created", "started", "recovered_stopped")
+	assertListenerAuditLinks(
+		t,
+		database,
+		listenerID,
+		[]string{"listener.create", "listener.start", "listener.recover"},
+		[]string{"shared-token", "shared-token", "microc2-server"},
+	)
 
 	// Reconciliation is idempotent: a second reload does not append another
 	// recovery transition.
@@ -907,6 +929,47 @@ func assertListenerEventTypes(t *testing.T, events []ListenerEvent, want ...stri
 			events[index].OccurredAt.IsZero() {
 			t.Fatalf("event %d is incomplete: %#v", index, events[index])
 		}
+	}
+}
+
+func assertListenerAuditLinks(
+	t *testing.T,
+	database *persistence.Database,
+	listenerID string,
+	wantActions []string,
+	wantActorIDs []string,
+) {
+	t.Helper()
+	rows, err := database.SQL().Query(
+		`SELECT audit.action, audit.actor_id
+		 FROM listener_events AS lifecycle
+		 JOIN audit_events AS audit
+		   ON audit.seq = lifecycle.audit_event_seq
+		 WHERE lifecycle.listener_id = ?
+		 ORDER BY lifecycle.seq`,
+		listenerID,
+	)
+	if err != nil {
+		t.Fatalf("query linked listener audits: %v", err)
+	}
+	defer rows.Close()
+	var actions, actorIDs []string
+	for rows.Next() {
+		var action, actorID string
+		if err := rows.Scan(&action, &actorID); err != nil {
+			t.Fatalf("scan linked listener audit: %v", err)
+		}
+		actions = append(actions, action)
+		actorIDs = append(actorIDs, actorID)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate linked listener audits: %v", err)
+	}
+	if strings.Join(actions, ",") != strings.Join(wantActions, ",") {
+		t.Fatalf("listener audit actions = %#v, want %#v", actions, wantActions)
+	}
+	if strings.Join(actorIDs, ",") != strings.Join(wantActorIDs, ",") {
+		t.Fatalf("listener audit actors = %#v, want %#v", actorIDs, wantActorIDs)
 	}
 }
 

--- a/server/internal/persistence/migrations/0004_structured_audit_events.sql
+++ b/server/internal/persistence/migrations/0004_structured_audit_events.sql
@@ -1,0 +1,254 @@
+CREATE TABLE audit_events (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    schema_version INTEGER NOT NULL
+        CHECK (schema_version = 1),
+    occurred_at TEXT NOT NULL
+        CHECK (length(occurred_at) > 0),
+    actor_kind TEXT NOT NULL
+        CHECK (actor_kind IN ('operator', 'agent', 'system')),
+    actor_id TEXT NOT NULL
+        CHECK (length(actor_id) >= 1 AND length(actor_id) <= 128),
+    action TEXT NOT NULL
+        CHECK (length(action) >= 1 AND length(action) <= 128),
+    route TEXT NOT NULL
+        CHECK (length(route) >= 1 AND length(route) <= 256),
+    target_kind TEXT NOT NULL
+        CHECK (length(target_kind) >= 1 AND length(target_kind) <= 64),
+    target_id TEXT NOT NULL
+        CHECK (length(target_id) >= 1 AND length(target_id) <= 255),
+    outcome TEXT NOT NULL
+        CHECK (outcome IN ('succeeded', 'failed', 'denied', 'noop')),
+    reason_code TEXT
+        CHECK (
+            reason_code IS NULL
+            OR (length(reason_code) >= 1 AND length(reason_code) <= 64)
+        ),
+    causation_sequence INTEGER,
+    listener_id TEXT
+        CHECK (
+            listener_id IS NULL
+            OR (length(listener_id) >= 1 AND length(listener_id) <= 128)
+        ),
+    agent_id TEXT
+        CHECK (
+            agent_id IS NULL
+            OR (length(agent_id) >= 1 AND length(agent_id) <= 128)
+        ),
+    task_id TEXT
+        CHECK (
+            task_id IS NULL
+            OR (length(task_id) >= 1 AND length(task_id) <= 128)
+        ),
+    payload_build_id TEXT
+        CHECK (
+            payload_build_id IS NULL
+            OR (
+                length(payload_build_id) >= 1
+                AND length(payload_build_id) <= 128
+            )
+        ),
+    file_name TEXT
+        CHECK (
+            file_name IS NULL
+            OR (length(file_name) >= 1 AND length(file_name) <= 255)
+        ),
+    terminal_session_id TEXT
+        CHECK (
+            terminal_session_id IS NULL
+            OR (
+                length(terminal_session_id) >= 1
+                AND length(terminal_session_id) <= 128
+            )
+        ),
+    FOREIGN KEY (causation_sequence)
+        REFERENCES audit_events (seq)
+        ON UPDATE RESTRICT
+        ON DELETE SET NULL
+);
+
+CREATE INDEX idx_audit_events_occurred_seq
+    ON audit_events (occurred_at DESC, seq DESC);
+
+CREATE INDEX idx_audit_events_actor_seq
+    ON audit_events (actor_kind, actor_id, seq DESC);
+
+CREATE INDEX idx_audit_events_action_seq
+    ON audit_events (action, seq DESC);
+
+CREATE INDEX idx_audit_events_target_seq
+    ON audit_events (target_kind, target_id, seq DESC);
+
+CREATE INDEX idx_audit_events_outcome_seq
+    ON audit_events (outcome, seq DESC);
+
+CREATE INDEX idx_audit_events_listener_seq
+    ON audit_events (listener_id, seq DESC)
+    WHERE listener_id IS NOT NULL;
+
+CREATE INDEX idx_audit_events_agent_seq
+    ON audit_events (listener_id, agent_id, seq DESC)
+    WHERE agent_id IS NOT NULL;
+
+CREATE INDEX idx_audit_events_task_seq
+    ON audit_events (listener_id, task_id, seq DESC)
+    WHERE task_id IS NOT NULL;
+
+CREATE INDEX idx_audit_events_payload_seq
+    ON audit_events (payload_build_id, seq DESC)
+    WHERE payload_build_id IS NOT NULL;
+
+CREATE INDEX idx_audit_events_causation
+    ON audit_events (causation_sequence)
+    WHERE causation_sequence IS NOT NULL;
+
+ALTER TABLE tasks
+    ADD COLUMN created_audit_event_seq INTEGER
+        REFERENCES audit_events (seq)
+        ON UPDATE RESTRICT
+        ON DELETE RESTRICT;
+
+ALTER TABLE payload_builds
+    ADD COLUMN created_audit_event_seq INTEGER
+        REFERENCES audit_events (seq)
+        ON UPDATE RESTRICT
+        ON DELETE RESTRICT;
+
+ALTER TABLE listener_events
+    ADD COLUMN audit_event_seq INTEGER
+        REFERENCES audit_events (seq)
+        ON UPDATE RESTRICT
+        ON DELETE RESTRICT;
+
+CREATE INDEX idx_tasks_created_audit_event
+    ON tasks (created_audit_event_seq)
+    WHERE created_audit_event_seq IS NOT NULL;
+
+CREATE INDEX idx_payload_builds_created_audit_event
+    ON payload_builds (created_audit_event_seq)
+    WHERE created_audit_event_seq IS NOT NULL;
+
+CREATE INDEX idx_listener_events_audit_event
+    ON listener_events (audit_event_seq)
+    WHERE audit_event_seq IS NOT NULL;
+
+INSERT INTO audit_events (
+    schema_version,
+    occurred_at,
+    actor_kind,
+    actor_id,
+    action,
+    route,
+    target_kind,
+    target_id,
+    outcome,
+    reason_code,
+    listener_id,
+    agent_id,
+    task_id
+)
+SELECT
+    1,
+    created_at,
+    'system',
+    'migration:0004',
+    'task.migrated',
+    'internal:migration',
+    'task',
+    task_id,
+    'succeeded',
+    'pre_audit_state',
+    listener_id,
+    agent_id,
+    task_id
+FROM tasks
+ORDER BY seq;
+
+UPDATE tasks
+SET created_audit_event_seq = (
+    SELECT event.seq
+    FROM audit_events AS event
+    WHERE event.action = 'task.migrated'
+      AND event.listener_id = tasks.listener_id
+      AND event.task_id = tasks.task_id
+    ORDER BY event.seq DESC
+    LIMIT 1
+);
+
+INSERT INTO audit_events (
+    schema_version,
+    occurred_at,
+    actor_kind,
+    actor_id,
+    action,
+    route,
+    target_kind,
+    target_id,
+    outcome,
+    reason_code,
+    listener_id,
+    payload_build_id
+)
+SELECT
+    1,
+    created_at,
+    'system',
+    'migration:0004',
+    'payload_build.migrated',
+    'internal:migration',
+    'payload_build',
+    id,
+    'succeeded',
+    'pre_audit_state',
+    listener_id,
+    id
+FROM payload_builds
+ORDER BY created_at, id;
+
+UPDATE payload_builds
+SET created_audit_event_seq = (
+    SELECT event.seq
+    FROM audit_events AS event
+    WHERE event.action = 'payload_build.migrated'
+      AND event.payload_build_id = payload_builds.id
+    ORDER BY event.seq DESC
+    LIMIT 1
+);
+
+INSERT INTO audit_events (
+    schema_version,
+    occurred_at,
+    actor_kind,
+    actor_id,
+    action,
+    route,
+    target_kind,
+    target_id,
+    outcome,
+    reason_code,
+    listener_id
+)
+SELECT
+    1,
+    occurred_at,
+    'system',
+    'migration:0004',
+    'listener_event.migrated',
+    'internal:migration',
+    'listener_event',
+    CAST(seq AS TEXT),
+    'succeeded',
+    'pre_audit_state',
+    listener_id
+FROM listener_events
+ORDER BY seq;
+
+UPDATE listener_events
+SET audit_event_seq = (
+    SELECT event.seq
+    FROM audit_events AS event
+    WHERE event.action = 'listener_event.migrated'
+      AND event.target_kind = 'listener_event'
+      AND event.target_id = CAST(listener_events.seq AS TEXT)
+    ORDER BY event.seq DESC
+    LIMIT 1
+);

--- a/server/internal/persistence/persistence_test.go
+++ b/server/internal/persistence/persistence_test.go
@@ -43,6 +43,7 @@ func TestOpenBootstrapsAndReopensFileDatabase(t *testing.T) {
 		"payload_bootstrap_credentials",
 		"agent_enrollment_sessions",
 		"payload_enrollment_allocations",
+		"audit_events",
 	}
 	for _, table := range requiredTables {
 		var count int
@@ -68,12 +69,12 @@ func TestOpenBootstrapsAndReopensFileDatabase(t *testing.T) {
 	if err := database.SQL().QueryRow(
 		`SELECT name, checksum_sha256
 		 FROM schema_migrations
-		 WHERE version = 3`,
+		 WHERE version = 4`,
 	).Scan(&migrationName, &checksum); err != nil {
 		t.Fatalf("read latest migration ledger entry: %v", err)
 	}
-	if migrationCount != 3 ||
-		migrationName != "0003_payload_enrollment_allocations.sql" ||
+	if migrationCount != 4 ||
+		migrationName != "0004_structured_audit_events.sql" ||
 		len(checksum) != 64 {
 		t.Fatalf(
 			"unexpected migration ledger: count=%d name=%q checksum=%q",
@@ -124,6 +125,206 @@ func TestOpenBootstrapsAndReopensFileDatabase(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		assertPermissions(t, filepath.Dir(databasePath), databaseDirectoryMode)
 		assertPermissions(t, databasePath, databaseFileMode)
+	}
+}
+
+func TestAuditMigrationBackfillsExistingDurableObjectsAndLinks(t *testing.T) {
+	migrations, err := loadMigrations(embeddedMigrations)
+	if err != nil {
+		t.Fatalf("load migrations: %v", err)
+	}
+	if len(migrations) < 4 {
+		t.Fatalf("loaded %d migrations, want at least 4", len(migrations))
+	}
+
+	databasePath := filepath.Join(t.TempDir(), "microc2.db")
+	legacy, err := open(databasePath, migrations[:3])
+	if err != nil {
+		t.Fatalf("open version-3 database: %v", err)
+	}
+	now := "2026-07-24T12:00:00Z"
+	if _, err := legacy.SQL().Exec(
+		`INSERT INTO listeners (
+			id, name, config_json, config_sha256, status, last_error,
+			created_at, updated_at, deleted_at
+		) VALUES (?, ?, ?, ?, ?, '', ?, ?, NULL)`,
+		"listener-one",
+		"listener",
+		[]byte(`{"id":"listener-one","name":"listener"}`),
+		strings.Repeat("a", 64),
+		"STOPPED",
+		now,
+		now,
+	); err != nil {
+		_ = legacy.Close()
+		t.Fatalf("insert version-3 listener: %v", err)
+	}
+	if _, err := legacy.SQL().Exec(
+		`INSERT INTO listener_events (
+			listener_id, event_type, status, message, occurred_at
+		) VALUES (?, ?, ?, '', ?)`,
+		"listener-one",
+		"created",
+		"STOPPED",
+		now,
+	); err != nil {
+		_ = legacy.Close()
+		t.Fatalf("insert version-3 listener event: %v", err)
+	}
+	if _, err := legacy.SQL().Exec(
+		`INSERT INTO tasks (
+			listener_id, task_id, agent_id, schema_version, task_type,
+			command, timeout_seconds, status, created_at, queued_at,
+			expires_at, legacy_origin
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"listener-one",
+		"task-one",
+		"agent-one",
+		1,
+		"shell",
+		"whoami",
+		30,
+		"queued",
+		now,
+		now,
+		"2026-07-24T12:05:00Z",
+		0,
+	); err != nil {
+		_ = legacy.Close()
+		t.Fatalf("insert version-3 task: %v", err)
+	}
+	if _, err := legacy.SQL().Exec(
+		`INSERT INTO payload_builds (
+			id, payload_id, listener_id, mutation_seed, filename,
+			relative_path, size, sha256, created_at, state,
+			state_detail, provenance_json
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?)`,
+		"payload-one",
+		"payload-one",
+		"listener-one",
+		"0000000000000001",
+		"agent.bin",
+		"release/payload-one/agent.bin",
+		7,
+		strings.Repeat("b", 64),
+		now,
+		"completed",
+		[]byte(`{}`),
+	); err != nil {
+		_ = legacy.Close()
+		t.Fatalf("insert version-3 payload: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatalf("close version-3 database: %v", err)
+	}
+
+	upgraded, err := Open(databasePath)
+	if err != nil {
+		t.Fatalf("upgrade database through audit migration: %v", err)
+	}
+	defer upgraded.Close()
+
+	for table, column := range map[string]string{
+		"tasks":           "created_audit_event_seq",
+		"payload_builds":  "created_audit_event_seq",
+		"listener_events": "audit_event_seq",
+	} {
+		if !tableHasColumn(t, upgraded.SQL(), table, column) {
+			t.Fatalf("table %s is missing audit-link column %s", table, column)
+		}
+	}
+
+	type expectedLink struct {
+		query      string
+		action     string
+		targetKind string
+		targetID   string
+	}
+	for name, expected := range map[string]expectedLink{
+		"task": {
+			query: `SELECT
+					event.action, event.target_kind, event.target_id,
+					event.actor_kind, event.actor_id, event.outcome,
+					event.reason_code
+				FROM tasks AS object
+				JOIN audit_events AS event
+				  ON event.seq = object.created_audit_event_seq
+				WHERE object.listener_id = 'listener-one'
+				  AND object.task_id = 'task-one'`,
+			action:     "task.migrated",
+			targetKind: "task",
+			targetID:   "task-one",
+		},
+		"payload": {
+			query: `SELECT
+					event.action, event.target_kind, event.target_id,
+					event.actor_kind, event.actor_id, event.outcome,
+					event.reason_code
+				FROM payload_builds AS object
+				JOIN audit_events AS event
+				  ON event.seq = object.created_audit_event_seq
+				WHERE object.id = 'payload-one'`,
+			action:     "payload_build.migrated",
+			targetKind: "payload_build",
+			targetID:   "payload-one",
+		},
+		"listener event": {
+			query: `SELECT
+					event.action, event.target_kind, event.target_id,
+					event.actor_kind, event.actor_id, event.outcome,
+					event.reason_code
+				FROM listener_events AS object
+				JOIN audit_events AS event
+				  ON event.seq = object.audit_event_seq
+				WHERE object.listener_id = 'listener-one'`,
+			action:     "listener_event.migrated",
+			targetKind: "listener_event",
+			targetID:   "1",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var action, targetKind, targetID string
+			var actorKind, actorID, outcome, reasonCode string
+			if err := upgraded.SQL().QueryRow(expected.query).Scan(
+				&action,
+				&targetKind,
+				&targetID,
+				&actorKind,
+				&actorID,
+				&outcome,
+				&reasonCode,
+			); err != nil {
+				t.Fatalf("read backfilled audit link: %v", err)
+			}
+			if action != expected.action ||
+				targetKind != expected.targetKind ||
+				targetID != expected.targetID ||
+				actorKind != "system" ||
+				actorID != "migration:0004" ||
+				outcome != "succeeded" ||
+				reasonCode != "pre_audit_state" {
+				t.Fatalf(
+					"backfilled event = (%q, %q, %q, %q, %q, %q, %q)",
+					action,
+					targetKind,
+					targetID,
+					actorKind,
+					actorID,
+					outcome,
+					reasonCode,
+				)
+			}
+		})
+	}
+
+	var auditCount int
+	if err := upgraded.SQL().QueryRow(
+		`SELECT COUNT(*) FROM audit_events`,
+	).Scan(&auditCount); err != nil {
+		t.Fatalf("count backfilled events: %v", err)
+	}
+	if auditCount != 3 {
+		t.Fatalf("backfilled audit event count = %d, want 3", auditCount)
 	}
 }
 
@@ -366,6 +567,47 @@ func newTestMigration(version int, name, statement string) migration {
 
 func sha256ForTest(value string) [32]byte {
 	return sha256.Sum256([]byte(value))
+}
+
+func tableHasColumn(
+	t *testing.T,
+	database *sql.DB,
+	table string,
+	column string,
+) bool {
+	t.Helper()
+	rows, err := database.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatalf("inspect table %s: %v", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			columnID     int
+			name         string
+			columnType   string
+			notNull      int
+			defaultValue sql.NullString
+			primaryKey   int
+		)
+		if err := rows.Scan(
+			&columnID,
+			&name,
+			&columnType,
+			&notNull,
+			&defaultValue,
+			&primaryKey,
+		); err != nil {
+			t.Fatalf("scan table %s metadata: %v", table, err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate table %s metadata: %v", table, err)
+	}
+	return false
 }
 
 func assertPermissions(t *testing.T, path string, want os.FileMode) {

--- a/server/internal/tasks/durable_store.go
+++ b/server/internal/tasks/durable_store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/persistence"
 
 	"github.com/google/uuid"
@@ -32,6 +33,7 @@ type LegacyResult struct {
 type DurableStore struct {
 	mu               sync.Mutex
 	db               *persistence.Database
+	audit            *audit.Store
 	listenerID       string
 	now              func() time.Time
 	dispatchLease    time.Duration
@@ -75,8 +77,13 @@ func newDurableStoreWithOptions(
 	if maxTasksPerAgent <= 0 {
 		maxTasksPerAgent = MaxTaskHistoryPerAgent
 	}
+	auditStore, err := audit.NewStore(db)
+	if err != nil {
+		return nil, fmt.Errorf("initialize durable task audit store: %w", err)
+	}
 	return &DurableStore{
 		db:               db,
+		audit:            auditStore,
 		listenerID:       listenerID,
 		now:              now,
 		dispatchLease:    dispatchLease,
@@ -85,12 +92,32 @@ func newDurableStoreWithOptions(
 }
 
 func (s *DurableStore) Create(agentID string, request CreateRequest) (Task, error) {
-	return s.create(agentID, request, false)
+	return s.CreateContext(context.Background(), agentID, request)
+}
+
+// CreateContext creates a task with the trusted operator actor attached by the
+// operator authentication boundary. Create remains for compatibility and
+// records an explicit unspecified operator actor.
+func (s *DurableStore) CreateContext(
+	ctx context.Context,
+	agentID string,
+	request CreateRequest,
+) (Task, error) {
+	return s.create(ctx, agentID, request, false)
 }
 
 func (s *DurableStore) CreateLegacyShell(agentID, command string) (Task, error) {
+	return s.CreateLegacyShellContext(context.Background(), agentID, command)
+}
+
+// CreateLegacyShellContext is the actor-aware form of the deprecated shell
+// task adapter.
+func (s *DurableStore) CreateLegacyShellContext(
+	ctx context.Context,
+	agentID, command string,
+) (Task, error) {
 	expiresIn := DefaultExpiresIn
-	return s.create(agentID, CreateRequest{
+	return s.create(ctx, agentID, CreateRequest{
 		SchemaVersion:    SchemaVersion,
 		Type:             TypeShell,
 		Arguments:        ShellArguments{Command: command},
@@ -100,6 +127,7 @@ func (s *DurableStore) CreateLegacyShell(agentID, command string) (Task, error) 
 }
 
 func (s *DurableStore) create(
+	ctx context.Context,
 	agentID string,
 	request CreateRequest,
 	legacyOrigin bool,
@@ -114,7 +142,9 @@ func (s *DurableStore) create(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ctx := context.Background()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	tx, err := s.db.SQL().BeginTx(ctx, nil)
 	if err != nil {
 		return Task{}, fmt.Errorf("begin durable task create: %w", err)
@@ -135,6 +165,19 @@ func (s *DurableStore) create(
 	}
 	expiresAt := now.Add(time.Duration(expiresIn) * time.Second)
 	taskID := uuid.NewString()
+	queuedEvent, err := s.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:      audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		Action:     "task.queued",
+		Route:      taskQueueAuditRoute(legacyOrigin),
+		Target:     audit.Target{Kind: "task", ID: taskID},
+		Outcome:    audit.OutcomeSucceeded,
+		ListenerID: s.listenerID,
+		AgentID:    agentID,
+		TaskID:     taskID,
+	})
+	if err != nil {
+		return Task{}, fmt.Errorf("record durable task queue audit event: %w", err)
+	}
 	// The statement is static and every request-derived value is bound through
 	// SQLite parameters.
 	// foxguard: ignore[go/taint-sql-injection]
@@ -142,8 +185,9 @@ func (s *DurableStore) create(
 		ctx,
 		`INSERT INTO tasks (
 			listener_id, task_id, agent_id, schema_version, task_type, command,
-			timeout_seconds, status, created_at, queued_at, expires_at, legacy_origin
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			timeout_seconds, status, created_at, queued_at, expires_at,
+			legacy_origin, created_audit_event_seq
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		s.listenerID,
 		taskID,
 		agentID,
@@ -156,6 +200,7 @@ func (s *DurableStore) create(
 		formatDurableTime(now),
 		formatDurableTime(expiresAt),
 		boolToSQLite(legacyOrigin),
+		queuedEvent.Sequence,
 	); err != nil {
 		return Task{}, fmt.Errorf("insert durable task: %w", err)
 	}
@@ -168,6 +213,58 @@ func (s *DurableStore) create(
 		return Task{}, fmt.Errorf("commit durable task create: %w", err)
 	}
 	return record.task, nil
+}
+
+func taskQueueAuditRoute(legacyOrigin bool) string {
+	if legacyOrigin {
+		return "/api/agents/{agent_id}/command"
+	}
+	return "/api/agents/{agent_id}/tasks"
+}
+
+func taskAgentAuditRoute(action string, legacyOrigin bool) string {
+	switch action {
+	case "task.dispatched", "task.redelivered":
+		if legacyOrigin {
+			return "/api/agent/{agent_id}/command"
+		}
+		return "/api/agent/{agent_id}/tasks"
+	case "task.running":
+		return "/api/agent/{agent_id}/tasks/{task_id}/status"
+	case "task.result_received":
+		if legacyOrigin {
+			return "/api/agent/{agent_id}/result"
+		}
+		return "/api/agent/{agent_id}/results"
+	default:
+		return "internal:task_store"
+	}
+}
+
+func (s *DurableStore) appendTaskAuditTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	actor audit.Actor,
+	action string,
+	route string,
+	record durableTaskRecord,
+) error {
+	causationSequence := record.createdAuditEventSeq
+	_, err := s.audit.AppendTx(ctx, tx, audit.Input{
+		Actor:             actor,
+		Action:            action,
+		Route:             route,
+		Target:            audit.Target{Kind: "task", ID: record.task.ID},
+		Outcome:           audit.OutcomeSucceeded,
+		CausationSequence: &causationSequence,
+		ListenerID:        s.listenerID,
+		AgentID:           record.task.AgentID,
+		TaskID:            record.task.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("record %s audit event: %w", action, err)
+	}
+	return nil
 }
 
 func (s *DurableStore) List(agentID string) ([]Task, error) {
@@ -380,6 +477,16 @@ func (s *DurableStore) dispatchNext(
 		if err != nil {
 			return Task{}, false, err
 		}
+		if err := s.appendTaskAuditTx(
+			ctx,
+			tx,
+			audit.Actor{Kind: audit.ActorAgent, ID: agentID},
+			"task.redelivered",
+			taskAgentAuditRoute("task.redelivered", record.legacyOrigin),
+			record,
+		); err != nil {
+			return Task{}, false, err
+		}
 		if err := tx.Commit(); err != nil {
 			return Task{}, false, fmt.Errorf("commit durable task redelivery: %w", err)
 		}
@@ -418,6 +525,16 @@ func (s *DurableStore) dispatchNext(
 	}
 	record, err = s.getTaskTx(ctx, tx, agentID, record.task.ID)
 	if err != nil {
+		return Task{}, false, err
+	}
+	if err := s.appendTaskAuditTx(
+		ctx,
+		tx,
+		audit.Actor{Kind: audit.ActorAgent, ID: agentID},
+		"task.dispatched",
+		taskAgentAuditRoute("task.dispatched", record.legacyOrigin),
+		record,
+	); err != nil {
 		return Task{}, false, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -501,6 +618,16 @@ func (s *DurableStore) MarkRunning(
 	}
 	record, err = s.getTaskTx(ctx, tx, agentID, taskID)
 	if err != nil {
+		return Task{}, err
+	}
+	if err := s.appendTaskAuditTx(
+		ctx,
+		tx,
+		audit.Actor{Kind: audit.ActorAgent, ID: agentID},
+		"task.running",
+		taskAgentAuditRoute("task.running", record.legacyOrigin),
+		record,
+	); err != nil {
 		return Task{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -621,6 +748,16 @@ func (s *DurableStore) CompleteWithInfo(
 			return Task{}, CompletionInfo{}, err
 		}
 	}
+	if err := s.appendTaskAuditTx(
+		ctx,
+		tx,
+		audit.Actor{Kind: audit.ActorAgent, ID: agentID},
+		"task.result_received",
+		taskAgentAuditRoute("task.result_received", record.legacyOrigin),
+		record,
+	); err != nil {
+		return Task{}, CompletionInfo{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return Task{}, CompletionInfo{}, fmt.Errorf("commit durable task completion: %w", err)
 	}
@@ -629,6 +766,15 @@ func (s *DurableStore) CompleteWithInfo(
 }
 
 func (s *DurableStore) Cancel(agentID, taskID string) (Task, error) {
+	return s.CancelContext(context.Background(), agentID, taskID)
+}
+
+// CancelContext cancels a task with the trusted operator actor attached by the
+// operator authentication boundary.
+func (s *DurableStore) CancelContext(
+	ctx context.Context,
+	agentID, taskID string,
+) (Task, error) {
 	if err := validateIDs(agentID, taskID); err != nil {
 		return Task{}, err
 	}
@@ -636,7 +782,9 @@ func (s *DurableStore) Cancel(agentID, taskID string) (Task, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ctx := context.Background()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	tx, err := s.db.SQL().BeginTx(ctx, nil)
 	if err != nil {
 		return Task{}, fmt.Errorf("begin durable task cancellation: %w", err)
@@ -675,6 +823,16 @@ func (s *DurableStore) Cancel(agentID, taskID string) (Task, error) {
 	}
 	record, err = s.getTaskTx(ctx, tx, agentID, taskID)
 	if err != nil {
+		return Task{}, err
+	}
+	if err := s.appendTaskAuditTx(
+		ctx,
+		tx,
+		audit.ActorOr(ctx, audit.DefaultOperatorActor()),
+		"task.cancelled",
+		"/api/agents/{agent_id}/tasks/{task_id}/cancel",
+		record,
+	); err != nil {
 		return Task{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -799,6 +957,16 @@ func (s *DurableStore) CompleteLegacy(
 
 	record, err = s.getTaskTx(ctx, tx, agentID, record.task.ID)
 	if err != nil {
+		return Task{}, false, err
+	}
+	if err := s.appendTaskAuditTx(
+		ctx,
+		tx,
+		audit.Actor{Kind: audit.ActorAgent, ID: agentID},
+		"task.result_received",
+		taskAgentAuditRoute("task.result_received", true),
+		record,
+	); err != nil {
 		return Task{}, false, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -926,11 +1094,12 @@ func (s *DurableStore) GetLegacyResultsPage(
 }
 
 type durableTaskRecord struct {
-	seq               int64
-	task              Task
-	lastDeliveryAt    *time.Time
-	acceptedRunningAt *time.Time
-	legacyOrigin      bool
+	seq                  int64
+	task                 Task
+	lastDeliveryAt       *time.Time
+	acceptedRunningAt    *time.Time
+	legacyOrigin         bool
+	createdAuditEventSeq int64
 }
 
 // durableTaskSummarySelect intentionally excludes r.stdout and r.stderr. Those
@@ -979,6 +1148,7 @@ const durableTaskSelect = `SELECT
 	t.server_completed_at,
 	t.expires_at,
 	t.legacy_origin,
+	t.created_audit_event_seq,
 	r.schema_version,
 	r.agent_id,
 	r.outcome,
@@ -1097,6 +1267,7 @@ func scanDurableTask(scanner durableRowScanner) (durableTaskRecord, error) {
 	var serverStartedAt, acceptedRunningAt sql.NullString
 	var serverCompletedAt, expiresAt sql.NullString
 	var legacyOrigin int
+	var createdAuditEventSeq sql.NullInt64
 	var resultSchema sql.NullInt64
 	var resultAgentID, resultOutcome sql.NullString
 	var resultStartedAt, resultCompletedAt sql.NullString
@@ -1121,6 +1292,7 @@ func scanDurableTask(scanner durableRowScanner) (durableTaskRecord, error) {
 		&serverCompletedAt,
 		&expiresAt,
 		&legacyOrigin,
+		&createdAuditEventSeq,
 		&resultSchema,
 		&resultAgentID,
 		&resultOutcome,
@@ -1138,6 +1310,12 @@ func scanDurableTask(scanner durableRowScanner) (durableTaskRecord, error) {
 	record.task.Type = Type(taskType)
 	record.task.Status = Status(status)
 	record.legacyOrigin = legacyOrigin != 0
+	if !createdAuditEventSeq.Valid || createdAuditEventSeq.Int64 <= 0 {
+		return durableTaskRecord{}, errors.New(
+			"durable task is missing its causal audit event",
+		)
+	}
+	record.createdAuditEventSeq = createdAuditEventSeq.Int64
 	if record.task.CreatedAt, err = parseDurableTime(createdAt); err != nil {
 		return durableTaskRecord{}, fmt.Errorf("parse task created_at: %w", err)
 	}

--- a/server/internal/tasks/durable_store_test.go
+++ b/server/internal/tasks/durable_store_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"microc2/server/internal/audit"
 	"microc2/server/internal/persistence"
 )
 
@@ -55,6 +56,286 @@ func TestDurableStoreRestartPreservesDispatchLease(t *testing.T) {
 			redelivered.DispatchedAt,
 			originalDispatchedAt,
 		)
+	}
+}
+
+func TestDurableStoreAuditLifecycleIsCausalAndIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "microc2.db")
+	now := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
+	db, store := openDurableTestStore(
+		t,
+		path,
+		"listener-one",
+		&now,
+		10*time.Second,
+		10,
+	)
+	defer closeDurableTestDatabase(t, db)
+
+	operator := audit.Actor{Kind: audit.ActorOperator, ID: "operator-test"}
+	operatorContext := audit.WithActor(context.Background(), operator)
+	secretCommand := "printf super-secret-command"
+	task, err := store.CreateContext(
+		operatorContext,
+		"agent-one",
+		validCreateRequest(secretCommand, 300),
+	)
+	if err != nil {
+		t.Fatalf("create audited task: %v", err)
+	}
+	var taskRootSequence int64
+	if err := db.SQL().QueryRow(
+		`SELECT created_audit_event_seq
+		 FROM tasks
+		 WHERE listener_id = ? AND task_id = ?`,
+		"listener-one",
+		task.ID,
+	).Scan(&taskRootSequence); err != nil {
+		t.Fatalf("read task causal audit sequence: %v", err)
+	}
+	if taskRootSequence <= 0 {
+		t.Fatalf("task has invalid causal audit sequence %d", taskRootSequence)
+	}
+	encodedTask, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("encode public task: %v", err)
+	}
+	if strings.Contains(string(encodedTask), "audit") {
+		t.Fatalf("public Task JSON exposed audit internals: %s", encodedTask)
+	}
+
+	if _, ok, err := store.DispatchNext("agent-one"); err != nil || !ok {
+		t.Fatalf("dispatch audited task: ok=%t err=%v", ok, err)
+	}
+	if _, ok, err := store.DispatchNext("agent-one"); err != nil || ok {
+		t.Fatalf("dispatch inside lease: ok=%t err=%v", ok, err)
+	}
+	now = now.Add(10 * time.Second)
+	if _, ok, err := store.DispatchNext("agent-one"); err != nil || !ok {
+		t.Fatalf("redeliver audited task: ok=%t err=%v", ok, err)
+	}
+
+	startedAt := now.Add(-time.Second)
+	runningUpdate := StatusUpdate{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Status:        StatusRunning,
+		Timestamp:     startedAt,
+	}
+	if _, err := store.MarkRunning("agent-one", task.ID, runningUpdate); err != nil {
+		t.Fatalf("mark audited task running: %v", err)
+	}
+	if _, err := store.MarkRunning("agent-one", task.ID, runningUpdate); err != nil {
+		t.Fatalf("replay audited running update: %v", err)
+	}
+
+	exitCode := 0
+	secretOutput := "super-secret-result"
+	result := Result{
+		SchemaVersion: SchemaVersion,
+		TaskID:        task.ID,
+		AgentID:       "agent-one",
+		Outcome:       OutcomeCompleted,
+		StartedAt:     startedAt,
+		CompletedAt:   now,
+		ExitCode:      &exitCode,
+		Output:        Output{Stdout: secretOutput},
+	}
+	if _, info, err := store.CompleteWithInfo("agent-one", result); err != nil || !info.Applied {
+		t.Fatalf("complete audited task: info=%#v err=%v", info, err)
+	}
+	if _, info, err := store.CompleteWithInfo("agent-one", result); err != nil || info.Applied {
+		t.Fatalf("replay audited completion: info=%#v err=%v", info, err)
+	}
+
+	cancelled, err := store.CreateContext(
+		operatorContext,
+		"agent-one",
+		validCreateRequest("another-secret-command", 300),
+	)
+	if err != nil {
+		t.Fatalf("create task for audited cancellation: %v", err)
+	}
+	var cancelledRootSequence int64
+	if err := db.SQL().QueryRow(
+		`SELECT created_audit_event_seq
+		 FROM tasks
+		 WHERE listener_id = ? AND task_id = ?`,
+		"listener-one",
+		cancelled.ID,
+	).Scan(&cancelledRootSequence); err != nil {
+		t.Fatalf("read cancelled task causal sequence: %v", err)
+	}
+	if _, err := store.CancelContext(
+		operatorContext,
+		"agent-one",
+		cancelled.ID,
+	); err != nil {
+		t.Fatalf("cancel audited task: %v", err)
+	}
+	if _, err := store.CancelContext(
+		operatorContext,
+		"agent-one",
+		cancelled.ID,
+	); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("repeated cancellation returned %v", err)
+	}
+
+	auditStore, err := audit.NewStore(db)
+	if err != nil {
+		t.Fatalf("open audit store: %v", err)
+	}
+	page, err := auditStore.Page(context.Background(), audit.PageOptions{
+		Limit:  50,
+		Offset: 0,
+	})
+	if err != nil {
+		t.Fatalf("page task audit events: %v", err)
+	}
+	if page.Total != 7 || len(page.Events) != 7 {
+		t.Fatalf("unexpected task audit event count: total=%d events=%#v", page.Total, page.Events)
+	}
+	events := make([]audit.Event, len(page.Events))
+	for index := range page.Events {
+		events[index] = page.Events[len(page.Events)-1-index]
+	}
+	expectedActions := []string{
+		"task.queued",
+		"task.dispatched",
+		"task.redelivered",
+		"task.running",
+		"task.result_received",
+		"task.queued",
+		"task.cancelled",
+	}
+	for index, expectedAction := range expectedActions {
+		event := events[index]
+		if event.Action != expectedAction ||
+			event.Target.Kind != "task" ||
+			event.ListenerID != "listener-one" ||
+			event.AgentID != "agent-one" {
+			t.Fatalf("unexpected audit event %d: %#v", index, event)
+		}
+		expectedTaskID := task.ID
+		expectedRoot := taskRootSequence
+		if index >= 5 {
+			expectedTaskID = cancelled.ID
+			expectedRoot = cancelledRootSequence
+		}
+		if event.TaskID != expectedTaskID || event.Target.ID != expectedTaskID {
+			t.Fatalf("audit event %d targeted the wrong task: %#v", index, event)
+		}
+		if expectedAction == "task.queued" {
+			if event.CausationSequence != nil || event.Actor != operator {
+				t.Fatalf("unexpected task root event %d: %#v", index, event)
+			}
+			if event.Sequence != expectedRoot {
+				t.Fatalf(
+					"task root event %d sequence=%d, linked row=%d",
+					index,
+					event.Sequence,
+					expectedRoot,
+				)
+			}
+			continue
+		}
+		if event.CausationSequence == nil ||
+			*event.CausationSequence != expectedRoot {
+			t.Fatalf("audit event %d lost causation: %#v", index, event)
+		}
+		expectedActor := audit.Actor{Kind: audit.ActorAgent, ID: "agent-one"}
+		if expectedAction == "task.cancelled" {
+			expectedActor = operator
+		}
+		if event.Actor != expectedActor {
+			t.Fatalf("audit event %d has actor %#v, want %#v", index, event.Actor, expectedActor)
+		}
+	}
+	encodedAudit, err := json.Marshal(page)
+	if err != nil {
+		t.Fatalf("encode task audit page: %v", err)
+	}
+	for _, secret := range []string{
+		secretCommand,
+		"another-secret-command",
+		secretOutput,
+	} {
+		if strings.Contains(string(encodedAudit), secret) {
+			t.Fatalf("task audit page retained secret %q: %s", secret, encodedAudit)
+		}
+	}
+}
+
+func TestDurableStoreAuditFailureRollsBackTaskMutation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "microc2.db")
+	now := time.Date(2026, 7, 24, 10, 0, 0, 0, time.UTC)
+	db, store := openDurableTestStore(
+		t,
+		path,
+		"listener-one",
+		&now,
+		time.Second,
+		10,
+	)
+	defer closeDurableTestDatabase(t, db)
+
+	if _, err := db.SQL().Exec(`
+		CREATE TRIGGER reject_task_queue_audit
+		BEFORE INSERT ON audit_events
+		WHEN NEW.action = 'task.queued'
+		BEGIN
+			SELECT RAISE(ABORT, 'injected task queue audit failure');
+		END
+	`); err != nil {
+		t.Fatalf("create task queue audit failure trigger: %v", err)
+	}
+	if _, err := store.Create(
+		"agent-one",
+		validCreateRequest("must-not-persist", 300),
+	); err == nil {
+		t.Fatal("task creation unexpectedly survived audit failure")
+	}
+	var taskCount int
+	if err := db.SQL().QueryRow(
+		`SELECT COUNT(*) FROM tasks WHERE listener_id = ?`,
+		"listener-one",
+	).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks after audit failure: %v", err)
+	}
+	if taskCount != 0 {
+		t.Fatalf("audit failure left %d queued tasks", taskCount)
+	}
+	if _, err := db.SQL().Exec(`DROP TRIGGER reject_task_queue_audit`); err != nil {
+		t.Fatalf("drop task queue audit failure trigger: %v", err)
+	}
+
+	task, err := store.Create(
+		"agent-one",
+		validCreateRequest("dispatch-must-roll-back", 300),
+	)
+	if err != nil {
+		t.Fatalf("create dispatch rollback fixture: %v", err)
+	}
+	if _, err := db.SQL().Exec(`
+		CREATE TRIGGER reject_task_dispatch_audit
+		BEFORE INSERT ON audit_events
+		WHEN NEW.action = 'task.dispatched'
+		BEGIN
+			SELECT RAISE(ABORT, 'injected task dispatch audit failure');
+		END
+	`); err != nil {
+		t.Fatalf("create task dispatch audit failure trigger: %v", err)
+	}
+	if _, ok, err := store.DispatchNext("agent-one"); err == nil || ok {
+		t.Fatalf("task dispatch survived audit failure: ok=%t err=%v", ok, err)
+	}
+	persisted, err := store.Get("agent-one", task.ID)
+	if err != nil {
+		t.Fatalf("get task after rolled-back dispatch: %v", err)
+	}
+	if persisted.Status != StatusQueued || persisted.DispatchedAt != nil {
+		t.Fatalf("audit failure left partial dispatch state: %#v", persisted)
 	}
 }
 
@@ -489,6 +770,43 @@ func TestDurableStoreLegacyCompletionAndPagingSurviveRestart(t *testing.T) {
 	}
 	if _, matched, err := store.CompleteLegacy("agent-one", "whoami", "operator\n"); err != nil || matched {
 		t.Fatalf("repeated legacy completion: matched=%t err=%v", matched, err)
+	}
+	auditStore, err := audit.NewStore(db)
+	if err != nil {
+		t.Fatalf("open legacy task audit store: %v", err)
+	}
+	auditPage, err := auditStore.Page(context.Background(), audit.PageOptions{
+		Limit:  10,
+		Offset: 0,
+	})
+	if err != nil {
+		t.Fatalf("page legacy task audit events: %v", err)
+	}
+	actionCounts := make(map[string]int)
+	for _, event := range auditPage.Events {
+		actionCounts[event.Action]++
+		if event.TaskID != task.ID ||
+			event.ListenerID != "listener-one" ||
+			event.AgentID != "agent-one" {
+			t.Fatalf("legacy task audit event lost scope: %#v", event)
+		}
+	}
+	for _, action := range []string{
+		"task.queued",
+		"task.dispatched",
+		"task.result_received",
+	} {
+		if actionCounts[action] != 1 {
+			t.Fatalf(
+				"legacy task audit action %q count=%d, events=%#v",
+				action,
+				actionCounts[action],
+				auditPage.Events,
+			)
+		}
+	}
+	if auditPage.Total != 3 {
+		t.Fatalf("legacy result retry duplicated audit history: %#v", auditPage)
 	}
 	page, total, _, err = store.GetLegacyResultsPage(
 		"agent-one",

--- a/server/internal/websocket/terminal_session.go
+++ b/server/internal/websocket/terminal_session.go
@@ -69,11 +69,32 @@ func NewTerminalHandler(checkOrigin func(*http.Request) bool) *TerminalHandler {
 //   - Terminal session started and commands processed until disconnection
 //   - Resources properly cleaned up when the connection is closed
 func (h *TerminalHandler) HandleConnection(w http.ResponseWriter, r *http.Request) {
+	h.HandleConnectionWithLifecycle(w, r, nil, nil)
+}
+
+// HandleConnectionWithLifecycle handles a terminal connection while allowing
+// the guarded operator layer to durably record the point at which the
+// WebSocket has actually opened and the point at which it closes. If onOpen
+// fails, the connection closes before any terminal command is read.
+func (h *TerminalHandler) HandleConnectionWithLifecycle(
+	w http.ResponseWriter,
+	r *http.Request,
+	onOpen func() error,
+	onClose func(),
+) {
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
 	}
 	defer conn.Close()
+	if onOpen != nil {
+		if err := onOpen(); err != nil {
+			return
+		}
+	}
+	if onClose != nil {
+		defer onClose()
+	}
 
 	session := &TerminalSession{
 		WorkingDir: os.Getenv("HOME"),


### PR DESCRIPTION
Closes #100

## Summary
- add immutable Audit Event v1 storage, migration/backfill, causal links, and a bounded newest-first operator API
- emit redacted events across listener and agent-session lifecycle, typed tasking, payload build/download/revocation, file-drop actions, and terminal access
- disable the server terminal by default and audit requests, denials, opens, and closes without commands or output
- harden audit-adjacent paths with atomic credential completion, staged symlink-safe uploads, a 32 MiB upload cap, truthful download outcomes, generic build diagnostics, and bounded audit offsets
- document retention, redaction, backup, and the next roadmap sequence

## Safety and scope
- targets dev only; this PR does not promote dev to main
- #108 tracks the pre-existing same-UID payload path containment race and is an explicit dev-to-main promotion gate
- independent security and migration/transaction reviews found no blocker for this dev-only integration

## Validation
- go test -count=1 ./...
- go test -race -count=1 ./internal/audit ./internal/enrollment ./internal/filestore ./internal/handlers/api ./internal/handlers/api/payload ./internal/handlers/ws ./internal/listeners ./internal/tasks
- go vet ./...
- native and Windows Go builds
- shell/JavaScript/JSON static gates; 11 web contract tests
- 8 schema examples, 6 lifecycle cases, 45 schema-negative cases, and 4 semantic-negative cases across 9 schemas
- cargo fmt --check; 75 Rust tests; cargo clippy/build; mutation determinism
- git diff --check