### PR TITLE
fix(server): anchor payload artifact access

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
+	github.com/google/safeopen v0.0.0-20260327150837-43626d6f4685
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	golang.org/x/net v0.39.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -2,6 +2,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/safeopen v0.0.0-20260327150837-43626d6f4685 h1:NcJjfIYRDHuboRtptwjtdQflVDKgXSqTIfwu9PpE9uo=
+github.com/google/safeopen v0.0.0-20260327150837-43626d6f4685/go.mod h1:D59KewtQCiD2Avi8N/v2zb/xTYaefwJl+ux2ejB58GQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/server/internal/handlers/api/payload/payload_dir_unix.go
+++ b/server/internal/handlers/api/payload/payload_dir_unix.go
@@ -1,0 +1,86 @@
+//go:build unix
+
+package payload
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func ensurePayloadClassDirectory(payloadRoot, class string) error {
+	if !validPayloadDirectorySegment(class) {
+		return errors.New("invalid payload class directory")
+	}
+	rootFD, err := unix.Open(
+		payloadRoot,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open payload root: %w", err)
+	}
+	defer unix.Close(rootFD)
+
+	if err := unix.Mkdirat(rootFD, class, 0700); err != nil &&
+		!errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("create payload class directory: %w", err)
+	}
+	classFD, err := openPayloadDirectoryAt(rootFD, class)
+	if err != nil {
+		return fmt.Errorf("open payload class directory: %w", err)
+	}
+	defer unix.Close(classFD)
+	if err := unix.Fchmod(classFD, 0700); err != nil {
+		return fmt.Errorf("restrict payload class directory: %w", err)
+	}
+	return nil
+}
+
+func createPayloadBuildDirectory(
+	payloadRoot string,
+	class string,
+	buildID string,
+) error {
+	if !validPayloadDirectorySegment(class) ||
+		!validPayloadDirectorySegment(buildID) {
+		return errors.New("invalid payload build directory")
+	}
+	rootFD, err := unix.Open(
+		payloadRoot,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open payload root: %w", err)
+	}
+	defer unix.Close(rootFD)
+	classFD, err := openPayloadDirectoryAt(rootFD, class)
+	if err != nil {
+		return fmt.Errorf("open payload class directory: %w", err)
+	}
+	defer unix.Close(classFD)
+
+	if err := unix.Mkdirat(classFD, buildID, 0700); err != nil {
+		return fmt.Errorf("create payload build directory: %w", err)
+	}
+	buildFD, err := openPayloadDirectoryAt(classFD, buildID)
+	if err != nil {
+		return fmt.Errorf("open payload build directory: %w", err)
+	}
+	defer unix.Close(buildFD)
+	if err := unix.Fchmod(buildFD, 0700); err != nil {
+		return fmt.Errorf("restrict payload build directory: %w", err)
+	}
+	return nil
+}
+
+func openPayloadDirectoryAt(parentFD int, name string) (int, error) {
+	return unix.Openat(
+		parentFD,
+		name,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+}

--- a/server/internal/handlers/api/payload/payload_dir_unix.go
+++ b/server/internal/handlers/api/payload/payload_dir_unix.go
@@ -5,9 +5,14 @@ package payload
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"golang.org/x/sys/unix"
 )
+
+func isPayloadNotExistError(err error) bool {
+	return errors.Is(err, os.ErrNotExist)
+}
 
 func ensurePayloadClassDirectory(payloadRoot, class string) error {
 	if !validPayloadDirectorySegment(class) {

--- a/server/internal/handlers/api/payload/payload_dir_windows.go
+++ b/server/internal/handlers/api/payload/payload_dir_windows.go
@@ -1,0 +1,131 @@
+//go:build windows
+
+package payload
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func ensurePayloadClassDirectory(payloadRoot, class string) error {
+	if !validPayloadDirectorySegment(class) {
+		return errors.New("invalid payload class directory")
+	}
+	root, err := openWindowsPayloadDirectory(
+		windows.InvalidHandle,
+		`\??\`+payloadRoot,
+		windows.FILE_OPEN,
+	)
+	if err != nil {
+		return fmt.Errorf("open payload root: %w", err)
+	}
+	defer windows.CloseHandle(root)
+	classHandle, err := openWindowsPayloadDirectory(
+		root,
+		class,
+		windows.FILE_OPEN_IF,
+	)
+	if err != nil {
+		return fmt.Errorf("ensure payload class directory: %w", err)
+	}
+	return windows.CloseHandle(classHandle)
+}
+
+func createPayloadBuildDirectory(
+	payloadRoot string,
+	class string,
+	buildID string,
+) error {
+	if !validPayloadDirectorySegment(class) ||
+		!validPayloadDirectorySegment(buildID) {
+		return errors.New("invalid payload build directory")
+	}
+	root, err := openWindowsPayloadDirectory(
+		windows.InvalidHandle,
+		`\??\`+payloadRoot,
+		windows.FILE_OPEN,
+	)
+	if err != nil {
+		return fmt.Errorf("open payload root: %w", err)
+	}
+	defer windows.CloseHandle(root)
+	classHandle, err := openWindowsPayloadDirectory(
+		root,
+		class,
+		windows.FILE_OPEN,
+	)
+	if err != nil {
+		return fmt.Errorf("open payload class directory: %w", err)
+	}
+	defer windows.CloseHandle(classHandle)
+	buildHandle, err := openWindowsPayloadDirectory(
+		classHandle,
+		buildID,
+		windows.FILE_CREATE,
+	)
+	if err != nil {
+		return fmt.Errorf("create payload build directory: %w", err)
+	}
+	return windows.CloseHandle(buildHandle)
+}
+
+func openWindowsPayloadDirectory(
+	parent windows.Handle,
+	name string,
+	disposition uint32,
+) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:     uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		ObjectName: objectName,
+	}
+	if parent != windows.InvalidHandle {
+		attributes.RootDirectory = parent
+	}
+	var (
+		handle         windows.Handle
+		allocationSize int64
+		status         windows.IO_STATUS_BLOCK
+	)
+	err = windows.NtCreateFile(
+		&handle,
+		windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE,
+		attributes,
+		&status,
+		&allocationSize,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ|
+			windows.FILE_SHARE_WRITE|
+			windows.FILE_SHARE_DELETE,
+		disposition,
+		windows.FILE_DIRECTORY_FILE|
+			windows.FILE_OPEN_REPARSE_POINT|
+			windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	var information windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(
+		handle,
+		&information,
+	); err != nil {
+		windows.CloseHandle(handle)
+		return windows.InvalidHandle, err
+	}
+	if information.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		windows.CloseHandle(handle)
+		return windows.InvalidHandle, errors.New(
+			"payload directory is a reparse point",
+		)
+	}
+	return handle, nil
+}

--- a/server/internal/handlers/api/payload/payload_dir_windows.go
+++ b/server/internal/handlers/api/payload/payload_dir_windows.go
@@ -5,10 +5,19 @@ package payload
 import (
 	"errors"
 	"fmt"
+	"os"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
+
+func isPayloadNotExistError(err error) bool {
+	return errors.Is(err, os.ErrNotExist) ||
+		errors.Is(err, windows.ERROR_FILE_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_PATH_NOT_FOUND) ||
+		errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) ||
+		errors.Is(err, windows.STATUS_OBJECT_PATH_NOT_FOUND)
+}
 
 func ensurePayloadClassDirectory(payloadRoot, class string) error {
 	if !validPayloadDirectorySegment(class) {

--- a/server/internal/handlers/api/payload/payload_handler.go
+++ b/server/internal/handlers/api/payload/payload_handler.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/safeopen"
 	"github.com/google/uuid"
 
 	"microc2/server/internal/audit"
@@ -209,16 +210,22 @@ func newPayloadHandler(
 	if err != nil {
 		return nil, fmt.Errorf("resolve payload directory: %w", err)
 	}
-	for _, dir := range []string{
-		absolutePayloadsDir,
-		filepath.Join(absolutePayloadsDir, "debug"),
-		filepath.Join(absolutePayloadsDir, "release"),
-	} {
-		if err := os.MkdirAll(dir, 0700); err != nil {
-			return nil, fmt.Errorf("create payload directory %s: %w", dir, err)
-		}
-		if err := os.Chmod(dir, 0700); err != nil {
-			return nil, fmt.Errorf("restrict payload directory %s: %w", dir, err)
+	if err := os.MkdirAll(absolutePayloadsDir, 0700); err != nil {
+		return nil, fmt.Errorf("create payload root: %w", err)
+	}
+	if err := os.Chmod(absolutePayloadsDir, 0700); err != nil {
+		return nil, fmt.Errorf("restrict payload root: %w", err)
+	}
+	for _, class := range []string{"debug", "release"} {
+		if err := ensurePayloadClassDirectory(
+			absolutePayloadsDir,
+			class,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"initialize %s payload directory: %w",
+				class,
+				err,
+			)
 		}
 	}
 	var enrollmentStore *enrollment.Store
@@ -304,16 +311,35 @@ func gitRevision(dir string) string {
 // writeProvenance records non-secret build context next to the artifact. The
 // high-entropy enrollment credential is intentionally not retained, so this
 // metadata does not promise byte-for-byte reproduction (issue #99).
-func writeProvenance(artifactDir string, provenance map[string]interface{}) error {
+func writeProvenance(
+	payloadRoot string,
+	artifactRelativePath string,
+	provenance map[string]interface{},
+) error {
 	data, err := json.MarshalIndent(provenance, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal provenance: %w", err)
 	}
-	path := filepath.Join(artifactDir, "provenance.json")
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	nativeArtifactPath, err := containedNativeRelativePath(artifactRelativePath)
+	if err != nil {
+		return fmt.Errorf("invalid artifact path for provenance: %w", err)
+	}
+	relativePath := filepath.Join(
+		filepath.Dir(nativeArtifactPath),
+		"provenance.json",
+	)
+	if err := createPayloadFileBeneath(
+		payloadRoot,
+		relativePath,
+		data,
+		0600,
+	); err != nil {
 		return fmt.Errorf("failed to write provenance: %w", err)
 	}
-	log.Printf("[INFO] Wrote build provenance to %s", path)
+	log.Printf(
+		"[INFO] Wrote build provenance to %s",
+		filepath.Join(payloadRoot, relativePath),
+	)
 	return nil
 }
 
@@ -508,8 +534,8 @@ func advertisedListenerEndpoint(
 }
 
 // runSerializedBuild protects the shared agent source tree and build-script
-// sidecars until the script has copied the artifact from its private Cargo
-// target into the build-specific output directory.
+// sidecars until the script has produced the artifact in private per-build
+// staging.
 func (h *PayloadHandler) runSerializedBuild(cmd *exec.Cmd) ([]byte, error) {
 	h.buildMutex.Lock()
 	defer h.buildMutex.Unlock()
@@ -1326,15 +1352,13 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 
 	// Create a directory for build artifacts
 	outputDir := filepath.Join(h.payloadsDir, buildType, payloadID)
-	if err := os.MkdirAll(outputDir, 0700); err != nil {
+	if err := createPayloadBuildDirectory(
+		h.payloadsDir,
+		buildType,
+		payloadID,
+	); err != nil {
 		log.Printf("[ERROR] Failed to create output directory %s: %v", outputDir, err)
 		return PayloadResult{}, fmt.Errorf("failed to create output directory: %w", err)
-	}
-	if err := os.Chmod(outputDir, 0700); err != nil {
-		return PayloadResult{}, fmt.Errorf(
-			"failed to restrict output directory: %w",
-			err,
-		)
 	}
 	log.Printf("[INFO] Created output directory: %s", outputDir)
 	payloadPath := filepath.Join(outputDir, payloadFileName)
@@ -1352,9 +1376,21 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		"target",
 	)
 	cargoTargetPath := filepath.Join(h.agentSourceDir, cargoTargetDir)
+	stagingOutputDir := filepath.Join(cargoBuildDir, "output")
+	stagingArtifactRelativePath := filepath.Join(
+		"output",
+		payloadFileName,
+	)
 
-	// Create agent config file
-	configPath := filepath.Join(outputDir, "config.json")
+	// Create the build config through a root-anchored handle. The build
+	// contract still receives the ordinary output directory path, but server
+	// writes never follow a swapped component outside the payload root.
+	configRelativePath := filepath.Join(
+		buildType,
+		payloadID,
+		"config.json",
+	)
+	configPath := filepath.Join(h.payloadsDir, configRelativePath)
 
 	allowInsecureIsolatedLab :=
 		protocol == "http" && h.allowInsecureIsolatedLab
@@ -1417,7 +1453,12 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		return PayloadResult{}, fmt.Errorf("failed to marshal agent config: %w", err)
 	}
 
-	if err := os.WriteFile(configPath, configJSON, 0644); err != nil {
+	if err := createPayloadFileBeneath(
+		h.payloadsDir,
+		configRelativePath,
+		configJSON,
+		0600,
+	); err != nil {
 		log.Printf("[ERROR] Failed to write agent config to %s: %v", configPath, err)
 		return PayloadResult{}, fmt.Errorf("failed to write agent config: %w", err)
 	}
@@ -1449,7 +1490,7 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	cmdArgs := []string{
 		buildScript,
 		"--target", buildTarget,
-		"--output", outputDir,
+		"--output", stagingOutputDir,
 		"--build-type", buildType,
 		"--format", config.Format,
 		"--payload-id", payloadID,
@@ -1487,7 +1528,7 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	// Add environment variables
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("TARGET=%s", buildTarget),
-		fmt.Sprintf("OUTPUT_DIR=%s", outputDir),
+		fmt.Sprintf("OUTPUT_DIR=%s", stagingOutputDir),
 		fmt.Sprintf("CARGO_TARGET_DIR=%s", cargoTargetDir),
 		fmt.Sprintf("BUILD_TYPE=%s", buildType),
 		fmt.Sprintf("PROTOCOL=%s", protocol),
@@ -1523,17 +1564,29 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	)
 
 	log.Printf("[INFO] Environment variables set: TARGET=%s, OUTPUT_DIR=%s, BUILD_TYPE=%s, SLEEP_INTERVAL=%d, SOCKS5_ENABLED=%t, SOCKS5_PORT=%d",
-		buildTarget, outputDir, buildType, config.Sleep, config.Socks5Enabled, config.Socks5Port)
+		buildTarget, stagingOutputDir, buildType, config.Sleep, config.Socks5Enabled, config.Socks5Port)
 
 	log.Printf("[INFO] Starting build process...")
 	if err := ensurePrivateCargoBuildDirectories(
 		cargoBuildRoot,
 		cargoBuildDir,
 		cargoTargetPath,
+		stagingOutputDir,
 	); err != nil {
 		return PayloadResult{}, err
 	}
 	_, err = h.runSerializedBuild(cmd)
+	var (
+		fileInfo     os.FileInfo
+		artifactHash string
+	)
+	if err == nil {
+		fileInfo, artifactHash, err = h.publishGeneratedArtifact(
+			cargoBuildDir,
+			stagingArtifactRelativePath,
+			plannedRelativePath,
+		)
+	}
 	if cleanupErr := removePrivateCargoBuildDirectory(
 		cargoBuildRoot,
 		cargoBuildDir,
@@ -1557,68 +1610,10 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	}
 	log.Printf("[INFO] Payload build command completed")
 
-	// Find the generated payload
-	log.Printf("[INFO] Checking for payload at: %s", payloadPath)
-
-	// Check if file exists
-	fileInfo, err := os.Stat(payloadPath)
-	if err != nil {
-		log.Printf("[ERROR] Payload not found at expected location %s: %v", payloadPath, err)
-		// Check alternative location (the one the build script uses)
-		alternativePayloadPath := filepath.Join(h.agentSourceDir, "static", "payloads", buildType, payloadID, payloadFileName)
-		log.Printf("[INFO] Checking alternative location: %s", alternativePayloadPath)
-
-		alternativeFileInfo, alternativeErr := os.Stat(alternativePayloadPath)
-		if alternativeErr == nil {
-			// Found it in the alternative location, update the path
-			log.Printf("[INFO] Found payload at alternative location: %s", alternativePayloadPath)
-			payloadPath = alternativePayloadPath
-			fileInfo = alternativeFileInfo
-		} else {
-			// Still not found, look in any subdirectory of the output directory
-			log.Printf("[INFO] Searching for payload in output directory and subdirectories...")
-			var foundPath string
-			var foundInfo os.FileInfo
-
-			// Walk through the output directory to find the payload file
-			err := filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-				if !info.IsDir() && (info.Name() == payloadFileName || strings.HasSuffix(info.Name(), payloadFileName)) {
-					foundPath = path
-					foundInfo = info
-					return filepath.SkipAll // Stop the walk
-				}
-				return nil
-			})
-
-			if err == nil && foundPath != "" {
-				log.Printf("[INFO] Found payload during directory search: %s", foundPath)
-				payloadPath = foundPath
-				fileInfo = foundInfo
-			} else {
-				// List directory contents to aid debugging
-				files, err := os.ReadDir(outputDir)
-				if err != nil {
-					log.Printf("[ERROR] Failed to read output directory: %v", err)
-				} else {
-					log.Printf("[INFO] Output directory %s contents:", outputDir)
-					for _, file := range files {
-						log.Printf("[INFO] - %s", file.Name())
-					}
-				}
-				return PayloadResult{}, fmt.Errorf("payload not found at expected location: %w", err)
-			}
-		}
-	}
-
-	if err := os.Chmod(payloadPath, 0700); err != nil {
-		return PayloadResult{}, fmt.Errorf(
-			"restrict generated payload artifact permissions: %w",
-			err,
-		)
-	}
+	// The build contract has one deterministic artifact path. Publishing,
+	// permission restriction, and hashing all used the same anchored handle;
+	// legacy fallback searches cannot preserve that guarantee.
+	log.Printf("[INFO] Published payload at: %s", payloadPath)
 	completedAt := time.Now().UTC()
 
 	// Persist non-secret provenance. Enrollment uses a fresh, deliberately
@@ -1634,22 +1629,17 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		"mutation_flags":               []string{"config-xor-key", "junk-code", "surface-strings"},
 		"enrollment_credential_source": "server-generated-ephemeral",
 	}
-	if err := writeProvenance(filepath.Dir(payloadPath), provenance); err != nil {
+	if err := writeProvenance(
+		h.payloadsDir,
+		plannedRelativePath,
+		provenance,
+	); err != nil {
 		log.Printf("[WARNING] Failed to write build provenance: %v", err)
 	}
 	provenanceJSON, err := json.Marshal(provenance)
 	if err != nil {
 		return PayloadResult{}, fmt.Errorf("marshal payload provenance: %w", err)
 	}
-	relativePath, err := h.relativeArtifactPath(payloadPath)
-	if err != nil {
-		return PayloadResult{}, err
-	}
-	artifactHash, err := hashArtifact(payloadPath)
-	if err != nil {
-		return PayloadResult{}, fmt.Errorf("hash payload artifact: %w", err)
-	}
-
 	// Create the result
 	result = PayloadResult{
 		ID:           payloadID,
@@ -1660,7 +1650,7 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		Path:         payloadPath,
 		Size:         fileInfo.Size(),
 		Created:      completedAt.Format(time.RFC3339Nano),
-		relativePath: relativePath,
+		relativePath: plannedRelativePath,
 		sha256:       artifactHash,
 		provenanceJSON: append(
 			json.RawMessage(nil),
@@ -2022,7 +2012,7 @@ func (h *PayloadHandler) lookupPayload(id string) (payloadBuildRecord, error) {
 			record.RelativePath = relativePath
 		}
 		if record.SHA256 == "" {
-			hash, err := hashArtifact(result.Path)
+			hash, err := h.hashPayloadArtifact(record.RelativePath)
 			if err != nil {
 				return payloadBuildRecord{}, err
 			}
@@ -2373,18 +2363,20 @@ func (h *PayloadHandler) openVerifiedPayload(
 	if !validPayloadFilename(record.Filename) {
 		return nil, payloadStateCorrupt, "payload filename is invalid", ""
 	}
-	artifactPath, err := h.resolveArtifactPath(record.RelativePath)
+	nativeRelativePath, err := containedNativeRelativePath(
+		record.RelativePath,
+	)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, payloadStateMissing, "artifact is missing", ""
-		}
 		return nil, payloadStateCorrupt, err.Error(), ""
 	}
-	if filepath.Base(artifactPath) != record.Filename {
+	if filepath.Base(nativeRelativePath) != record.Filename {
 		return nil, payloadStateCorrupt, "artifact filename does not match metadata", ""
 	}
 
-	file, err = openPayloadArtifact(artifactPath)
+	file, err = openPayloadArtifactBeneath(
+		h.payloadsDir,
+		nativeRelativePath,
+	)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, payloadStateMissing, "artifact is missing", ""
@@ -2448,50 +2440,22 @@ func (h *PayloadHandler) relativeArtifactPath(artifactPath string) (string, erro
 		return "", fmt.Errorf("resolve artifact path: %w", err)
 	}
 	relativePath, err := filepath.Rel(h.payloadsDir, absoluteArtifactPath)
-	if err != nil || !isContainedRelativePath(relativePath) {
+	if err != nil {
 		return "", errors.New("payload artifact is outside the configured payload root")
 	}
-	resolvedRoot, err := filepath.EvalSymlinks(h.payloadsDir)
-	if err != nil {
-		return "", fmt.Errorf("resolve payload root: %w", err)
-	}
-	resolvedArtifact, err := filepath.EvalSymlinks(absoluteArtifactPath)
-	if err != nil {
-		return "", fmt.Errorf("resolve payload artifact: %w", err)
-	}
-	resolvedRelative, err := filepath.Rel(resolvedRoot, resolvedArtifact)
-	if err != nil || !isContainedRelativePath(resolvedRelative) {
-		return "", errors.New("payload artifact resolves outside the configured payload root")
+	if _, err := containedNativeRelativePath(relativePath); err != nil {
+		return "", errors.New("payload artifact is outside the configured payload root")
 	}
 	return filepath.ToSlash(relativePath), nil
 }
 
-func (h *PayloadHandler) resolveArtifactPath(relativePath string) (string, error) {
-	if relativePath == "" || filepath.IsAbs(relativePath) {
-		return "", errors.New("artifact path is not a contained relative path")
-	}
+func containedNativeRelativePath(relativePath string) (string, error) {
 	nativeRelativePath := filepath.FromSlash(relativePath)
-	if !isContainedRelativePath(nativeRelativePath) {
+	if !isContainedRelativePath(nativeRelativePath) ||
+		filepath.Clean(nativeRelativePath) != nativeRelativePath {
 		return "", errors.New("artifact path is not a contained relative path")
 	}
-	artifactPath := filepath.Join(h.payloadsDir, nativeRelativePath)
-	lexicalRelative, err := filepath.Rel(h.payloadsDir, artifactPath)
-	if err != nil || !isContainedRelativePath(lexicalRelative) {
-		return "", errors.New("artifact path escapes the configured payload root")
-	}
-	resolvedRoot, err := filepath.EvalSymlinks(h.payloadsDir)
-	if err != nil {
-		return "", fmt.Errorf("resolve payload root: %w", err)
-	}
-	resolvedArtifact, err := filepath.EvalSymlinks(artifactPath)
-	if err != nil {
-		return "", err
-	}
-	resolvedRelative, err := filepath.Rel(resolvedRoot, resolvedArtifact)
-	if err != nil || !isContainedRelativePath(resolvedRelative) {
-		return "", errors.New("artifact path resolves outside the configured payload root")
-	}
-	return resolvedArtifact, nil
+	return nativeRelativePath, nil
 }
 
 func isContainedRelativePath(path string) bool {
@@ -2499,6 +2463,166 @@ func isContainedRelativePath(path string) bool {
 		return false
 	}
 	return !strings.HasPrefix(path, ".."+string(filepath.Separator))
+}
+
+func validPayloadDirectorySegment(segment string) bool {
+	return segment != "" &&
+		segment != "." &&
+		segment != ".." &&
+		!strings.ContainsAny(segment, "/\\:\x00")
+}
+
+func openPayloadArtifactBeneath(
+	payloadRoot string,
+	relativePath string,
+) (*os.File, error) {
+	nativeRelativePath, err := containedNativeRelativePath(relativePath)
+	if err != nil {
+		return nil, err
+	}
+	return safeopen.OpenBeneath(payloadRoot, nativeRelativePath)
+}
+
+func createPayloadFileBeneath(
+	payloadRoot string,
+	relativePath string,
+	data []byte,
+	mode os.FileMode,
+) (returnErr error) {
+	nativeRelativePath, err := containedNativeRelativePath(relativePath)
+	if err != nil {
+		return err
+	}
+	file, err := safeopen.OpenFileBeneath(
+		payloadRoot,
+		nativeRelativePath,
+		os.O_RDWR|os.O_CREATE|os.O_EXCL,
+		mode,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("payload path is not a regular file")
+	}
+	if err := file.Chmod(mode); err != nil {
+		return err
+	}
+	written, err := file.Write(data)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func (h *PayloadHandler) publishGeneratedArtifact(
+	stagingRoot string,
+	stagingRelativePath string,
+	destinationRelativePath string,
+) (info os.FileInfo, artifactHash string, returnErr error) {
+	source, err := openPayloadArtifactBeneath(
+		stagingRoot,
+		stagingRelativePath,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("open staged payload artifact: %w", err)
+	}
+	defer func() {
+		if closeErr := source.Close(); closeErr != nil && returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+	sourceInfo, err := source.Stat()
+	if err != nil {
+		return nil, "", fmt.Errorf("inspect staged payload artifact: %w", err)
+	}
+	if !sourceInfo.Mode().IsRegular() {
+		return nil, "", errors.New("staged payload artifact is not a regular file")
+	}
+
+	nativeDestination, err := containedNativeRelativePath(
+		destinationRelativePath,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	destination, err := safeopen.OpenFileBeneath(
+		h.payloadsDir,
+		nativeDestination,
+		os.O_RDWR|os.O_CREATE|os.O_EXCL,
+		0700,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("create published payload artifact: %w", err)
+	}
+	defer func() {
+		if closeErr := destination.Close(); closeErr != nil &&
+			returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+	if err := destination.Chmod(0700); err != nil {
+		return nil, "", fmt.Errorf(
+			"restrict published payload artifact permissions: %w",
+			err,
+		)
+	}
+	copied, err := io.Copy(destination, source)
+	if err != nil {
+		return nil, "", fmt.Errorf("publish payload artifact: %w", err)
+	}
+	if copied != sourceInfo.Size() {
+		return nil, "", errors.New(
+			"staged payload artifact changed during publishing",
+		)
+	}
+	artifactHash, err = hashOpenArtifact(destination)
+	if err != nil {
+		return nil, "", fmt.Errorf("hash published payload artifact: %w", err)
+	}
+	info, err = destination.Stat()
+	if err != nil {
+		return nil, "", fmt.Errorf(
+			"inspect published payload artifact: %w",
+			err,
+		)
+	}
+	if !info.Mode().IsRegular() || info.Size() != copied {
+		return nil, "", errors.New(
+			"published payload artifact changed during inspection",
+		)
+	}
+	return info, artifactHash, nil
+}
+
+func (h *PayloadHandler) hashPayloadArtifact(
+	relativePath string,
+) (artifactHash string, returnErr error) {
+	file, err := openPayloadArtifactBeneath(
+		h.payloadsDir,
+		relativePath,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && returnErr == nil {
+			returnErr = closeErr
+		}
+	}()
+	return hashOpenArtifact(file)
 }
 
 func validPayloadFilename(filename string) bool {
@@ -2523,15 +2647,6 @@ func validPayloadID(id string) bool {
 	return true
 }
 
-func hashArtifact(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	return hashOpenArtifact(file)
-}
-
 func hashOpenArtifact(file *os.File) (string, error) {
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return "", err
@@ -2544,10 +2659,6 @@ func hashOpenArtifact(file *os.File) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
-}
-
-func openPayloadArtifact(path string) (*os.File, error) {
-	return os.Open(filepath.Clean(path))
 }
 
 // RegisterRoutes registers all payload-related routes on the provided mux.

--- a/server/internal/handlers/api/payload/payload_handler.go
+++ b/server/internal/handlers/api/payload/payload_handler.go
@@ -2378,7 +2378,7 @@ func (h *PayloadHandler) openVerifiedPayload(
 		nativeRelativePath,
 	)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if isPayloadNotExistError(err) {
 			return nil, payloadStateMissing, "artifact is missing", ""
 		}
 		return nil, payloadStateCorrupt, "artifact cannot be opened", ""

--- a/server/internal/handlers/api/payload/payload_handler_test.go
+++ b/server/internal/handlers/api/payload/payload_handler_test.go
@@ -2923,11 +2923,18 @@ func TestGeneratePayloadDoesNotUseLegacyFallbackArtifact(t *testing.T) {
 	if legacyArtifactPath == "" {
 		t.Fatal("build hook did not create the legacy artifact")
 	}
+	contents, err := os.ReadFile(legacyArtifactPath)
+	if err != nil {
+		t.Fatalf("read legacy artifact: %v", err)
+	}
+	if string(contents) != "legacy fallback artifact" {
+		t.Fatalf("legacy artifact content changed to %q", contents)
+	}
 	info, err := os.Stat(legacyArtifactPath)
 	if err != nil {
 		t.Fatalf("stat legacy artifact: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Fatalf(
 			"legacy artifact mode changed to %o",
 			info.Mode().Perm(),

--- a/server/internal/handlers/api/payload/payload_handler_test.go
+++ b/server/internal/handlers/api/payload/payload_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -102,6 +103,17 @@ func TestGeneratePayloadGeneratesSeedAndWritesProvenance(t *testing.T) {
 	})
 
 	handler := NewPayloadHandlerForIsolatedLab(filepath.Join(tempDir, "static", "payloads"), agentDir)
+	var receivedSeeds []string
+	handler.runBuild = func(command *exec.Cmd) ([]byte, error) {
+		for _, entry := range command.Env {
+			name, value, found := strings.Cut(entry, "=")
+			if found && name == "MUTATION_SEED" {
+				receivedSeeds = append(receivedSeeds, value)
+				break
+			}
+		}
+		return command.CombinedOutput()
+	}
 	config := PayloadConfig{
 		ListenerID: "listener-one",
 		AgentType:  "debugAgent",
@@ -119,13 +131,12 @@ func TestGeneratePayloadGeneratesSeedAndWritesProvenance(t *testing.T) {
 		t.Fatalf("generated mutation seed %q does not match 16 lowercase hex chars", first.MutationSeed)
 	}
 
-	// The build script must receive the seed through its environment.
-	envSeed, err := os.ReadFile(filepath.Join(filepath.Dir(first.Path), "mutation_seed.env"))
-	if err != nil {
-		t.Fatalf("read recorded build env seed: %v", err)
-	}
-	if string(envSeed) != first.MutationSeed {
-		t.Fatalf("build script received MUTATION_SEED=%q, want %q", envSeed, first.MutationSeed)
+	if len(receivedSeeds) != 1 || receivedSeeds[0] != first.MutationSeed {
+		t.Fatalf(
+			"build script received MUTATION_SEED=%q, want %q",
+			receivedSeeds,
+			first.MutationSeed,
+		)
 	}
 
 	provenance := readJSONFile(t, filepath.Join(filepath.Dir(first.Path), "provenance.json"))
@@ -709,9 +720,9 @@ func TestConcurrentPayloadBuildsSerializeSharedAgentWorkspace(t *testing.T) {
 
 	var stateMutex sync.Mutex
 	invocations := 0
-	expectedByOutput := make(map[string]string)
+	expectedByPayloadID := make(map[string]string)
 	handler.runBuild = func(command *exec.Cmd) ([]byte, error) {
-		var credential, outputDir string
+		var credential, outputDir, payloadID string
 		for _, entry := range command.Env {
 			name, value, found := strings.Cut(entry, "=")
 			if found && name == "ENROLLMENT_CREDENTIAL" {
@@ -719,19 +730,21 @@ func TestConcurrentPayloadBuildsSerializeSharedAgentWorkspace(t *testing.T) {
 			}
 		}
 		for index := 0; index+1 < len(command.Args); index++ {
-			if command.Args[index] == "--output" {
+			switch command.Args[index] {
+			case "--output":
 				outputDir = command.Args[index+1]
-				break
+			case "--payload-id":
+				payloadID = command.Args[index+1]
 			}
 		}
-		if credential == "" || outputDir == "" {
+		if credential == "" || outputDir == "" || payloadID == "" {
 			return nil, errors.New("build hook is missing credential or output")
 		}
 
 		stateMutex.Lock()
 		invocations++
 		invocation := invocations
-		expectedByOutput[outputDir] = credential
+		expectedByPayloadID[payloadID] = credential
 		stateMutex.Unlock()
 
 		if err := os.WriteFile(
@@ -830,12 +843,11 @@ func TestConcurrentPayloadBuildsSerializeSharedAgentWorkspace(t *testing.T) {
 	}
 
 	for _, result := range results {
-		outputDir := filepath.Dir(result.Path)
 		stateMutex.Lock()
-		expectedCredential := expectedByOutput[outputDir]
+		expectedCredential := expectedByPayloadID[result.ID]
 		stateMutex.Unlock()
 		if expectedCredential == "" {
-			t.Fatalf("no credential recorded for build output %s", outputDir)
+			t.Fatalf("no credential recorded for build %s", result.ID)
 		}
 		artifact, err := os.ReadFile(result.Path)
 		if err != nil {
@@ -2489,6 +2501,440 @@ func TestBuildingPayloadBecomesInterruptedExactlyOnceOnRestart(t *testing.T) {
 	}
 }
 
+func TestPayloadArtifactOperationsRejectSymlinkEscapes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on Windows")
+	}
+
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T, payloadRoot, outsideDir string)
+	}{
+		{
+			name: "parent component",
+			setup: func(t *testing.T, payloadRoot, outsideDir string) {
+				t.Helper()
+				if err := os.Symlink(
+					outsideDir,
+					filepath.Join(payloadRoot, "release", "build"),
+				); err != nil {
+					t.Fatalf("create parent symlink: %v", err)
+				}
+			},
+		},
+		{
+			name: "final components",
+			setup: func(t *testing.T, payloadRoot, outsideDir string) {
+				t.Helper()
+				buildDir := filepath.Join(payloadRoot, "release", "build")
+				if err := os.Mkdir(buildDir, 0700); err != nil {
+					t.Fatalf("create payload build directory: %v", err)
+				}
+				for _, filename := range []string{"agent", "provenance.json"} {
+					if err := os.Symlink(
+						filepath.Join(outsideDir, filename),
+						filepath.Join(buildDir, filename),
+					); err != nil {
+						t.Fatalf("create %s symlink: %v", filename, err)
+					}
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			payloadRoot := filepath.Join(tempDir, "payload-root")
+			outsideDir := filepath.Join(tempDir, "outside")
+			stagingRoot := filepath.Join(tempDir, "staging")
+			if err := os.MkdirAll(
+				filepath.Join(payloadRoot, "release"),
+				0700,
+			); err != nil {
+				t.Fatalf("create payload root: %v", err)
+			}
+			if err := os.Mkdir(outsideDir, 0700); err != nil {
+				t.Fatalf("create outside directory: %v", err)
+			}
+			if err := os.MkdirAll(
+				filepath.Join(stagingRoot, "output"),
+				0700,
+			); err != nil {
+				t.Fatalf("create staging directory: %v", err)
+			}
+			if err := os.WriteFile(
+				filepath.Join(stagingRoot, "output", "agent"),
+				[]byte("trusted staged artifact"),
+				0600,
+			); err != nil {
+				t.Fatalf("write staged artifact: %v", err)
+			}
+
+			artifactSentinel := []byte("outside artifact sentinel")
+			provenanceSentinel := []byte("outside provenance sentinel")
+			artifactPath := filepath.Join(outsideDir, "agent")
+			provenancePath := filepath.Join(outsideDir, "provenance.json")
+			if err := os.WriteFile(artifactPath, artifactSentinel, 0644); err != nil {
+				t.Fatalf("write outside artifact sentinel: %v", err)
+			}
+			if err := os.WriteFile(
+				provenancePath,
+				provenanceSentinel,
+				0644,
+			); err != nil {
+				t.Fatalf("write outside provenance sentinel: %v", err)
+			}
+			originalInfo, err := os.Stat(artifactPath)
+			if err != nil {
+				t.Fatalf("stat outside artifact sentinel: %v", err)
+			}
+
+			test.setup(t, payloadRoot, outsideDir)
+			handler := &PayloadHandler{payloadsDir: payloadRoot}
+			relativeArtifact := filepath.ToSlash(
+				filepath.Join("release", "build", "agent"),
+			)
+			if _, _, err := handler.publishGeneratedArtifact(
+				stagingRoot,
+				filepath.Join("output", "agent"),
+				relativeArtifact,
+			); err == nil {
+				t.Fatal("symlinked artifact publication unexpectedly succeeded")
+			}
+			file, state, _, _ := handler.openVerifiedPayload(
+				payloadBuildRecord{
+					Filename:       "agent",
+					RelativePath:   relativeArtifact,
+					Size:           int64(len(artifactSentinel)),
+					ProvenanceJSON: []byte("{}"),
+				},
+			)
+			if file != nil {
+				_ = file.Close()
+				t.Fatal("symlinked artifact verification unexpectedly succeeded")
+			}
+			if state == payloadStateCompleted {
+				t.Fatal("symlinked artifact was marked completed")
+			}
+			if err := writeProvenance(
+				payloadRoot,
+				relativeArtifact,
+				map[string]interface{}{"source": "attacker-controlled"},
+			); err == nil {
+				t.Fatal("symlinked provenance write unexpectedly succeeded")
+			}
+
+			gotArtifact, err := os.ReadFile(artifactPath)
+			if err != nil {
+				t.Fatalf("read outside artifact sentinel: %v", err)
+			}
+			if !bytes.Equal(gotArtifact, artifactSentinel) {
+				t.Fatalf(
+					"outside artifact changed to %q",
+					gotArtifact,
+				)
+			}
+			gotProvenance, err := os.ReadFile(provenancePath)
+			if err != nil {
+				t.Fatalf("read outside provenance sentinel: %v", err)
+			}
+			if !bytes.Equal(gotProvenance, provenanceSentinel) {
+				t.Fatalf(
+					"outside provenance changed to %q",
+					gotProvenance,
+				)
+			}
+			infoAfter, err := os.Stat(artifactPath)
+			if err != nil {
+				t.Fatalf("restat outside artifact sentinel: %v", err)
+			}
+			if infoAfter.Mode().Perm() != originalInfo.Mode().Perm() {
+				t.Fatalf(
+					"outside artifact mode changed from %o to %o",
+					originalInfo.Mode().Perm(),
+					infoAfter.Mode().Perm(),
+				)
+			}
+		})
+	}
+}
+
+func TestPayloadDirectoryCreationRejectsSymlinkClass(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on Windows")
+	}
+
+	tempDir := t.TempDir()
+	payloadRoot := filepath.Join(tempDir, "payload-root")
+	outsideDir := filepath.Join(tempDir, "outside")
+	if err := os.Mkdir(payloadRoot, 0700); err != nil {
+		t.Fatalf("create payload root: %v", err)
+	}
+	if err := os.Mkdir(outsideDir, 0700); err != nil {
+		t.Fatalf("create outside directory: %v", err)
+	}
+	if err := os.Symlink(
+		outsideDir,
+		filepath.Join(payloadRoot, "release"),
+	); err != nil {
+		t.Fatalf("create payload class symlink: %v", err)
+	}
+
+	if err := createPayloadBuildDirectory(
+		payloadRoot,
+		"release",
+		"build",
+	); err == nil {
+		t.Fatal("created a build directory through a symlinked class")
+	}
+	if _, err := os.Stat(
+		filepath.Join(outsideDir, "build"),
+	); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside build directory was created: %v", err)
+	}
+}
+
+func TestPayloadArtifactParentSwapNeverEscapesRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on Windows")
+	}
+
+	tempDir := t.TempDir()
+	payloadRoot := filepath.Join(tempDir, "payload-root")
+	releaseDir := filepath.Join(payloadRoot, "release")
+	buildDir := filepath.Join(releaseDir, "build")
+	parkedBuildDir := filepath.Join(releaseDir, "build.real")
+	outsideDir := filepath.Join(tempDir, "outside")
+	stagingRoot := filepath.Join(tempDir, "staging")
+	if err := os.MkdirAll(buildDir, 0700); err != nil {
+		t.Fatalf("create payload build directory: %v", err)
+	}
+	if err := os.Mkdir(outsideDir, 0700); err != nil {
+		t.Fatalf("create outside directory: %v", err)
+	}
+	if err := os.MkdirAll(
+		filepath.Join(stagingRoot, "output"),
+		0700,
+	); err != nil {
+		t.Fatalf("create staging directory: %v", err)
+	}
+
+	trustedArtifact := []byte("trusted artifact")
+	outsideArtifact := []byte("outside artifact sentinel")
+	outsideProvenance := []byte("outside provenance sentinel")
+	if err := os.WriteFile(
+		filepath.Join(buildDir, "agent"),
+		trustedArtifact,
+		0600,
+	); err != nil {
+		t.Fatalf("write trusted artifact: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(outsideDir, "agent"),
+		outsideArtifact,
+		0644,
+	); err != nil {
+		t.Fatalf("write outside artifact sentinel: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(outsideDir, "provenance.json"),
+		outsideProvenance,
+		0644,
+	); err != nil {
+		t.Fatalf("write outside provenance sentinel: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(stagingRoot, "output", "agent"),
+		trustedArtifact,
+		0600,
+	); err != nil {
+		t.Fatalf("write staged artifact: %v", err)
+	}
+
+	stop := make(chan struct{})
+	swapResult := make(chan error, 1)
+	var stopOnce sync.Once
+	stopSwap := func() {
+		stopOnce.Do(func() {
+			close(stop)
+		})
+	}
+	t.Cleanup(stopSwap)
+	go func() {
+		for {
+			if err := os.Rename(buildDir, parkedBuildDir); err != nil {
+				swapResult <- fmt.Errorf("park build directory: %w", err)
+				return
+			}
+			if err := os.Symlink(outsideDir, buildDir); err != nil {
+				swapResult <- fmt.Errorf("install parent symlink: %w", err)
+				return
+			}
+			runtime.Gosched()
+			if err := os.Remove(buildDir); err != nil {
+				swapResult <- fmt.Errorf("remove parent symlink: %w", err)
+				return
+			}
+			if err := os.Rename(parkedBuildDir, buildDir); err != nil {
+				swapResult <- fmt.Errorf("restore build directory: %w", err)
+				return
+			}
+			runtime.Gosched()
+			select {
+			case <-stop:
+				swapResult <- nil
+				return
+			default:
+			}
+		}
+	}()
+
+	relativeArtifact := filepath.ToSlash(
+		filepath.Join("release", "build", "agent"),
+	)
+	handler := &PayloadHandler{payloadsDir: payloadRoot}
+	successfulOpens, successfulPublications := 0, 0
+	for iteration := range 500 {
+		file, err := openPayloadArtifactBeneath(
+			payloadRoot,
+			relativeArtifact,
+		)
+		if err == nil {
+			content, readErr := io.ReadAll(file)
+			closeErr := file.Close()
+			if readErr != nil {
+				t.Fatalf("read safely opened artifact: %v", readErr)
+			}
+			if closeErr != nil {
+				t.Fatalf("close safely opened artifact: %v", closeErr)
+			}
+			if !bytes.Equal(content, trustedArtifact) {
+				t.Fatalf("safely opened artifact contained %q", content)
+			}
+			successfulOpens++
+		}
+		if _, _, err := handler.publishGeneratedArtifact(
+			stagingRoot,
+			filepath.Join("output", "agent"),
+			filepath.ToSlash(filepath.Join(
+				"release",
+				"build",
+				fmt.Sprintf("published-%d", iteration),
+			)),
+		); err == nil {
+			successfulPublications++
+		}
+		_ = writeProvenance(
+			payloadRoot,
+			relativeArtifact,
+			map[string]interface{}{"source": "trusted"},
+		)
+	}
+	stopSwap()
+	if err := <-swapResult; err != nil {
+		t.Fatal(err)
+	}
+	if successfulOpens == 0 {
+		t.Fatal("swap test never opened the legitimate artifact")
+	}
+	if successfulPublications == 0 {
+		t.Fatal("swap test never published into the legitimate directory")
+	}
+
+	gotOutsideArtifact, err := os.ReadFile(
+		filepath.Join(outsideDir, "agent"),
+	)
+	if err != nil {
+		t.Fatalf("read outside artifact sentinel: %v", err)
+	}
+	if !bytes.Equal(gotOutsideArtifact, outsideArtifact) {
+		t.Fatalf("outside artifact changed to %q", gotOutsideArtifact)
+	}
+	gotOutsideProvenance, err := os.ReadFile(
+		filepath.Join(outsideDir, "provenance.json"),
+	)
+	if err != nil {
+		t.Fatalf("read outside provenance sentinel: %v", err)
+	}
+	if !bytes.Equal(gotOutsideProvenance, outsideProvenance) {
+		t.Fatalf("outside provenance changed to %q", gotOutsideProvenance)
+	}
+	outsideEntries, err := os.ReadDir(outsideDir)
+	if err != nil {
+		t.Fatalf("list outside directory: %v", err)
+	}
+	if len(outsideEntries) != 2 {
+		t.Fatalf("outside directory gained entries: %#v", outsideEntries)
+	}
+}
+
+func TestGeneratePayloadDoesNotUseLegacyFallbackArtifact(t *testing.T) {
+	tempDir := t.TempDir()
+	payloadRoot := filepath.Join(tempDir, "payload-root")
+	agentDir := filepath.Join(tempDir, "agent")
+	writePlaceholderBuildScript(t, agentDir)
+	handler, err := newPayloadHandler(
+		payloadRoot,
+		agentDir,
+		testListenerLookup(),
+		nil,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("create payload handler: %v", err)
+	}
+
+	var legacyArtifactPath string
+	handler.runBuild = func(command *exec.Cmd) ([]byte, error) {
+		var buildType, format, payloadID string
+		for index := 0; index+1 < len(command.Args); index++ {
+			switch command.Args[index] {
+			case "--build-type":
+				buildType = command.Args[index+1]
+			case "--format":
+				format = command.Args[index+1]
+			case "--payload-id":
+				payloadID = command.Args[index+1]
+			}
+		}
+		legacyArtifactPath = filepath.Join(
+			agentDir,
+			"static",
+			"payloads",
+			buildType,
+			payloadID,
+			payloadFilename(format),
+		)
+		if err := os.MkdirAll(
+			filepath.Dir(legacyArtifactPath),
+			0700,
+		); err != nil {
+			return nil, err
+		}
+		return nil, os.WriteFile(
+			legacyArtifactPath,
+			[]byte("legacy fallback artifact"),
+			0600,
+		)
+	}
+
+	if _, err := handler.GeneratePayload(testPayloadConfig()); err == nil {
+		t.Fatal("generation accepted an artifact outside the build contract")
+	}
+	if legacyArtifactPath == "" {
+		t.Fatal("build hook did not create the legacy artifact")
+	}
+	info, err := os.Stat(legacyArtifactPath)
+	if err != nil {
+		t.Fatalf("stat legacy artifact: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf(
+			"legacy artifact mode changed to %o",
+			info.Mode().Perm(),
+		)
+	}
+}
+
 func TestDownloadStreamsVerifiedHandleAcrossPathSwap(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("requires POSIX rename semantics for an open file")
@@ -2509,7 +2955,14 @@ func TestDownloadStreamsVerifiedHandleAcrossPathSwap(t *testing.T) {
 	if err := os.WriteFile(artifactPath, trustedContent, 0644); err != nil {
 		t.Fatalf("write trusted artifact: %v", err)
 	}
-	artifactHash, err := hashArtifact(artifactPath)
+	artifactFile, err := os.Open(artifactPath)
+	if err != nil {
+		t.Fatalf("open trusted artifact: %v", err)
+	}
+	artifactHash, err := hashOpenArtifact(artifactFile)
+	if closeErr := artifactFile.Close(); err == nil {
+		err = closeErr
+	}
 	if err != nil {
 		t.Fatalf("hash trusted artifact: %v", err)
 	}
@@ -2774,15 +3227,15 @@ func installSuccessfulBuildHook(
 	t *testing.T,
 	handler *PayloadHandler,
 	database *persistence.Database,
-	payloadsDir string,
+	_ string,
 ) {
 	t.Helper()
-	handler.runBuild = func(_ *exec.Cmd) ([]byte, error) {
-		var relativePath, state, artifactHash string
+	handler.runBuild = func(command *exec.Cmd) ([]byte, error) {
+		var relativePath, filename, state, artifactHash string
 		var size int64
 		var provenanceJSON []byte
 		if err := database.SQL().QueryRow(
-			`SELECT relative_path, state, size, sha256, provenance_json
+			`SELECT relative_path, filename, state, size, sha256, provenance_json
 			 FROM payload_builds
 			 WHERE state = ?
 			 ORDER BY created_at DESC
@@ -2790,6 +3243,7 @@ func installSuccessfulBuildHook(
 			payloadStateBuilding,
 		).Scan(
 			&relativePath,
+			&filename,
 			&state,
 			&size,
 			&artifactHash,
@@ -2809,14 +3263,21 @@ func installSuccessfulBuildHook(
 				provenanceJSON,
 			)
 		}
-		artifactPath := filepath.Join(
-			payloadsDir,
-			filepath.FromSlash(relativePath),
-		)
-		if err := os.MkdirAll(filepath.Dir(artifactPath), 0755); err != nil {
-			t.Fatalf("create hooked artifact directory: %v", err)
+		outputDir := ""
+		for index := 0; index+1 < len(command.Args); index++ {
+			if command.Args[index] == "--output" {
+				outputDir = command.Args[index+1]
+				break
+			}
 		}
-		if err := os.WriteFile(artifactPath, []byte("fake agent"), 0644); err != nil {
+		if outputDir == "" {
+			t.Fatal("build command omitted --output")
+		}
+		if err := os.WriteFile(
+			filepath.Join(outputDir, filename),
+			[]byte("fake agent"),
+			0644,
+		); err != nil {
 			t.Fatalf("write hooked payload artifact: %v", err)
 		}
 		return []byte("hook build complete"), nil


### PR DESCRIPTION
Closes #108.

## Summary
- build payloads in private per-build staging, then publish only through a root-anchored `O_EXCL` handle
- create payload class/build directories with no-follow Unix and Windows directory handles
- hash, chmod, validate, and stream the same safely opened artifact handle
- remove legacy fallback/search paths and anchor config/provenance writes

## Validation
- payload package tests pass
- repeated parent/final symlink swap tests pass
- focused race tests pass
- focused `go vet` passes
- Windows/amd64 package cross-compile passes

Target is `dev` only; this PR does not promote or modify `main`.