### PR TITLE
feat(payload): enforce build contract and manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,12 @@ This framework was built by someone running on way too much caffeine. If you enc
 
 ### Building Payloads
 - Use the Payload Generator in the web UI to generate agent binaries for your
-  target OS/architecture. Each production build receives a new secret
-  enrollment input; source revision and mutation seed reproduce mutation
-  choices, but do not recreate a byte-identical credential-bearing artifact.
+  target OS/architecture. The exact supported profiles, validation rules,
+  deterministic output path, manifest API, and download integrity headers are
+  documented in [Payload build contract](docs/payload-builds.md).
+- Each production build receives a new secret enrollment input; source
+  revision and mutation seed reproduce mutation choices, but do not recreate a
+  byte-identical credential-bearing artifact.
 
 ### File Drop
 - Upload and download files via the File Drop section in the web UI. Folder in codebase is /server/uploads/

--- a/agent/Cross.toml
+++ b/agent/Cross.toml
@@ -29,6 +29,7 @@ passthrough = [
     "C2_THRESH_MAX_MULT",
     "PROC_SCAN_INTERVAL_SECS",
     "MUTATION_SEED",
+    "EFFECTIVE_CONFIG_PATH",
 ]
 
 [target.x86_64-pc-windows-gnu]

--- a/agent/build.rs
+++ b/agent/build.rs
@@ -190,7 +190,7 @@ fn export_effective_config(config_content: &str) {
         .join(payload_id)
         .join("output")
         .join("effective-config.json");
-    if Path::new(&requested_destination) != destination {
+    if requested_destination.as_os_str() != destination.as_os_str() {
         panic!("EFFECTIVE_CONFIG_PATH must be the private per-build effective-config path");
     }
     config.remove("enrollment_credential");

--- a/agent/build.rs
+++ b/agent/build.rs
@@ -173,15 +173,26 @@ fn canonical_server_url(raw: &str, protocol: &str, host: &str, port: &str) -> St
 }
 
 fn export_effective_config(config_content: &str) {
-    let Some(destination) = env::var_os("EFFECTIVE_CONFIG_PATH") else {
+    let Some(requested_destination) = env::var_os("EFFECTIVE_CONFIG_PATH") else {
         return;
     };
-    let destination = PathBuf::from(destination);
     let mut config: serde_json::Value = serde_json::from_str(config_content)
         .unwrap_or_else(|err| panic!("failed to parse embedded config for export: {err}"));
     let config = config
         .as_object_mut()
         .unwrap_or_else(|| panic!("embedded config must be a JSON object"));
+    let payload_id = config
+        .get("payload_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("embedded config payload_id must be a string"));
+    validate_identifier("PAYLOAD_ID", payload_id);
+    let destination = Path::new(".microc2-build")
+        .join(payload_id)
+        .join("output")
+        .join("effective-config.json");
+    if Path::new(&requested_destination) != destination {
+        panic!("EFFECTIVE_CONFIG_PATH must be the private per-build effective-config path");
+    }
     config.remove("enrollment_credential");
     let sanitized = serde_json::to_vec(config)
         .unwrap_or_else(|err| panic!("failed to serialize effective config: {err}"));

--- a/agent/build.rs
+++ b/agent/build.rs
@@ -172,6 +172,27 @@ fn canonical_server_url(raw: &str, protocol: &str, host: &str, port: &str) -> St
     expected
 }
 
+fn export_effective_config(config_content: &str) {
+    let Some(destination) = env::var_os("EFFECTIVE_CONFIG_PATH") else {
+        return;
+    };
+    let destination = PathBuf::from(destination);
+    let mut config: serde_json::Value = serde_json::from_str(config_content)
+        .unwrap_or_else(|err| panic!("failed to parse embedded config for export: {err}"));
+    let config = config
+        .as_object_mut()
+        .unwrap_or_else(|| panic!("embedded config must be a JSON object"));
+    config.remove("enrollment_credential");
+    let sanitized = serde_json::to_vec(config)
+        .unwrap_or_else(|err| panic!("failed to serialize effective config: {err}"));
+    fs::write(&destination, sanitized)
+        .unwrap_or_else(|err| panic!("failed to write effective config to {destination:?}: {err}"));
+    log_build(&format!(
+        "Wrote credential-free effective config to {:?}",
+        destination
+    ));
+}
+
 // Generate OUT_DIR/mutation.rs: seed-derived decoy functions, random string
 // constants and a random-length padding blob. The agent references
 // mutation_entry() once via std::hint::black_box so LLVM keeps everything.
@@ -272,6 +293,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=MIN_BG_OPSEC_SECS");
     println!("cargo:rerun-if-env-changed=REDUCED_ACTIVITY_SLEEP_SECS");
     println!("cargo:rerun-if-env-changed=MUTATION_SEED");
+    println!("cargo:rerun-if-env-changed=EFFECTIVE_CONFIG_PATH");
 
     // Resolve the mutation seed; server-driven builds always set it, manual
     // builds fall back to a fixed dev seed so existing fixtures keep working.
@@ -475,6 +497,8 @@ fn main() {
         .replace("{}", &u64::MAX.to_string())
         .to_string()
     };
+
+    export_effective_config(&config_content);
 
     // Generate Rust code with the embedded config
     let out_dir: PathBuf = match env::var_os("OUT_DIR") {

--- a/agent/build.sh
+++ b/agent/build.sh
@@ -552,14 +552,14 @@ echo "  MIN_BG_OPSEC_SECS: $MIN_BG_OPSEC_SECS, REDUCED_ACTIVITY_SLEEP_SECS: $RED
 echo "Building for $TARGET (Format: $FORMAT) with flags: $BUILD_FLAGS $CARGO_FEATURES..."
 if [[ "$TARGET" == *windows* ]]; then
     if command -v cross &> /dev/null; then
-        cross build $BUILD_FLAGS $CARGO_FEATURES --target $TARGET
+        cross build --locked $BUILD_FLAGS $CARGO_FEATURES --target $TARGET
     else
         echo "Warning: 'cross' command not found. Attempting with 'cargo build'. Make sure Rust target '$TARGET' is installed."
         rustup target add $TARGET # Ensure target is installed
-        cargo build $BUILD_FLAGS $CARGO_FEATURES --target $TARGET
+        cargo build --locked $BUILD_FLAGS $CARGO_FEATURES --target $TARGET
     fi
 else # For Linux, macOS, etc.
-    cargo build $BUILD_FLAGS $CARGO_FEATURES --target $TARGET
+    cargo build --locked $BUILD_FLAGS $CARGO_FEATURES --target $TARGET
 fi
 
 BUILD_SUCCESS=$?

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,12 +253,11 @@ payload root with owner-only directory and artifact permissions.
 
 Listener, payload/build, and runtime agent IDs are distinct. A selected listener
 provides connection configuration, each build receives its own payload ID, and
-each execution enrolls with a runtime agent ID. Build provenance is present but
-still partial; issue #99 tracks supported-profile validation, canonical output
-paths, and the complete inspectable manifest. A source revision and mutation
-seed reproduce mutation choices, but cannot recreate the exact production
-artifact without its deliberately unrecorded random bootstrap secret. The build
-row begins in
+each execution enrolls with a runtime agent ID. Issue #99 now defines the
+supported profiles, canonical output path, and complete versioned manifest; see
+[Payload build contract](payload-builds.md). A source revision and mutation seed
+reproduce mutation choices, but cannot recreate the exact production artifact
+without its deliberately unrecorded random bootstrap secret. The build row begins in
 `building`, then transitions to `completed` or `failed`; startup turns a
 leftover build into `interrupted` without resuming it. Startup and download-time
 revalidation keep a completed indexed artifact in `completed`, `missing`, or
@@ -389,11 +388,12 @@ The main remaining gaps are tracked as issues:
   line; it does not imply a `dev` to `main` promotion.
 - #100: structured, durable audit events are complete on the `dev` integration
   line; operator-facing evidence export is still future work.
-- #108: replace payload artifact check-then-use paths with cross-platform
-  open-beneath handles before any `dev` to `main` promotion.
+- #108: cross-platform open-beneath payload artifact handling is complete on
+  the `dev` integration line; no `dev` to `main` promotion was performed.
 - #88: add file transfer and pivot controls as typed task families after #98.
-- #99: finish payload validation and manifests; current provenance is partial.
+- #99: the bounded payload validation and manifest contract is implemented.
 - #65: finish the agent configuration system and optional OPSEC feature gating.
 
-Until those are complete, MicroC2 should be treated as a controlled lab research
-prototype rather than a hardened multi-user operations platform.
+Until the remaining production-hardening work is complete, MicroC2 should be
+treated as a controlled lab research prototype rather than a hardened
+multi-user operations platform.

--- a/docs/design.md
+++ b/docs/design.md
@@ -229,12 +229,11 @@ Listener, payload/build, and runtime agent identities are now distinct:
 | Payload/build ID | Indexed build artifact, embedded config, and bootstrap allowance. |
 | Agent runtime ID | One live or historical runtime agent instance. |
 
-Several payload UI options remain aspirational: indirect syscalls, custom sleep
-techniques, DLL sideloading metadata, shellcode output, and an OPSEC checkbox
-are passed through parts of the UI/config/build path but are not a complete
-implemented payload feature set. Issue #99 is therefore only partially complete:
-seed provenance exists, while supported-profile validation, canonical outputs,
-and a complete inspectable build manifest remain.
+Issue #99 defines and implements the bounded payload-build contract. Linux x64
+ELF and Windows x64 EXE builds support debug and release modes; unsupported
+profiles and aspirational options fail validation before build side effects.
+Every successful build has one canonical output and a mandatory, versioned,
+inspectable manifest. See [Payload build contract](payload-builds.md).
 
 Reproducibility has an intentional security boundary. Mutation decisions are
 derived from the source revision and mutation seed, but every production build
@@ -346,8 +345,8 @@ paths.
 
 1. Extend the typed task registry with file transfer and pivot operations now
    that the v1 shell contract in #98 is stable (#88).
-2. Complete payload profile validation and full build manifests; current #99
-   provenance is partial P1 work.
+2. Preserve the implemented #99 payload-profile and manifest contract as new
+   formats or optional capabilities are researched.
 3. Add operator-facing evidence export and reporting on the structured audit
    foundation.
 

--- a/docs/payload-builds.md
+++ b/docs/payload-builds.md
@@ -1,0 +1,122 @@
+# Payload Build Contract
+
+MicroC2 payload generation accepts a deliberately small, explicit build
+matrix. Requests outside this matrix fail validation before listener lookup,
+credential generation, durable build creation, filesystem changes, or build
+script execution.
+
+## Supported Profiles
+
+| Target OS | Architecture | Format | Rust target triple | Artifact |
+| --- | --- | --- | --- | --- |
+| Linux | `x64` | `linux_elf` | `x86_64-unknown-linux-gnu` | `agent` |
+| Windows | `x64` | `windows_exe` | `x86_64-pc-windows-gnu` | `agent.exe` |
+
+Both profiles support these build types:
+
+| `agentType` request value | Build type |
+| --- | --- |
+| `agent` | `release` |
+| `debugAgent` | `debug` |
+
+The server returns a specific `400 Bad Request` validation error for an
+unsupported or inconsistent profile. In particular, `x86` and `arm64`
+architectures and Windows DLL, service, shellcode, Linux ARM, macOS dylib, and
+Linux shared-object formats are not supported by the payload API.
+
+The following options remain aspirational and are rejected when requested:
+
+- indirect syscalls;
+- custom sleep techniques (`standard` is the only supported technique);
+- DLL sideloading, sideload DLL names, and export names;
+- a standalone OPSEC enable profile (supported numeric settings remain
+  individually configurable); and
+- independently configured OPSEC exit thresholds.
+
+Other fields are validated before the build. This includes a positive sleep
+interval, a valid SOCKS5 host and port, bounded enrollment sessions,
+non-negative duration and counter values, finite non-negative factors, and
+OPSEC entry thresholds from 0 through 100. An omitted SOCKS5 host and port
+resolve to `127.0.0.1:9050`; an omitted sleep technique resolves to
+`standard`.
+
+## Deterministic Output
+
+Each accepted build publishes exactly one artifact beneath the configured
+payload root:
+
+```text
+<debug|release>/<payload-id>/<agent|agent.exe>
+```
+
+This path is stored and returned with forward slashes relative to the payload
+root. The build runs in private per-build staging and must produce the exact
+expected filename. The server does not walk output directories or fall back to
+alternate artifact locations.
+
+The artifact directory also contains the resolved, non-secret `config.json`
+and the mandatory `provenance.json` build manifest. A build cannot transition
+to `completed` if the artifact or manifest cannot be published.
+
+## Build Manifest
+
+`provenance.json` uses schema
+`microc2.payload-build-manifest.v1`. The same JSON document is stored in the
+durable payload-build record. It contains:
+
+- `schema_version`;
+- `payload_id` and `listener_id`;
+- `git_revision` and `source_state` (`clean`, `dirty`, or `unknown`);
+- `target_os`, `architecture`, `target_triple`, `format`, and `build_type`;
+- the exact embedded `effective_config` object after removal of the ephemeral
+  enrollment credential, and its `config_sha256`;
+- `artifact.path`, `artifact.filename`, `artifact.size`, and
+  `artifact.sha256`;
+- `created_at`;
+- `mutation_seed`, `seed_generated_by_server`, and `mutation_flags`; and
+- `enrollment_credential_source`.
+
+The artifact path is always root-relative. SHA-256 values are lowercase
+hexadecimal digests. The Rust build exports the sanitized effective
+configuration from the same JSON object it embeds, so SOCKS state, normalized
+numeric values, the mutation-selected user agent, and mutation endpoint
+segments cannot drift from the manifest. The server refuses a build if that
+export is missing, malformed, inconsistent with the build identity, or
+contains credential material. The manifest decoder verifies its schema,
+profile, relative path, effective-config digest, artifact digest shape, and
+creation timestamp before the API serves it.
+
+The successful generation response includes both an inline `manifest` and its
+root-relative `manifest_url`. A persisted manifest can be inspected later:
+
+```http
+GET /api/payload/{payload-id}/manifest
+```
+
+The endpoint accepts no query parameters, returns
+`Cache-Control: no-store`, and reports the durable state in
+`X-MicroC2-Payload-State`. It returns `404` for an unknown build, `409` while a
+build is incomplete, and `410` for invalid or inconsistent manifest metadata.
+
+An artifact download includes:
+
+```http
+X-MicroC2-Artifact-SHA256: <64 lowercase hexadecimal characters>
+Link: </api/payload/{payload-id}/manifest>; rel="describedby"; type="application/json"
+```
+
+The `Link` header is present only when the persisted manifest validates
+against the durable artifact metadata.
+
+## Reproducibility Boundary
+
+The manifest records the source revision and state, normalized build profile,
+effective non-secret configuration, and mutation seed. Those values explain
+and reproduce the non-secret build and mutation choices.
+
+They do not recreate a byte-identical production artifact. Every build embeds
+a fresh, high-entropy enrollment bootstrap credential. The raw credential is
+never written to `provenance.json`, `config.json`, API responses, or logs; only
+its hash is retained in enrollment state. The manifest records
+`enrollment_credential_source` as `server-generated-ephemeral` so this boundary
+is explicit rather than implying byte-for-byte reproducibility.

--- a/docs/research/r1-mutation-engine.md
+++ b/docs/research/r1-mutation-engine.md
@@ -58,27 +58,36 @@ The agent reports its own seed at startup (debug log) via
 
 ## Provenance
 
-Every server-driven build writes `provenance.json` next to the artifact:
+Every server-driven build writes `provenance.json` next to the artifact. This
+abridged excerpt shows the mutation fields and artifact linkage:
 
 ```json
 {
+  "schema_version": "microc2.payload-build-manifest.v1",
+  "payload_id": "<build-id>",
+  "listener_id": "<listener-id>",
   "mutation_seed": "0123456789abcdef",
   "seed_generated_by_server": true,
   "git_revision": "<commit>",
-  "target": "x86_64-unknown-linux-gnu",
-  "built_at": "<RFC3339>",
-  "config_sha256": "<sha256 of resolved agent config>",
-  "mutation_flags": ["config-xor-key", "junk-code", "surface-strings"]
+  "target_triple": "x86_64-unknown-linux-gnu",
+  "created_at": "<RFC3339>",
+  "artifact": {
+    "path": "release/<build-id>/agent",
+    "filename": "agent",
+    "sha256": "<artifact-sha256>"
+  }
 }
 ```
 
-The seed is also returned in the payload API result (`mutation_seed`) and
-shown in the payload UI log.
+The full schema, effective-config fields, supported profiles, and inspection
+endpoint are documented in the
+[payload build contract](../payload-builds.md). The seed is also returned in
+the payload API result (`mutation_seed`) and shown in the payload UI log.
 
-`config_sha256` records a digest of the resolved configuration; it does not
-contain enough material to reconstruct it. In particular, the raw enrollment
-credential is embedded in the payload but is never written to provenance or
-durable server metadata.
+`effective_config` records the exact embedded configuration after the raw
+enrollment credential is removed, and `config_sha256` protects that sanitized
+object. The raw enrollment credential is embedded in the payload but is never
+written to provenance or durable server metadata.
 
 ## Determinism and reproduction boundary
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -211,9 +211,9 @@ Exit criteria:
 
 Candidate issues:
 
-- #99 `[Payload] Validate build options and record build provenance` — partial,
-  P1. Seed provenance landed, but the supported build matrix, fail-fast option
-  validation, canonical artifact path, and complete inspectable manifest remain.
+- #99 `[Payload] Validate build options and record build provenance` —
+  implemented. The bounded build matrix, fail-fast validation, canonical
+  artifact path, and versioned inspectable manifest form one explicit contract.
 - #79 `[Agent] Reduce dependencies as much as possible`
 - #67 `[Agent] - Source-Level Mutation Engine (Phase 1)` — v0 landed: seeded
   mutation (`MUTATION_SEED`) covering the config XOR key, a junk-code module,
@@ -382,13 +382,14 @@ Recommended next sequence:
 
 1. Tackle #88 after #98, adding file transfer and pivot operations as explicit
    task types instead of new string commands.
-2. Continue the bounded #99 payload-quality track alongside the data path.
+2. Preserve the implemented #99 payload-build contract while future profiles
+   remain separate, explicitly scoped work.
 3. Build evidence export and reporting views on the completed structured audit
    foundation.
 
 The data path **#98 → #97 → #100** is complete on the `dev` integration line,
 and #104 closes the authenticated-enrollment boundary there. No `dev` to
 `main` promotion is part of this sequence, and completion does not imply that
-one is ready. Issue #108 is an explicit promotion gate for cross-platform
-payload-path containment. Issue #99 remains a bounded P1 payload-quality track
-that can proceed alongside it.
+one is ready. Issue #108's cross-platform payload-path containment work is also
+complete on `dev`. Issue #99's bounded payload-quality contract is implemented;
+additional profiles remain future work.

--- a/server/internal/handlers/api/payload/build_contract.go
+++ b/server/internal/handlers/api/payload/build_contract.go
@@ -1,0 +1,486 @@
+package payload
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"path"
+	"strings"
+	"time"
+)
+
+const payloadBuildManifestSchemaV1 = "microc2.payload-build-manifest.v1"
+
+type payloadProfileKey struct {
+	architecture string
+	format       string
+}
+
+type payloadBuildProfile struct {
+	targetOS     string
+	targetTriple string
+	filename     string
+}
+
+var supportedPayloadProfiles = map[payloadProfileKey]payloadBuildProfile{
+	{architecture: "x64", format: "linux_elf"}: {
+		targetOS:     "linux",
+		targetTriple: "x86_64-unknown-linux-gnu",
+		filename:     "agent",
+	},
+	{architecture: "x64", format: "windows_exe"}: {
+		targetOS:     "windows",
+		targetTriple: "x86_64-pc-windows-gnu",
+		filename:     "agent.exe",
+	},
+}
+
+type payloadBuildPlan struct {
+	config      PayloadConfig
+	profile     payloadBuildProfile
+	buildType   string
+	maxSessions int
+}
+
+type payloadConfigValidationError struct {
+	field  string
+	reason string
+}
+
+func (err *payloadConfigValidationError) Error() string {
+	return fmt.Sprintf("invalid payload configuration: %s %s", err.field, err.reason)
+}
+
+func invalidPayloadConfig(field, reason string) error {
+	return &payloadConfigValidationError{field: field, reason: reason}
+}
+
+func validateAndResolvePayloadConfig(
+	config PayloadConfig,
+) (payloadBuildPlan, error) {
+	if config.ListenerID == "" {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"listener",
+			"is required",
+		)
+	}
+	if config.ListenerID != strings.TrimSpace(config.ListenerID) {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"listener",
+			"must not contain surrounding whitespace",
+		)
+	}
+	if !validPayloadID(config.ListenerID) {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"listener",
+			"must satisfy the identifier contract",
+		)
+	}
+
+	buildType := ""
+	switch config.AgentType {
+	case "agent":
+		buildType = "release"
+	case "debugAgent":
+		buildType = "debug"
+	default:
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"agentType",
+			`must be "agent" or "debugAgent"`,
+		)
+	}
+
+	profile, supported := supportedPayloadProfiles[payloadProfileKey{
+		architecture: config.Architecture,
+		format:       config.Format,
+	}]
+	if !supported {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"architecture/format",
+			fmt.Sprintf(
+				"combination %q/%q is unsupported; supported combinations are x64/linux_elf and x64/windows_exe",
+				config.Architecture,
+				config.Format,
+			),
+		)
+	}
+	if config.Sleep < 1 {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"sleep",
+			"must be at least 1 second",
+		)
+	}
+	if config.MutationSeed != "" {
+		normalizedSeed, _, err := resolveMutationSeed(config.MutationSeed)
+		if err != nil {
+			return payloadBuildPlan{}, invalidPayloadConfig(
+				"mutation_seed",
+				"must be a hexadecimal u64",
+			)
+		}
+		config.MutationSeed = normalizedSeed
+	}
+	if config.IndirectSyscall {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"indirectSyscall",
+			"is not implemented",
+		)
+	}
+	switch config.SleepTechnique {
+	case "":
+		config.SleepTechnique = "standard"
+	case "standard":
+	default:
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"sleepTechnique",
+			`must be "standard"; custom sleep techniques are not implemented`,
+		)
+	}
+	if config.DllSideloading ||
+		config.SideloadDll != "" ||
+		config.ExportName != "" {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"dllSideloading",
+			"is not implemented",
+		)
+	}
+	if config.BaseThresholdExitFullOpsec != 0 ||
+		config.BaseThresholdExitReducedActivity != 0 {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"OPSEC exit thresholds",
+			"are not implemented",
+		)
+	}
+
+	if config.Socks5Host == "" {
+		config.Socks5Host = "127.0.0.1"
+	}
+	if config.Socks5Port == 0 {
+		config.Socks5Port = 9050
+	}
+	socks5Host, err := normalizeAdvertisedHost(config.Socks5Host)
+	if err != nil {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"socks5_host",
+			err.Error(),
+		)
+	}
+	config.Socks5Host = socks5Host
+	if config.Socks5Port < 1 || config.Socks5Port > 65535 {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"socks5_port",
+			"must be between 1 and 65535",
+		)
+	}
+
+	for _, setting := range []struct {
+		field string
+		value int
+	}{
+		{"proc_scan_interval_secs", config.ProcScanIntervalSecs},
+		{"min_duration_full_opsec_secs", config.MinDurationFullOpsecSecs},
+		{"min_duration_reduced_activity_secs", config.MinDurationReducedActivitySecs},
+		{"min_duration_background_opsec_secs", config.MinDurationBackgroundOpsecSecs},
+		{"reduced_activity_sleep_secs", config.ReducedActivitySleepSecs},
+		{"base_max_consecutive_c2_failures", config.BaseMaxConsecutiveC2Failures},
+		{"c2_threshold_adjust_interval_secs", config.C2ThresholdAdjustIntervalSecs},
+	} {
+		if setting.value < 0 {
+			return payloadBuildPlan{}, invalidPayloadConfig(
+				setting.field,
+				"must not be negative",
+			)
+		}
+	}
+	for _, setting := range []struct {
+		field string
+		value float64
+	}{
+		{"base_threshold_enter_full_opsec", config.BaseThresholdEnterFullOpsec},
+		{"base_threshold_enter_reduced_activity", config.BaseThresholdEnterReducedActivity},
+		{"c2_failure_threshold_increase_factor", config.C2FailureThresholdIncreaseFactor},
+		{"c2_failure_threshold_decrease_factor", config.C2FailureThresholdDecreaseFactor},
+		{"c2_dynamic_threshold_max_multiplier", config.C2DynamicThresholdMaxMultiplier},
+	} {
+		if math.IsNaN(setting.value) ||
+			math.IsInf(setting.value, 0) ||
+			setting.value < 0 {
+			return payloadBuildPlan{}, invalidPayloadConfig(
+				setting.field,
+				"must be a finite non-negative number",
+			)
+		}
+	}
+	for _, setting := range []struct {
+		field string
+		value float64
+	}{
+		{"base_threshold_enter_full_opsec", config.BaseThresholdEnterFullOpsec},
+		{"base_threshold_enter_reduced_activity", config.BaseThresholdEnterReducedActivity},
+	} {
+		if setting.value > 100 {
+			return payloadBuildPlan{}, invalidPayloadConfig(
+				setting.field,
+				"must not exceed 100",
+			)
+		}
+	}
+	if value := config.C2FailureThresholdIncreaseFactor; value != 0 && value < 1 {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"c2_failure_threshold_increase_factor",
+			"must be at least 1 when set",
+		)
+	}
+	if value := config.C2FailureThresholdDecreaseFactor; value > 1 {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"c2_failure_threshold_decrease_factor",
+			"must not exceed 1",
+		)
+	}
+	if value := config.C2DynamicThresholdMaxMultiplier; value != 0 && value < 1 {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"c2_dynamic_threshold_max_multiplier",
+			"must be at least 1 when set",
+		)
+	}
+
+	maxSessions, err := resolvedPayloadMaxSessions(config.MaxSessions)
+	if err != nil {
+		return payloadBuildPlan{}, invalidPayloadConfig(
+			"max_sessions",
+			strings.TrimPrefix(err.Error(), "max_sessions "),
+		)
+	}
+	return payloadBuildPlan{
+		config:      config,
+		profile:     profile,
+		buildType:   buildType,
+		maxSessions: maxSessions,
+	}, nil
+}
+
+func decodePayloadBuildManifest(
+	data []byte,
+) (PayloadBuildManifest, error) {
+	var manifest PayloadBuildManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return PayloadBuildManifest{}, fmt.Errorf("decode payload build manifest: %w", err)
+	}
+	if manifest.SchemaVersion != payloadBuildManifestSchemaV1 {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"unsupported payload build manifest schema %q",
+			manifest.SchemaVersion,
+		)
+	}
+	if manifest.PayloadID == "" || manifest.ListenerID == "" {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest identity is incomplete",
+		)
+	}
+	if manifest.GitRevision == "" ||
+		manifest.SourceState == "" ||
+		manifest.TargetOS == "" ||
+		manifest.Architecture == "" ||
+		manifest.TargetTriple == "" ||
+		manifest.Format == "" ||
+		manifest.BuildType == "" {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest profile is incomplete",
+		)
+	}
+	if manifest.SourceState != "clean" &&
+		manifest.SourceState != "dirty" &&
+		manifest.SourceState != "unknown" {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest source state is invalid",
+		)
+	}
+	if manifest.MutationSeed == "" {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest mutation seed is missing",
+		)
+	}
+	normalizedSeed, _, err := resolveMutationSeed(manifest.MutationSeed)
+	if err != nil || normalizedSeed != manifest.MutationSeed {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest mutation seed is invalid",
+		)
+	}
+	if len(manifest.MutationFlags) == 0 ||
+		manifest.EnrollmentCredentialSource != "server-generated-ephemeral" {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest mutation or enrollment provenance is incomplete",
+		)
+	}
+	canonicalEffectiveConfig, err := canonicalJSONObject(
+		manifest.EffectiveConfig,
+	)
+	if err != nil {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest effective config is invalid: %w",
+			err,
+		)
+	}
+	var effectiveConfig map[string]interface{}
+	if err := json.Unmarshal(
+		canonicalEffectiveConfig,
+		&effectiveConfig,
+	); err != nil || effectiveConfig == nil {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest effective config is not an object",
+		)
+	}
+	if _, containsCredential := effectiveConfig["enrollment_credential"]; containsCredential {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest effective config contains enrollment credential material",
+		)
+	}
+	if !validSHA256(manifest.ConfigSHA256) ||
+		!validSHA256(manifest.Artifact.SHA256) {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest digest is invalid",
+		)
+	}
+	if effectiveConfigHash := fmt.Sprintf(
+		"%x",
+		sha256.Sum256(canonicalEffectiveConfig),
+	); effectiveConfigHash != manifest.ConfigSHA256 {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest effective config digest does not match",
+		)
+	}
+	if manifest.Artifact.Filename == "" ||
+		manifest.Artifact.Size < 0 {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest artifact is incomplete",
+		)
+	}
+	if _, err := containedNativeRelativePath(manifest.Artifact.Path); err != nil {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest artifact path is invalid: %w",
+			err,
+		)
+	}
+	profile, supported := supportedPayloadProfiles[payloadProfileKey{
+		architecture: manifest.Architecture,
+		format:       manifest.Format,
+	}]
+	if !supported ||
+		profile.targetOS != manifest.TargetOS ||
+		profile.targetTriple != manifest.TargetTriple ||
+		profile.filename != manifest.Artifact.Filename ||
+		path.Base(manifest.Artifact.Path) != manifest.Artifact.Filename {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest profile is unsupported or inconsistent",
+		)
+	}
+	if manifest.BuildType != "debug" && manifest.BuildType != "release" {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest build type is invalid",
+		)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, manifest.CreatedAt); err != nil {
+		return PayloadBuildManifest{}, fmt.Errorf(
+			"payload build manifest creation time is invalid",
+		)
+	}
+	return manifest, nil
+}
+
+func readEffectiveBuildConfig(
+	buildRoot string,
+	relativePath string,
+	payloadID string,
+	listenerID string,
+	mutationSeed string,
+	enrollmentCredential string,
+) (json.RawMessage, error) {
+	file, err := openPayloadArtifactBeneath(buildRoot, relativePath)
+	if err != nil {
+		return nil, fmt.Errorf("open effective build config: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspect effective build config: %w", err)
+	}
+	if !info.Mode().IsRegular() ||
+		info.Size() < 1 ||
+		info.Size() > maxPayloadRequestBytes {
+		return nil, errors.New(
+			"effective build config must be a bounded regular file",
+		)
+	}
+	data, err := io.ReadAll(io.LimitReader(
+		file,
+		maxPayloadRequestBytes+1,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("read effective build config: %w", err)
+	}
+	if len(data) > maxPayloadRequestBytes {
+		return nil, errors.New("effective build config is too large")
+	}
+	if enrollmentCredential != "" &&
+		bytes.Contains(data, []byte(enrollmentCredential)) {
+		return nil, errors.New(
+			"effective build config contains enrollment credential material",
+		)
+	}
+	canonical, err := canonicalJSONObject(data)
+	if err != nil {
+		return nil, fmt.Errorf("validate effective build config: %w", err)
+	}
+	var config map[string]interface{}
+	if err := json.Unmarshal(canonical, &config); err != nil {
+		return nil, fmt.Errorf("decode effective build config: %w", err)
+	}
+	if _, containsCredential := config["enrollment_credential"]; containsCredential {
+		return nil, errors.New(
+			"effective build config contains enrollment credential material",
+		)
+	}
+	if config["payload_id"] != payloadID ||
+		config["listener_id"] != listenerID ||
+		config["mutation_seed"] != mutationSeed {
+		return nil, errors.New(
+			"effective build config identity does not match the build",
+		)
+	}
+	protocol, ok := config["protocol"].(string)
+	if !ok || (protocol != "http" && protocol != "https") {
+		return nil, errors.New(
+			"effective build config protocol is invalid",
+		)
+	}
+	return canonical, nil
+}
+
+func canonicalJSONObject(data []byte) (json.RawMessage, error) {
+	var object map[string]interface{}
+	if err := json.Unmarshal(data, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, errors.New("JSON value is not an object")
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, data); err != nil {
+		return nil, err
+	}
+	return append(json.RawMessage(nil), compact.Bytes()...), nil
+}
+
+func validSHA256(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/server/internal/handlers/api/payload/build_contract_test.go
+++ b/server/internal/handlers/api/payload/build_contract_test.go
@@ -1,0 +1,335 @@
+package payload
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateAndResolvePayloadConfigSupportedProfiles(t *testing.T) {
+	testCases := []struct {
+		name       string
+		agentType  string
+		format     string
+		wantTarget string
+		wantOS     string
+		wantFile   string
+		wantBuild  string
+	}{
+		{
+			name:       "Linux release ELF",
+			agentType:  "agent",
+			format:     "linux_elf",
+			wantTarget: "x86_64-unknown-linux-gnu",
+			wantOS:     "linux",
+			wantFile:   "agent",
+			wantBuild:  "release",
+		},
+		{
+			name:       "Windows debug executable",
+			agentType:  "debugAgent",
+			format:     "windows_exe",
+			wantTarget: "x86_64-pc-windows-gnu",
+			wantOS:     "windows",
+			wantFile:   "agent.exe",
+			wantBuild:  "debug",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := validPayloadBuildConfig()
+			config.AgentType = testCase.agentType
+			config.Format = testCase.format
+			plan, err := validateAndResolvePayloadConfig(config)
+			if err != nil {
+				t.Fatalf("resolve supported profile: %v", err)
+			}
+			if plan.profile.targetTriple != testCase.wantTarget ||
+				plan.profile.targetOS != testCase.wantOS ||
+				plan.profile.filename != testCase.wantFile ||
+				plan.buildType != testCase.wantBuild {
+				t.Fatalf("resolved profile = %#v, want target=%q os=%q file=%q build=%q",
+					plan,
+					testCase.wantTarget,
+					testCase.wantOS,
+					testCase.wantFile,
+					testCase.wantBuild,
+				)
+			}
+			if plan.config.Socks5Host != "127.0.0.1" ||
+				plan.config.Socks5Port != 9050 ||
+				plan.config.SleepTechnique != "standard" {
+				t.Fatalf("resolved defaults are incomplete: %#v", plan.config)
+			}
+		})
+	}
+}
+
+func TestValidateAndResolvePayloadConfigRejectsUnsupportedOptions(
+	t *testing.T,
+) {
+	testCases := []struct {
+		name   string
+		field  string
+		mutate func(*PayloadConfig)
+	}{
+		{
+			name:  "unknown agent type",
+			field: "agentType",
+			mutate: func(config *PayloadConfig) {
+				config.AgentType = "stealth"
+			},
+		},
+		{
+			name:  "x86 architecture",
+			field: "architecture/format",
+			mutate: func(config *PayloadConfig) {
+				config.Architecture = "x86"
+			},
+		},
+		{
+			name:  "ARM64 architecture",
+			field: "architecture/format",
+			mutate: func(config *PayloadConfig) {
+				config.Architecture = "arm64"
+			},
+		},
+		{
+			name:  "DLL format",
+			field: "architecture/format",
+			mutate: func(config *PayloadConfig) {
+				config.Format = "windows_dll"
+			},
+		},
+		{
+			name:  "service format",
+			field: "architecture/format",
+			mutate: func(config *PayloadConfig) {
+				config.Format = "windows_service"
+			},
+		},
+		{
+			name:  "shellcode format",
+			field: "architecture/format",
+			mutate: func(config *PayloadConfig) {
+				config.Format = "windows_shellcode"
+			},
+		},
+		{
+			name:  "indirect syscalls",
+			field: "indirectSyscall",
+			mutate: func(config *PayloadConfig) {
+				config.IndirectSyscall = true
+			},
+		},
+		{
+			name:  "custom sleep",
+			field: "sleepTechnique",
+			mutate: func(config *PayloadConfig) {
+				config.SleepTechnique = "modified"
+			},
+		},
+		{
+			name:  "DLL sideloading",
+			field: "dllSideloading",
+			mutate: func(config *PayloadConfig) {
+				config.DllSideloading = true
+			},
+		},
+		{
+			name:  "ignored exit threshold",
+			field: "OPSEC exit thresholds",
+			mutate: func(config *PayloadConfig) {
+				config.BaseThresholdExitFullOpsec = 30
+			},
+		},
+		{
+			name:  "zero sleep",
+			field: "sleep",
+			mutate: func(config *PayloadConfig) {
+				config.Sleep = 0
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := validPayloadBuildConfig()
+			testCase.mutate(&config)
+			_, err := validateAndResolvePayloadConfig(config)
+			var validationError *payloadConfigValidationError
+			if !errors.As(err, &validationError) {
+				t.Fatalf("validation error = %v, want typed validation error", err)
+			}
+			if validationError.field != testCase.field {
+				t.Fatalf(
+					"validation field = %q, want %q",
+					validationError.field,
+					testCase.field,
+				)
+			}
+		})
+	}
+}
+
+func TestPayloadGenerateRejectsUnsupportedProfileBeforeBuild(t *testing.T) {
+	handler := NewPayloadHandlerForIsolatedLab(t.TempDir(), t.TempDir())
+	buildCalls := 0
+	handler.runBuild = func(*exec.Cmd) ([]byte, error) {
+		buildCalls++
+		return nil, nil
+	}
+	config := validPayloadBuildConfig()
+	config.Format = "windows_shellcode"
+	body, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshal payload config: %v", err)
+	}
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/api/payload/generate",
+		bytes.NewReader(body),
+	)
+	response := httptest.NewRecorder()
+	handler.HandleGeneratePayload(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf(
+			"unsupported profile status = %d, want 400: %s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	if !strings.Contains(response.Body.String(), "architecture/format") {
+		t.Fatalf("validation response is not actionable: %q", response.Body.String())
+	}
+	if buildCalls != 0 {
+		t.Fatalf("invalid profile invoked build %d times", buildCalls)
+	}
+}
+
+func TestManifestUsesExactCredentialFreeConfigExportedByBuild(t *testing.T) {
+	tempDir := t.TempDir()
+	agentDir := filepath.Join(tempDir, "agent")
+	writePlaceholderBuildScript(t, agentDir)
+	handler, err := newPayloadHandler(
+		filepath.Join(tempDir, "payloads"),
+		agentDir,
+		testListenerLookup(),
+		nil,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("create payload handler: %v", err)
+	}
+	handler.runBuild = func(command *exec.Cmd) ([]byte, error) {
+		values := make(map[string]string)
+		for _, entry := range command.Env {
+			name, value, found := strings.Cut(entry, "=")
+			if found {
+				values[name] = value
+			}
+		}
+		outputDir := ""
+		for index := 0; index+1 < len(command.Args); index++ {
+			if command.Args[index] == "--output" {
+				outputDir = command.Args[index+1]
+				break
+			}
+		}
+		if outputDir == "" {
+			return nil, errors.New("build command omitted --output")
+		}
+		if err := os.WriteFile(
+			filepath.Join(outputDir, "agent"),
+			[]byte("fake agent"),
+			0o600,
+		); err != nil {
+			return nil, err
+		}
+		effectivePath := values["EFFECTIVE_CONFIG_PATH"]
+		if !filepath.IsAbs(effectivePath) {
+			effectivePath = filepath.Join(command.Dir, effectivePath)
+		}
+		effective := map[string]interface{}{
+			"server_url":                           values["SERVER_URL"],
+			"payload_id":                           values["PAYLOAD_ID"],
+			"agent_id":                             "",
+			"listener_id":                          values["LISTENER_ID"],
+			"mutation_seed":                        values["MUTATION_SEED"],
+			"protocol":                             values["PROTOCOL"],
+			"socks5_enabled":                       true,
+			"user_agent":                           "seed-selected-user-agent",
+			"mutation_endpoint_segments":           []string{"first-segment", "second-segment"},
+			"allow_invalid_certs":                  false,
+			"allow_insecure_isolated_lab":          true,
+			"c2_failure_threshold_increase_factor": 1.23,
+		}
+		data, err := json.Marshal(effective)
+		if err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(effectivePath, data, 0o600); err != nil {
+			return nil, err
+		}
+		return []byte("hook build complete"), nil
+	}
+
+	config := testPayloadConfig()
+	config.Socks5Enabled = true
+	config.C2FailureThresholdIncreaseFactor = 1.234
+	result, err := handler.GeneratePayload(config)
+	if err != nil {
+		t.Fatalf("generate payload: %v", err)
+	}
+	if result.Manifest == nil {
+		t.Fatal("generation result omitted its build manifest")
+	}
+	var effective map[string]interface{}
+	if err := json.Unmarshal(result.Manifest.EffectiveConfig, &effective); err != nil {
+		t.Fatalf("decode effective config: %v", err)
+	}
+	if effective["protocol"] != "http" ||
+		effective["socks5_enabled"] != true ||
+		effective["user_agent"] != "seed-selected-user-agent" ||
+		effective["c2_failure_threshold_increase_factor"] != 1.23 {
+		t.Fatalf("manifest did not preserve exact build export: %#v", effective)
+	}
+	publishedConfig, err := os.ReadFile(
+		filepath.Join(filepath.Dir(result.Path), "config.json"),
+	)
+	if err != nil {
+		t.Fatalf("read published effective config: %v", err)
+	}
+	if !bytes.Equal(publishedConfig, result.Manifest.EffectiveConfig) {
+		t.Fatalf(
+			"published config differs from manifest: %s != %s",
+			publishedConfig,
+			result.Manifest.EffectiveConfig,
+		)
+	}
+	sidecar, err := os.ReadFile(
+		filepath.Join(filepath.Dir(result.Path), "provenance.json"),
+	)
+	if err != nil {
+		t.Fatalf("read manifest sidecar: %v", err)
+	}
+	if _, err := decodePayloadBuildManifest(sidecar); err != nil {
+		t.Fatalf("manifest sidecar failed its decoder: %v", err)
+	}
+}
+
+func validPayloadBuildConfig() PayloadConfig {
+	return PayloadConfig{
+		ListenerID:   "listener-one",
+		AgentType:    "debugAgent",
+		Architecture: "x64",
+		Format:       "linux_elf",
+		Sleep:        5,
+	}
+}

--- a/server/internal/handlers/api/payload/payload_handler.go
+++ b/server/internal/handlers/api/payload/payload_handler.go
@@ -48,6 +48,7 @@ const (
 	maxPayloadRequestBytes       = 64 << 10
 	maxPayloadRevokeBodyBytes    = 1
 	privateCargoBuildRoot        = ".microc2-build"
+	effectiveConfigFilename      = "effective-config.json"
 )
 
 type payloadBuildRecord struct {
@@ -305,7 +306,34 @@ func gitRevision(dir string) string {
 	if err != nil {
 		return "unknown"
 	}
-	return strings.TrimSpace(string(out))
+	revision := strings.TrimSpace(string(out))
+	if revision == "" {
+		return "unknown"
+	}
+	return revision
+}
+
+func gitSourceState(dir string) (revision string, state string) {
+	revision = gitRevision(dir)
+	if revision == "unknown" {
+		return revision, "unknown"
+	}
+	out, err := exec.Command(
+		"git",
+		"-C",
+		dir,
+		"status",
+		"--porcelain",
+		"--",
+		".",
+	).Output()
+	if err != nil {
+		return revision, "unknown"
+	}
+	if len(strings.TrimSpace(string(out))) > 0 {
+		return revision, "dirty"
+	}
+	return revision, "clean"
 }
 
 // writeProvenance records non-secret build context next to the artifact. The
@@ -314,15 +342,18 @@ func gitRevision(dir string) string {
 func writeProvenance(
 	payloadRoot string,
 	artifactRelativePath string,
-	provenance map[string]interface{},
+	manifest interface{},
 ) error {
-	data, err := json.MarshalIndent(provenance, "", "  ")
+	// Keep the sidecar byte-for-byte equivalent to the durable JSON form.
+	// Pretty-printing an outer object rewrites whitespace inside RawMessage
+	// fields and would invalidate the effective-config digest.
+	data, err := json.Marshal(manifest)
 	if err != nil {
-		return fmt.Errorf("failed to marshal provenance: %w", err)
+		return fmt.Errorf("failed to marshal payload build manifest: %w", err)
 	}
 	nativeArtifactPath, err := containedNativeRelativePath(artifactRelativePath)
 	if err != nil {
-		return fmt.Errorf("invalid artifact path for provenance: %w", err)
+		return fmt.Errorf("invalid artifact path for build manifest: %w", err)
 	}
 	relativePath := filepath.Join(
 		filepath.Dir(nativeArtifactPath),
@@ -334,10 +365,10 @@ func writeProvenance(
 		data,
 		0600,
 	); err != nil {
-		return fmt.Errorf("failed to write provenance: %w", err)
+		return fmt.Errorf("failed to write payload build manifest: %w", err)
 	}
 	log.Printf(
-		"[INFO] Wrote build provenance to %s",
+		"[INFO] Wrote payload build manifest to %s",
 		filepath.Join(payloadRoot, relativePath),
 	)
 	return nil
@@ -378,20 +409,14 @@ func (h *PayloadHandler) HandleGeneratePayload(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Enforce listener selection
-	if config.ListenerID == "" {
-		http.Error(w, "Listener selection is required. You must select a listener for agent communication.", http.StatusBadRequest)
-		log.Printf("[ERROR] Payload generation aborted: no listener selected.")
-		return
-	}
-	if _, err := resolvedPayloadMaxSessions(config.MaxSessions); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	// Generate payload
 	result, err := h.GeneratePayloadWithContext(r.Context(), config)
 	if err != nil {
+		var validationError *payloadConfigValidationError
+		if errors.As(err, &validationError) {
+			http.Error(w, validationError.Error(), http.StatusBadRequest)
+			return
+		}
 		log.Print("[ERROR] Payload generation failed")
 		http.Error(w, "Payload generation failed", http.StatusInternalServerError)
 		return
@@ -639,6 +664,122 @@ func parsePayloadEnrollmentRevokePath(
 		return "", true, false
 	}
 	return payloadID, true, true
+}
+
+func payloadManifestURL(payloadID string) string {
+	return "/api/payload/" + payloadID + "/manifest"
+}
+
+func parsePayloadManifestPath(
+	path string,
+) (payloadID string, matched bool, valid bool) {
+	const (
+		prefix = "/api/payload/"
+		suffix = "/manifest"
+	)
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", false, false
+	}
+	payloadID = strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	if strings.Contains(payloadID, "/") || !validPayloadID(payloadID) {
+		return payloadID, true, false
+	}
+	return payloadID, true, true
+}
+
+func payloadManifestMatchesRecord(
+	manifest PayloadBuildManifest,
+	record payloadBuildRecord,
+) error {
+	switch {
+	case manifest.PayloadID != record.ID ||
+		manifest.PayloadID != record.PayloadID ||
+		manifest.ListenerID != record.ListenerID:
+		return errors.New("payload build manifest identity does not match metadata")
+	case manifest.MutationSeed != record.MutationSeed:
+		return errors.New("payload build manifest mutation seed does not match metadata")
+	case manifest.Artifact.Path != record.RelativePath:
+		return errors.New("payload build manifest path does not match metadata")
+	case manifest.Artifact.Filename != record.Filename:
+		return errors.New("payload build manifest filename does not match metadata")
+	case manifest.Artifact.Size != record.Size:
+		return errors.New("payload build manifest size does not match metadata")
+	case manifest.Artifact.SHA256 != record.SHA256:
+		return errors.New("payload build manifest digest does not match metadata")
+	case manifest.CreatedAt != record.CreatedAt:
+		return errors.New("payload build manifest creation time does not match metadata")
+	}
+	return nil
+}
+
+// HandlePayloadResource dispatches payload subresources registered beneath
+// /api/payload/. More specific download routes remain registered separately.
+func (h *PayloadHandler) HandlePayloadResource(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	if _, matched, _ := parsePayloadManifestPath(r.URL.Path); matched {
+		h.HandlePayloadManifest(w, r)
+		return
+	}
+	h.HandleRevokePayloadEnrollment(w, r)
+}
+
+// HandlePayloadManifest exposes the persisted, non-secret build manifest.
+func (h *PayloadHandler) HandlePayloadManifest(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	w.Header().Set("Cache-Control", "no-store")
+	payloadID, matched, valid := parsePayloadManifestPath(r.URL.Path)
+	if !matched {
+		http.NotFound(w, r)
+		return
+	}
+	if !valid {
+		http.Error(w, "Invalid payload manifest path", http.StatusBadRequest)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if r.URL.RawQuery != "" {
+		http.Error(
+			w,
+			"Payload manifest does not accept query parameters",
+			http.StatusBadRequest,
+		)
+		return
+	}
+	if h.initErr != nil {
+		http.Error(w, "Payload handler is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	record, err := h.lookupPayload(payloadID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "Payload manifest not found", http.StatusNotFound)
+			return
+		}
+		log.Print("[ERROR] Failed to load payload manifest metadata")
+		http.Error(w, "Payload manifest is unavailable", http.StatusInternalServerError)
+		return
+	}
+	if record.State == payloadStateBuilding {
+		http.Error(w, "Payload manifest is not complete", http.StatusConflict)
+		return
+	}
+	manifest, err := decodePayloadBuildManifest(record.ProvenanceJSON)
+	if err != nil || payloadManifestMatchesRecord(manifest, record) != nil {
+		http.Error(w, "Payload manifest is corrupt", http.StatusGone)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(record.ProvenanceJSON)))
+	w.Header().Set("X-MicroC2-Payload-State", record.State)
+	_, _ = w.Write(record.ProvenanceJSON)
 }
 
 func (h *PayloadHandler) writePayloadEnrollmentRejection(
@@ -1080,6 +1221,18 @@ func (h *PayloadHandler) HandleDownloadPayload(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Content-Disposition", disposition)
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", strconv.FormatInt(record.Size, 10))
+	w.Header().Set("X-MicroC2-Artifact-SHA256", record.SHA256)
+	if manifest, err := decodePayloadBuildManifest(
+		record.ProvenanceJSON,
+	); err == nil && payloadManifestMatchesRecord(manifest, record) == nil {
+		w.Header().Set(
+			"Link",
+			fmt.Sprintf(
+				"<%s>; rel=\"describedby\"; type=\"application/json\"",
+				payloadManifestURL(record.ID),
+			),
+		)
+	}
 
 	// Stream file to response
 	if _, err := io.Copy(w, file); err != nil {
@@ -1262,6 +1415,12 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	if h.initErr != nil {
 		return PayloadResult{}, h.initErr
 	}
+	plan, err := validateAndResolvePayloadConfig(config)
+	if err != nil {
+		return PayloadResult{}, err
+	}
+	config = plan.config
+	sourceRevision, sourceState := gitSourceState(h.agentSourceDir)
 	log.Printf("[INFO] Generating payload with config: %+v", config)
 
 	// Get listener details
@@ -1294,10 +1453,6 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	payloadID := uuid.NewString()
 	buildStartedAt := time.Now().UTC()
 	log.Printf("[INFO] Generated payload build ID %s for listener %s", payloadID, listener.ID)
-	maxSessions, err := resolvedPayloadMaxSessions(config.MaxSessions)
-	if err != nil {
-		return PayloadResult{}, err
-	}
 	bootstrap, err := enrollment.GenerateBootstrapCredential()
 	if err != nil {
 		return PayloadResult{}, fmt.Errorf("generate payload enrollment credential: %w", err)
@@ -1312,14 +1467,10 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	}
 	log.Printf("[INFO] Using mutation seed %s (server-generated: %t)", mutationSeed, seedGenerated)
 
-	// Determine build type (debug or release)
-	buildType := "release"
-	if config.AgentType == "debugAgent" {
-		buildType = "debug"
-	}
+	buildType := plan.buildType
 	log.Printf("[INFO] Build type: %s", buildType)
 
-	payloadFileName := payloadFilename(config.Format)
+	payloadFileName := plan.profile.filename
 	log.Printf("[INFO] Payload filename: %s", payloadFileName)
 
 	plannedRelativePath := filepath.ToSlash(filepath.Join(
@@ -1381,10 +1532,18 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		"output",
 		payloadFileName,
 	)
+	effectiveConfigRelativePath := filepath.Join(
+		"output",
+		effectiveConfigFilename,
+	)
+	effectiveConfigBuildPath := filepath.Join(
+		privateCargoBuildRoot,
+		payloadID,
+		effectiveConfigRelativePath,
+	)
 
-	// Create the build config through a root-anchored handle. The build
-	// contract still receives the ordinary output directory path, but server
-	// writes never follow a swapped component outside the payload root.
+	// The exact credential-free config exported by build.rs is published at
+	// this root-relative path only after the build completes.
 	configRelativePath := filepath.Join(
 		buildType,
 		payloadID,
@@ -1395,87 +1554,7 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	allowInsecureIsolatedLab :=
 		protocol == "http" && h.allowInsecureIsolatedLab
 
-	agentConfig := map[string]interface{}{
-		"server_url":                  serverURL,
-		"sleep_interval":              config.Sleep,
-		"jitter":                      2, // Default jitter value
-		"payload_id":                  payloadID,
-		"agent_id":                    "",
-		"listener_id":                 listener.ID,
-		"protocol":                    protocol,
-		"allow_insecure_isolated_lab": allowInsecureIsolatedLab,
-	}
-
-	// Include SOCKS5 proxy settings if requested
-	agentConfig["socks5_enabled"] = config.Socks5Enabled
-	agentConfig["socks5_host"] = config.Socks5Host
-	agentConfig["socks5_port"] = config.Socks5Port
-	if config.Socks5Enabled {
-		agentConfig["protocol"] = "socks5"
-	}
-
-	// Add additional configuration options based on payload settings
-	if config.IndirectSyscall {
-		log.Printf("[INFO] Enabling indirect syscalls")
-		agentConfig["indirect_syscalls"] = true
-	}
-
-	if config.SleepTechnique != "" && config.SleepTechnique != "standard" {
-		log.Printf("[INFO] Using custom sleep technique: %s", config.SleepTechnique)
-		agentConfig["sleep_technique"] = config.SleepTechnique
-	}
-
-	if config.DllSideloading {
-		log.Printf("[INFO] Enabling DLL sideloading with DLL: %s, Export: %s",
-			config.SideloadDll, config.ExportName)
-		agentConfig["dll_sideloading"] = true
-		agentConfig["sideload_dll"] = config.SideloadDll
-		agentConfig["export_name"] = config.ExportName
-	}
-
-	// Add OPSEC configurations to agentConfig map
-	agentConfig["proc_scan_interval_secs"] = config.ProcScanIntervalSecs
-	agentConfig["base_score_threshold_reduced_to_full"] = config.BaseThresholdEnterFullOpsec     // Map from HTML name
-	agentConfig["base_score_threshold_bg_to_reduced"] = config.BaseThresholdEnterReducedActivity // Map from HTML name
-	agentConfig["min_duration_full_opsec_secs"] = config.MinDurationFullOpsecSecs
-	agentConfig["min_duration_reduced_activity_secs"] = config.MinDurationReducedActivitySecs
-	agentConfig["min_duration_background_opsec_secs"] = config.MinDurationBackgroundOpsecSecs
-	agentConfig["reduced_activity_sleep_secs"] = config.ReducedActivitySleepSecs
-	agentConfig["base_max_consecutive_c2_failures"] = config.BaseMaxConsecutiveC2Failures
-	agentConfig["c2_failure_threshold_increase_factor"] = config.C2FailureThresholdIncreaseFactor
-	agentConfig["c2_failure_threshold_decrease_factor"] = config.C2FailureThresholdDecreaseFactor
-	agentConfig["c2_threshold_adjust_interval_secs"] = config.C2ThresholdAdjustIntervalSecs
-	agentConfig["c2_dynamic_threshold_max_multiplier"] = config.C2DynamicThresholdMaxMultiplier
-
-	configJSON, err := json.MarshalIndent(agentConfig, "", "  ")
-	if err != nil {
-		log.Printf("[ERROR] Failed to marshal agent config: %v", err)
-		return PayloadResult{}, fmt.Errorf("failed to marshal agent config: %w", err)
-	}
-
-	if err := createPayloadFileBeneath(
-		h.payloadsDir,
-		configRelativePath,
-		configJSON,
-		0600,
-	); err != nil {
-		log.Printf("[ERROR] Failed to write agent config to %s: %v", configPath, err)
-		return PayloadResult{}, fmt.Errorf("failed to write agent config: %w", err)
-	}
-	log.Printf("[INFO] Created agent config file: %s", configPath)
-
-	// Determine build target
-	var buildTarget string
-	switch {
-	case config.Format == "windows_exe" || config.Format == "windows_dll" || config.Format == "windows_service":
-		buildTarget = "x86_64-pc-windows-gnu"
-	case config.Format == "linux_elf":
-		buildTarget = "x86_64-unknown-linux-gnu"
-	case config.Architecture == "arm64":
-		buildTarget = "aarch64-unknown-linux-gnu"
-	default:
-		buildTarget = "x86_64-unknown-linux-gnu" // Default to Linux x64
-	}
+	buildTarget := plan.profile.targetTriple
 	log.Printf("[INFO] Using build target: %s", buildTarget)
 
 	// Get the path to the build script
@@ -1499,25 +1578,6 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		"--protocol", protocol,
 	}
 
-	// Add additional build arguments based on configuration
-	if config.IndirectSyscall {
-		cmdArgs = append(cmdArgs, "--indirect-syscalls")
-	}
-
-	if config.SleepTechnique != "" && config.SleepTechnique != "standard" {
-		cmdArgs = append(cmdArgs, "--sleep-technique", config.SleepTechnique)
-	}
-
-	if config.DllSideloading {
-		cmdArgs = append(cmdArgs, "--dll-sideload")
-		if config.SideloadDll != "" {
-			cmdArgs = append(cmdArgs, "--sideload-dll", config.SideloadDll)
-		}
-		if config.ExportName != "" {
-			cmdArgs = append(cmdArgs, "--export-name", config.ExportName)
-		}
-	}
-
 	log.Printf("[INFO] Command: /bin/bash %s", strings.Join(cmdArgs, " "))
 	cmd := exec.Command("/bin/bash", cmdArgs...)
 
@@ -1530,12 +1590,17 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		fmt.Sprintf("TARGET=%s", buildTarget),
 		fmt.Sprintf("OUTPUT_DIR=%s", stagingOutputDir),
 		fmt.Sprintf("CARGO_TARGET_DIR=%s", cargoTargetDir),
+		fmt.Sprintf(
+			"EFFECTIVE_CONFIG_PATH=%s",
+			effectiveConfigBuildPath,
+		),
 		fmt.Sprintf("BUILD_TYPE=%s", buildType),
 		fmt.Sprintf("PROTOCOL=%s", protocol),
 		fmt.Sprintf("SERVER_URL=%s", serverURL),
 		fmt.Sprintf("LISTENER_HOST=%s", connectHost),
 		fmt.Sprintf("LISTENER_PORT=%d", listener.Port),
 		fmt.Sprintf("LISTENER_ID=%s", listener.ID),
+		fmt.Sprintf("PAYLOAD_ID=%s", payloadID),
 		fmt.Sprintf("SLEEP_INTERVAL=%d", config.Sleep),
 		fmt.Sprintf("SOCKS5_ENABLED=%t", config.Socks5Enabled),
 		fmt.Sprintf("SOCKS5_HOST=%s", config.Socks5Host),
@@ -1577,15 +1642,37 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	}
 	_, err = h.runSerializedBuild(cmd)
 	var (
-		fileInfo     os.FileInfo
-		artifactHash string
+		fileInfo            os.FileInfo
+		artifactHash        string
+		effectiveConfigJSON json.RawMessage
 	)
+	if err == nil {
+		effectiveConfigJSON, err = readEffectiveBuildConfig(
+			cargoBuildDir,
+			effectiveConfigRelativePath,
+			payloadID,
+			listener.ID,
+			mutationSeed,
+			bootstrap.Public,
+		)
+	}
 	if err == nil {
 		fileInfo, artifactHash, err = h.publishGeneratedArtifact(
 			cargoBuildDir,
 			stagingArtifactRelativePath,
 			plannedRelativePath,
 		)
+	}
+	if err == nil {
+		err = createPayloadFileBeneath(
+			h.payloadsDir,
+			configRelativePath,
+			effectiveConfigJSON,
+			0600,
+		)
+		if err != nil {
+			err = fmt.Errorf("publish effective payload config: %w", err)
+		}
 	}
 	if cleanupErr := removePrivateCargoBuildDirectory(
 		cargoBuildRoot,
@@ -1609,6 +1696,7 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		return PayloadResult{}, errors.New("payload build failed")
 	}
 	log.Printf("[INFO] Payload build command completed")
+	log.Printf("[INFO] Published effective agent config at: %s", configPath)
 
 	// The build contract has one deterministic artifact path. Publishing,
 	// permission restriction, and hashing all used the same anchored handle;
@@ -1616,29 +1704,55 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 	log.Printf("[INFO] Published payload at: %s", payloadPath)
 	completedAt := time.Now().UTC()
 
-	// Persist non-secret provenance. Enrollment uses a fresh, deliberately
-	// unrecorded high-entropy build input, so revision and mutation seed
-	// reproduce mutation choices but not the credential-bearing artifact.
-	provenance := map[string]interface{}{
-		"mutation_seed":                mutationSeed,
-		"seed_generated_by_server":     seedGenerated,
-		"git_revision":                 gitRevision(h.agentSourceDir),
-		"target":                       buildTarget,
-		"built_at":                     completedAt.Format(time.RFC3339Nano),
-		"config_sha256":                fmt.Sprintf("%x", sha256.Sum256(configJSON)),
-		"mutation_flags":               []string{"config-xor-key", "junk-code", "surface-strings"},
-		"enrollment_credential_source": "server-generated-ephemeral",
+	// Persist a complete non-secret manifest. Enrollment uses a fresh,
+	// deliberately unrecorded high-entropy build input, so revision and
+	// mutation seed reproduce mutation choices but not the
+	// credential-bearing artifact.
+	manifest := PayloadBuildManifest{
+		SchemaVersion: payloadBuildManifestSchemaV1,
+		PayloadID:     payloadID,
+		ListenerID:    listener.ID,
+		GitRevision:   sourceRevision,
+		SourceState:   sourceState,
+		TargetOS:      plan.profile.targetOS,
+		Architecture:  config.Architecture,
+		TargetTriple:  buildTarget,
+		Format:        config.Format,
+		BuildType:     buildType,
+		EffectiveConfig: append(
+			json.RawMessage(nil),
+			effectiveConfigJSON...,
+		),
+		ConfigSHA256: fmt.Sprintf(
+			"%x",
+			sha256.Sum256(effectiveConfigJSON),
+		),
+		Artifact: PayloadArtifactManifest{
+			Path:     plannedRelativePath,
+			Filename: payloadFileName,
+			Size:     fileInfo.Size(),
+			SHA256:   artifactHash,
+		},
+		CreatedAt:             completedAt.Format(time.RFC3339Nano),
+		MutationSeed:          mutationSeed,
+		SeedGeneratedByServer: seedGenerated,
+		MutationFlags: []string{
+			"config-xor-key",
+			"junk-code",
+			"surface-strings",
+		},
+		EnrollmentCredentialSource: "server-generated-ephemeral",
 	}
 	if err := writeProvenance(
 		h.payloadsDir,
 		plannedRelativePath,
-		provenance,
+		manifest,
 	); err != nil {
-		log.Printf("[WARNING] Failed to write build provenance: %v", err)
+		return PayloadResult{}, err
 	}
-	provenanceJSON, err := json.Marshal(provenance)
+	provenanceJSON, err := json.Marshal(manifest)
 	if err != nil {
-		return PayloadResult{}, fmt.Errorf("marshal payload provenance: %w", err)
+		return PayloadResult{}, fmt.Errorf("marshal payload build manifest: %w", err)
 	}
 	// Create the result
 	result = PayloadResult{
@@ -1650,6 +1764,8 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 		Path:         payloadPath,
 		Size:         fileInfo.Size(),
 		Created:      completedAt.Format(time.RFC3339Nano),
+		Manifest:     &manifest,
+		ManifestURL:  payloadManifestURL(payloadID),
 		relativePath: plannedRelativePath,
 		sha256:       artifactHash,
 		provenanceJSON: append(
@@ -1666,7 +1782,7 @@ func (h *PayloadHandler) GeneratePayloadWithContext(
 			PayloadBuildID:  payloadID,
 			ListenerID:      listener.ID,
 			BootstrapSHA256: bootstrap.SHA256,
-			MaxSessions:     maxSessions,
+			MaxSessions:     plan.maxSessions,
 		}
 		if err := h.completePayloadBuild(ctx, result, activation); err != nil {
 			return PayloadResult{}, fmt.Errorf("persist completed payload state: %w", err)
@@ -2672,7 +2788,7 @@ func hashOpenArtifact(file *os.File) (string, error) {
 func (h *PayloadHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/payload/generate", h.HandleGeneratePayload)
 	mux.HandleFunc("/api/payload/download/", h.HandleDownloadPayload)
-	mux.HandleFunc("/api/payload/", h.HandleRevokePayloadEnrollment)
+	mux.HandleFunc("/api/payload/", h.HandlePayloadResource)
 }
 
 // SetupRoutes registers payload routes on the default mux for legacy callers.

--- a/server/internal/handlers/api/payload/payload_handler_test.go
+++ b/server/internal/handlers/api/payload/payload_handler_test.go
@@ -43,10 +43,11 @@ func TestGeneratePayloadCreatesBuildIDsDistinctFromListenerID(t *testing.T) {
 
 	handler := NewPayloadHandlerForIsolatedLab(filepath.Join(tempDir, "static", "payloads"), agentDir)
 	config := PayloadConfig{
-		ListenerID: "listener-one",
-		AgentType:  "debugAgent",
-		Format:     "linux_elf",
-		Sleep:      5,
+		ListenerID:   "listener-one",
+		AgentType:    "debugAgent",
+		Architecture: "x64",
+		Format:       "linux_elf",
+		Sleep:        5,
 	}
 
 	first, err := handler.GeneratePayload(config)
@@ -115,10 +116,11 @@ func TestGeneratePayloadGeneratesSeedAndWritesProvenance(t *testing.T) {
 		return command.CombinedOutput()
 	}
 	config := PayloadConfig{
-		ListenerID: "listener-one",
-		AgentType:  "debugAgent",
-		Format:     "linux_elf",
-		Sleep:      5,
+		ListenerID:   "listener-one",
+		AgentType:    "debugAgent",
+		Architecture: "x64",
+		Format:       "linux_elf",
+		Sleep:        5,
 	}
 
 	seedPattern := regexp.MustCompile(`^[0-9a-f]{16}$`)
@@ -139,7 +141,33 @@ func TestGeneratePayloadGeneratesSeedAndWritesProvenance(t *testing.T) {
 		)
 	}
 
-	provenance := readJSONFile(t, filepath.Join(filepath.Dir(first.Path), "provenance.json"))
+	provenancePath := filepath.Join(
+		filepath.Dir(first.Path),
+		"provenance.json",
+	)
+	provenance := readJSONFile(t, provenancePath)
+	sidecarJSON, err := os.ReadFile(provenancePath)
+	if err != nil {
+		t.Fatalf("read payload build manifest sidecar: %v", err)
+	}
+	decodedSidecar, err := decodePayloadBuildManifest(sidecarJSON)
+	if err != nil {
+		t.Fatalf("decode payload build manifest sidecar: %v", err)
+	}
+	if decodedSidecar.PayloadID != first.ID {
+		t.Fatalf(
+			"decoded sidecar payload ID = %q, want %q",
+			decodedSidecar.PayloadID,
+			first.ID,
+		)
+	}
+	if provenance["schema_version"] != payloadBuildManifestSchemaV1 {
+		t.Fatalf("manifest schema = %#v, want %q", provenance["schema_version"], payloadBuildManifestSchemaV1)
+	}
+	if provenance["payload_id"] != first.ID ||
+		provenance["listener_id"] != "listener-one" {
+		t.Fatalf("manifest identity is incomplete: %#v", provenance)
+	}
 	if provenance["mutation_seed"] != first.MutationSeed {
 		t.Fatalf("provenance mutation_seed = %#v, want %q", provenance["mutation_seed"], first.MutationSeed)
 	}
@@ -149,14 +177,45 @@ func TestGeneratePayloadGeneratesSeedAndWritesProvenance(t *testing.T) {
 	if provenance["git_revision"] == nil || provenance["git_revision"] == "" {
 		t.Fatalf("provenance should record a git revision (or \"unknown\"): %#v", provenance["git_revision"])
 	}
-	if provenance["target"] != "x86_64-unknown-linux-gnu" {
-		t.Fatalf("provenance target = %#v, want x86_64-unknown-linux-gnu", provenance["target"])
+	if provenance["source_state"] == nil || provenance["source_state"] == "" {
+		t.Fatalf("manifest should record source state: %#v", provenance["source_state"])
+	}
+	if provenance["target_os"] != "linux" ||
+		provenance["architecture"] != "x64" ||
+		provenance["target_triple"] != "x86_64-unknown-linux-gnu" ||
+		provenance["format"] != "linux_elf" ||
+		provenance["build_type"] != "debug" {
+		t.Fatalf("manifest profile is incomplete: %#v", provenance)
 	}
 	if provenance["config_sha256"] == nil || provenance["config_sha256"] == "" {
 		t.Fatalf("provenance should record the resolved config hash: %#v", provenance["config_sha256"])
 	}
-	if provenance["built_at"] == nil || provenance["built_at"] == "" {
-		t.Fatalf("provenance should record a build timestamp: %#v", provenance["built_at"])
+	if provenance["created_at"] != first.Created {
+		t.Fatalf("manifest created_at = %#v, want %q", provenance["created_at"], first.Created)
+	}
+	effectiveConfig, ok := provenance["effective_config"].(map[string]interface{})
+	if !ok || effectiveConfig["payload_id"] != first.ID ||
+		effectiveConfig["listener_id"] != "listener-one" ||
+		effectiveConfig["mutation_seed"] != first.MutationSeed ||
+		effectiveConfig["protocol"] != "http" ||
+		effectiveConfig["user_agent"] != "test-agent" {
+		t.Fatalf("manifest effective config is incomplete: %#v", provenance["effective_config"])
+	}
+	if _, containsCredential := effectiveConfig["enrollment_credential"]; containsCredential {
+		t.Fatal("manifest effective config retained enrollment credential material")
+	}
+	artifact, ok := provenance["artifact"].(map[string]interface{})
+	if !ok ||
+		artifact["path"] != filepath.ToSlash(filepath.Join("debug", first.ID, "agent")) ||
+		artifact["filename"] != "agent" ||
+		artifact["size"] != float64(first.Size) ||
+		artifact["sha256"] == "" {
+		t.Fatalf("manifest artifact is incomplete: %#v", provenance["artifact"])
+	}
+	if first.Manifest == nil ||
+		first.Manifest.Artifact.SHA256 != artifact["sha256"] ||
+		first.ManifestURL != payloadManifestURL(first.ID) {
+		t.Fatalf("payload result did not expose its manifest: %#v", first)
 	}
 	if provenance["enrollment_credential_source"] !=
 		"server-generated-ephemeral" {
@@ -363,11 +422,17 @@ func TestPayloadBuildReceivesCanonicalIPv6ServerURL(t *testing.T) {
 			if command.Args[index] != "--output" {
 				continue
 			}
-			return []byte("hook build complete"), os.WriteFile(
+			if err := os.WriteFile(
 				filepath.Join(command.Args[index+1], "agent"),
 				[]byte("fake agent"),
 				0o600,
-			)
+			); err != nil {
+				return nil, err
+			}
+			if err := writeTestEffectiveConfig(command); err != nil {
+				return nil, err
+			}
+			return []byte("hook build complete"), nil
 		}
 		return nil, errors.New("build command omitted --output")
 	}
@@ -456,6 +521,9 @@ func TestPersistentPayloadEnrollmentCredentialIsHashOnlyAndNotProjected(
 			0o600,
 		); err != nil {
 			t.Fatalf("write hooked payload artifact: %v", err)
+		}
+		if err := writeTestEffectiveConfig(command); err != nil {
+			t.Fatalf("write hooked effective config: %v", err)
 		}
 		buildOutput = []byte(
 			"hook build complete; credential=" + bootstrapCredential,
@@ -769,6 +837,9 @@ func TestConcurrentPayloadBuildsSerializeSharedAgentWorkspace(t *testing.T) {
 		); err != nil {
 			return nil, fmt.Errorf("copy simulated shared artifact: %w", err)
 		}
+		if err := writeTestEffectiveConfig(command); err != nil {
+			return nil, err
+		}
 		return []byte("hook build complete"), nil
 	}
 
@@ -949,11 +1020,17 @@ func TestPayloadArtifactsRemainDownloadableWithPrivatePermissions(t *testing.T) 
 			if command.Args[index] != "--output" {
 				continue
 			}
-			return []byte("hook build complete"), os.WriteFile(
+			if err := os.WriteFile(
 				filepath.Join(command.Args[index+1], "agent"),
 				[]byte("private agent"),
 				0o644,
-			)
+			); err != nil {
+				return nil, err
+			}
+			if err := writeTestEffectiveConfig(command); err != nil {
+				return nil, err
+			}
+			return []byte("hook build complete"), nil
 		}
 		return nil, errors.New("build command omitted --output")
 	}
@@ -1202,11 +1279,17 @@ func TestPayloadEnrollmentRevokeOperatorRoute(t *testing.T) {
 			if command.Args[index] != "--output" {
 				continue
 			}
-			return []byte("hook build complete"), os.WriteFile(
+			if err := os.WriteFile(
 				filepath.Join(command.Args[index+1], "agent"),
 				[]byte("fake agent"),
 				0o600,
-			)
+			); err != nil {
+				return nil, err
+			}
+			if err := writeTestEffectiveConfig(command); err != nil {
+				return nil, err
+			}
+			return []byte("hook build complete"), nil
 		}
 		return nil, errors.New("build command omitted --output")
 	}
@@ -1578,6 +1661,7 @@ func TestGeneratePayloadHonoursSuppliedMutationSeed(t *testing.T) {
 	config := PayloadConfig{
 		ListenerID:   "listener-one",
 		AgentType:    "debugAgent",
+		Architecture: "x64",
 		Format:       "linux_elf",
 		Sleep:        5,
 		MutationSeed: "0123456789abcdef",
@@ -1712,11 +1796,17 @@ func TestPayloadCompletionAuditFailureRollsBackCredentialActivation(t *testing.T
 			if command.Args[index] != "--output" {
 				continue
 			}
-			return []byte("untrusted compiler output"), os.WriteFile(
+			if err := os.WriteFile(
 				filepath.Join(command.Args[index+1], "agent"),
 				[]byte("fake agent"),
 				0o600,
-			)
+			); err != nil {
+				return nil, err
+			}
+			if err := writeTestEffectiveConfig(command); err != nil {
+				return nil, err
+			}
+			return []byte("untrusted compiler output"), nil
 		}
 		return nil, errors.New("build command omitted --output")
 	}
@@ -1816,6 +1906,9 @@ func TestPayloadBuildAuditRootCompletionAndRedactionSurviveRestart(
 			0o600,
 		); err != nil {
 			return nil, fmt.Errorf("write hooked payload artifact: %w", err)
+		}
+		if err := writeTestEffectiveConfig(command); err != nil {
+			return nil, err
 		}
 		buildOutput = []byte(
 			buildOutputMarker + "; credential=" + bootstrapCredential,
@@ -2011,11 +2104,11 @@ func TestPayloadMetadataAndDownloadSurviveRestartWithCustomRoot(t *testing.T) {
 		firstDatabase.Close()
 		t.Fatalf("decode stored provenance: %v", err)
 	}
-	if provenance["built_at"] != generated.Created {
+	if provenance["created_at"] != generated.Created {
 		firstDatabase.Close()
 		t.Fatalf(
-			"stored provenance built_at = %#v, want %q",
-			provenance["built_at"],
+			"stored manifest created_at = %#v, want %q",
+			provenance["created_at"],
 			generated.Created,
 		)
 	}
@@ -2069,10 +2162,65 @@ func TestPayloadMetadataAndDownloadSurviveRestartWithCustomRoot(t *testing.T) {
 	if recorder.Header().Get("Content-Length") != "10" {
 		t.Fatalf("download content length = %q, want 10", recorder.Header().Get("Content-Length"))
 	}
+	if recorder.Header().Get("X-MicroC2-Artifact-SHA256") != artifactHash {
+		t.Fatalf(
+			"download artifact digest = %q, want %q",
+			recorder.Header().Get("X-MicroC2-Artifact-SHA256"),
+			artifactHash,
+		)
+	}
+	if wantLink := "<" + payloadManifestURL(generated.ID) +
+		">; rel=\"describedby\"; type=\"application/json\""; recorder.Header().Get(
+		"Link",
+	) != wantLink {
+		t.Fatalf(
+			"download manifest link = %q, want %q",
+			recorder.Header().Get("Link"),
+			wantLink,
+		)
+	}
 	if !strings.Contains(recorder.Header().Get("Content-Disposition"), "filename=agent") {
 		t.Fatalf(
 			"download content disposition = %q",
 			recorder.Header().Get("Content-Disposition"),
+		)
+	}
+
+	manifestRecorder := httptest.NewRecorder()
+	manifestRequest := httptest.NewRequest(
+		http.MethodGet,
+		payloadManifestURL(generated.ID),
+		nil,
+	)
+	manifestMux := http.NewServeMux()
+	secondHandler.RegisterRoutes(manifestMux)
+	manifestMux.ServeHTTP(manifestRecorder, manifestRequest)
+	if manifestRecorder.Code != http.StatusOK {
+		t.Fatalf(
+			"manifest after restart: status %d: %s",
+			manifestRecorder.Code,
+			manifestRecorder.Body.String(),
+		)
+	}
+	var manifest PayloadBuildManifest
+	if err := json.Unmarshal(manifestRecorder.Body.Bytes(), &manifest); err != nil {
+		t.Fatalf("decode manifest after restart: %v", err)
+	}
+	if manifest.SchemaVersion != payloadBuildManifestSchemaV1 ||
+		manifest.PayloadID != generated.ID ||
+		manifest.ListenerID != "listener-one" ||
+		manifest.Artifact.Path != relativePath ||
+		manifest.Artifact.SHA256 != artifactHash ||
+		manifest.Artifact.Size != 10 {
+		t.Fatalf("manifest after restart is incomplete: %#v", manifest)
+	}
+	if bytes.Contains(
+		manifestRecorder.Body.Bytes(),
+		[]byte(`"enrollment_credential":`),
+	) {
+		t.Fatalf(
+			"manifest exposed enrollment credential material: %s",
+			manifestRecorder.Body.String(),
 		)
 	}
 }
@@ -2693,6 +2841,79 @@ func TestPayloadDirectoryCreationRejectsSymlinkClass(t *testing.T) {
 	}
 }
 
+func TestGeneratePayloadFailsWhenManifestCannotBePublished(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on Windows")
+	}
+
+	tempDir := t.TempDir()
+	payloadRoot := filepath.Join(tempDir, "payload-root")
+	agentDir := filepath.Join(tempDir, "agent")
+	outsideManifest := filepath.Join(tempDir, "outside-manifest.json")
+	writePlaceholderBuildScript(t, agentDir)
+	if err := os.WriteFile(
+		outsideManifest,
+		[]byte("outside sentinel"),
+		0600,
+	); err != nil {
+		t.Fatalf("write outside manifest sentinel: %v", err)
+	}
+	handler, err := newPayloadHandler(
+		payloadRoot,
+		agentDir,
+		testListenerLookup(),
+		nil,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("create payload handler: %v", err)
+	}
+	handler.runBuild = func(command *exec.Cmd) ([]byte, error) {
+		var outputDir, payloadID string
+		for index := 0; index+1 < len(command.Args); index++ {
+			switch command.Args[index] {
+			case "--output":
+				outputDir = command.Args[index+1]
+			case "--payload-id":
+				payloadID = command.Args[index+1]
+			}
+		}
+		if outputDir == "" || payloadID == "" {
+			return nil, errors.New("build command omitted output or payload ID")
+		}
+		if err := os.WriteFile(
+			filepath.Join(outputDir, "agent"),
+			[]byte("fake agent"),
+			0600,
+		); err != nil {
+			return nil, err
+		}
+		if err := writeTestEffectiveConfig(command); err != nil {
+			return nil, err
+		}
+		return nil, os.Symlink(
+			outsideManifest,
+			filepath.Join(
+				payloadRoot,
+				"debug",
+				payloadID,
+				"provenance.json",
+			),
+		)
+	}
+
+	if _, err := handler.GeneratePayload(testPayloadConfig()); err == nil {
+		t.Fatal("generation succeeded without a publishable build manifest")
+	}
+	contents, err := os.ReadFile(outsideManifest)
+	if err != nil {
+		t.Fatalf("read outside manifest sentinel: %v", err)
+	}
+	if string(contents) != "outside sentinel" {
+		t.Fatalf("outside manifest changed to %q", contents)
+	}
+}
+
 func TestPayloadArtifactParentSwapNeverEscapesRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("creating symlinks requires privileges on Windows")
@@ -3058,6 +3279,7 @@ func generatePayloadOverHTTP(t *testing.T, handler *PayloadHandler) PayloadResul
 	body, err := json.Marshal(PayloadConfig{
 		ListenerID:   "listener-one",
 		AgentType:    "debugAgent",
+		Architecture: "x64",
 		Format:       "linux_elf",
 		Sleep:        5,
 		MutationSeed: "0123456789abcdef",
@@ -3097,6 +3319,7 @@ func testPayloadConfig() PayloadConfig {
 	return PayloadConfig{
 		ListenerID:   "listener-one",
 		AgentType:    "debugAgent",
+		Architecture: "x64",
 		Format:       "linux_elf",
 		Sleep:        5,
 		MutationSeed: "0123456789abcdef",
@@ -3210,6 +3433,12 @@ esac
 mkdir -p "$output"
 printf 'fake agent' > "$output/$artifact"
 printf '%s' "${MUTATION_SEED:-}" > "$output/mutation_seed.env"
+if [[ -n "${EFFECTIVE_CONFIG_PATH:-}" ]]; then
+  mkdir -p "$(dirname "$EFFECTIVE_CONFIG_PATH")"
+  printf '{"server_url":"%s","payload_id":"%s","agent_id":"","listener_id":"%s","mutation_seed":"%s","protocol":"%s","user_agent":"test-agent","mutation_endpoint_segments":["segment-a","segment-b"],"allow_invalid_certs":false}' \
+    "${SERVER_URL:-}" "${PAYLOAD_ID:-}" "${LISTENER_ID:-}" "${MUTATION_SEED:-}" "${PROTOCOL:-https}" \
+    > "$EFFECTIVE_CONFIG_PATH"
+fi
 `
 	if err := os.WriteFile(filepath.Join(agentDir, "build.sh"), []byte(script), 0644); err != nil {
 		t.Fatalf("write fake build script: %v", err)
@@ -3228,6 +3457,42 @@ func writePlaceholderBuildScript(t *testing.T, agentDir string) {
 	); err != nil {
 		t.Fatalf("write placeholder build script: %v", err)
 	}
+}
+
+func writeTestEffectiveConfig(command *exec.Cmd) error {
+	values := make(map[string]string)
+	for _, entry := range command.Env {
+		name, value, found := strings.Cut(entry, "=")
+		if found {
+			values[name] = value
+		}
+	}
+	destination := values["EFFECTIVE_CONFIG_PATH"]
+	if destination == "" {
+		return errors.New("build command omitted EFFECTIVE_CONFIG_PATH")
+	}
+	if !filepath.IsAbs(destination) {
+		destination = filepath.Join(command.Dir, destination)
+	}
+	config := map[string]interface{}{
+		"server_url":                 values["SERVER_URL"],
+		"payload_id":                 values["PAYLOAD_ID"],
+		"agent_id":                   "",
+		"listener_id":                values["LISTENER_ID"],
+		"mutation_seed":              values["MUTATION_SEED"],
+		"protocol":                   values["PROTOCOL"],
+		"user_agent":                 "test-agent",
+		"mutation_endpoint_segments": []string{"segment-a", "segment-b"},
+		"allow_invalid_certs":        false,
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal test effective config: %w", err)
+	}
+	if err := os.WriteFile(destination, data, 0o600); err != nil {
+		return fmt.Errorf("write test effective config: %w", err)
+	}
+	return nil
 }
 
 func installSuccessfulBuildHook(
@@ -3286,6 +3551,9 @@ func installSuccessfulBuildHook(
 			0644,
 		); err != nil {
 			t.Fatalf("write hooked payload artifact: %v", err)
+		}
+		if err := writeTestEffectiveConfig(command); err != nil {
+			t.Fatalf("write hooked effective config: %v", err)
 		}
 		return []byte("hook build complete"), nil
 	}

--- a/server/internal/handlers/api/payload/types.go
+++ b/server/internal/handlers/api/payload/types.go
@@ -53,19 +53,54 @@ type PayloadConfig struct {
 
 // PayloadResult contains information about a generated payload
 type PayloadResult struct {
-	ID           string `json:"id"`
-	PayloadID    string `json:"payload_id,omitempty"`
-	ListenerID   string `json:"listener_id,omitempty"`
-	MutationSeed string `json:"mutation_seed,omitempty"`
-	Filename     string `json:"filename"`
-	Path         string `json:"path"`
-	Size         int64  `json:"size"`
-	Created      string `json:"created"`
+	ID           string                `json:"id"`
+	PayloadID    string                `json:"payload_id,omitempty"`
+	ListenerID   string                `json:"listener_id,omitempty"`
+	MutationSeed string                `json:"mutation_seed,omitempty"`
+	Filename     string                `json:"filename"`
+	Path         string                `json:"path"`
+	Size         int64                 `json:"size"`
+	Created      string                `json:"created"`
+	Manifest     *PayloadBuildManifest `json:"manifest,omitempty"`
+	ManifestURL  string                `json:"manifest_url,omitempty"`
 
 	relativePath              string
 	sha256                    string
 	provenanceJSON            json.RawMessage
 	createdAuditEventSequence int64
+}
+
+// PayloadBuildManifest is the versioned, non-secret record of the exact
+// supported profile and effective runtime configuration used for a build.
+// Enrollment credentials are deliberately excluded.
+type PayloadBuildManifest struct {
+	SchemaVersion              string                  `json:"schema_version"`
+	PayloadID                  string                  `json:"payload_id"`
+	ListenerID                 string                  `json:"listener_id"`
+	GitRevision                string                  `json:"git_revision"`
+	SourceState                string                  `json:"source_state"`
+	TargetOS                   string                  `json:"target_os"`
+	Architecture               string                  `json:"architecture"`
+	TargetTriple               string                  `json:"target_triple"`
+	Format                     string                  `json:"format"`
+	BuildType                  string                  `json:"build_type"`
+	EffectiveConfig            json.RawMessage         `json:"effective_config"`
+	ConfigSHA256               string                  `json:"config_sha256"`
+	Artifact                   PayloadArtifactManifest `json:"artifact"`
+	CreatedAt                  string                  `json:"created_at"`
+	MutationSeed               string                  `json:"mutation_seed"`
+	SeedGeneratedByServer      bool                    `json:"seed_generated_by_server"`
+	MutationFlags              []string                `json:"mutation_flags"`
+	EnrollmentCredentialSource string                  `json:"enrollment_credential_source"`
+}
+
+// PayloadArtifactManifest identifies the one canonical artifact published by a
+// payload build. Path is always relative to the configured payload root.
+type PayloadArtifactManifest struct {
+	Path     string `json:"path"`
+	Filename string `json:"filename"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256"`
 }
 
 // ListenerLookup resolves the authoritative listener configuration used for a

--- a/server/web/js/payload.js
+++ b/server/web/js/payload.js
@@ -15,18 +15,9 @@ class PayloadManager {
     }
 
     setupEventListeners() {
-        // DLL sideloading toggle
-        document.getElementById('dllSideloading').addEventListener('change', function() {
-            document.getElementById('sideloadingOptions').classList.toggle('hidden', !this.checked);
-        });
         // SOCKS5 proxy toggle
         document.getElementById('socks5_enabled').addEventListener('change', function() {
             document.getElementById('socks5Options').classList.toggle('hidden', !this.checked);
-        });
-
-        // Architecture change handler
-        document.getElementById('architecture').addEventListener('change', (e) => {
-            this.updateAvailableFormats(e.target.value);
         });
 
         // Form submission handler
@@ -172,46 +163,6 @@ class PayloadManager {
         }
     }
 
-    updateAvailableFormats(architecture) {
-        const formatSelect = document.getElementById('format');
-        const isWindows = ['x64', 'x86'].includes(architecture);
-        
-        formatSelect.innerHTML = '';
-        
-        if (isWindows) {
-            const windowsFormats = [
-                { value: 'windows_exe', label: 'Windows EXE' },
-                { value: 'windows_dll', label: 'Windows DLL' },
-                { value: 'windows_shellcode', label: 'Windows Shellcode' },
-                { value: 'windows_service', label: 'Windows Service EXE' }
-            ];
-            
-            windowsFormats.forEach(format => {
-                const option = document.createElement('option');
-                option.value = format.value;
-                option.textContent = format.label;
-                formatSelect.appendChild(option);
-            });
-        } else if (architecture === 'arm64') {
-            [
-                { value: 'linux_elf', label: 'Linux ELF' },
-                { value: 'linux_arm_binary', label: 'Linux ARM Binary' }
-            ].forEach(format => {
-                const option = document.createElement('option');
-                option.value = format.value;
-                option.textContent = format.label;
-                formatSelect.appendChild(option);
-            });
-        } else {
-            const option = document.createElement('option');
-            option.value = 'linux_elf';
-            option.textContent = 'Linux ELF';
-            formatSelect.appendChild(option);
-        }
-        
-        formatSelect.dispatchEvent(new Event('change'));
-    }
-
     async handleFormSubmission(e) {
         const formData = new FormData(e.target);
         const config = Object.fromEntries(formData);
@@ -222,8 +173,6 @@ class PayloadManager {
             return;
         }
         // Convert checkbox values to boolean
-        config.indirectSyscall = config.indirectSyscall === 'on';
-        config.dllSideloading = config.dllSideloading === 'on';
         config.socks5_enabled = config.socks5_enabled === 'on';
         config.socks5_host = String(config.socks5_host || '').trim();
         config.socks5_port = parseInt(config.socks5_port, 10) || 0;
@@ -231,9 +180,7 @@ class PayloadManager {
         // ---  Parse OPSEC fields ---
         config.proc_scan_interval_secs = parseInt(config.proc_scan_interval_secs, 10) || 300;
         config.base_threshold_enter_full_opsec = parseFloat(config.base_threshold_enter_full_opsec) || 60.0;
-        config.base_threshold_exit_full_opsec = parseFloat(config.base_threshold_exit_full_opsec) || 60.0;
         config.base_threshold_enter_reduced_activity = parseFloat(config.base_threshold_enter_reduced_activity) || 20.0;
-        config.base_threshold_exit_reduced_activity = parseFloat(config.base_threshold_exit_reduced_activity) || 20.0;
         config.min_duration_full_opsec_secs = parseInt(config.min_duration_full_opsec_secs, 10) || 300;
         config.min_duration_reduced_activity_secs = parseInt(config.min_duration_reduced_activity_secs, 10) || 120;
         config.min_duration_background_opsec_secs = parseInt(config.min_duration_background_opsec_secs, 10) || 60;
@@ -251,6 +198,9 @@ class PayloadManager {
 
         const downloadSection = document.getElementById('download-section');
         downloadSection.classList.add('hidden');
+        const manifestLink = downloadSection.querySelector('.manifest-link');
+        manifestLink.hidden = true;
+        manifestLink.removeAttribute('href');
 
         this.clearLogDisplay();
         this.isGeneratingPayload = true;
@@ -268,7 +218,8 @@ class PayloadManager {
             });
 
             if (!response.ok) {
-                throw new Error('Failed to generate payload');
+                const responseText = (await response.text()).trim();
+                throw new Error(responseText || `Payload generation failed (${response.status})`);
             }
 
             const result = await response.json();
@@ -277,6 +228,18 @@ class PayloadManager {
             this.addLogEntry('payload', `Successfully generated payload: ${result.filename} (${formatBytes(result.size)})`, 'INFO');
             if (result.mutation_seed) {
                 this.addLogEntry('payload', `Mutation seed: ${result.mutation_seed} (record it with the git revision to reproduce mutation choices; enrollment remains unique per build)`, 'INFO');
+            }
+            if (result.manifest) {
+                if (result.manifest.target_triple) {
+                    this.addLogEntry('payload', `Target triple: ${result.manifest.target_triple}`, 'INFO');
+                }
+                if (result.manifest.git_revision) {
+                    this.addLogEntry('payload', `Git revision: ${result.manifest.git_revision}`, 'INFO');
+                }
+                const artifactSha256 = result.manifest.artifact?.sha256 || result.manifest.artifact_sha256;
+                if (artifactSha256) {
+                    this.addLogEntry('payload', `Artifact SHA-256: ${artifactSha256}`, 'INFO');
+                }
             }
             
             downloadSection.classList.remove('hidden');
@@ -289,6 +252,10 @@ class PayloadManager {
             downloadButton.onclick = () => {
                 window.location.href = `/api/payload/download/${result.id}`;
             };
+            if (result.manifest_url) {
+                manifestLink.href = result.manifest_url;
+                manifestLink.hidden = false;
+            }
         } catch (error) {
             console.error('Error:', error);
             this.addLogEntry('payload', `Failed to generate payload: ${error.message}`, 'ERROR');

--- a/server/web/payload.html
+++ b/server/web/payload.html
@@ -43,8 +43,6 @@
                                 <label for="architecture">Architecture</label>
                                 <select id="architecture" name="architecture" required>
                                     <option value="x64">x64</option>
-                                    <option value="x86">x86</option>
-                                    <option value="arm64">ARM64</option>
                                 </select>
                             </div>
 
@@ -52,9 +50,6 @@
                                 <label for="format">Format</label>
                                 <select id="format" name="format" required>
                                     <option value="windows_exe">Windows EXE</option>
-                                    <option value="windows_dll">Windows DLL</option>
-                                    <option value="windows_shellcode">Windows Shellcode</option>
-                                    <option value="windows_service">Windows Service EXE</option>
                                     <option value="linux_elf">Linux ELF</option>
                                 </select>
                             </div>
@@ -63,48 +58,8 @@
                         <div class="form-section">
                             <h3>Advanced Options</h3>
                             <div class="form-group">
-                                <label class="checkbox-label">
-                                    <input type="checkbox" id="opsec" name="opsec">
-                                    Enable OPSEC
-                                </label>
-                            </div>
-                            <div class="form-group">
                                 <label for="sleep">Sleep Interval (seconds)</label>
                                 <input type="number" id="sleep" name="sleep" value="60">
-                            </div>
-
-                            <div class="form-group">
-                                <label class="checkbox-label">
-                                    <input type="checkbox" id="indirectSyscall" name="indirectSyscall">
-                                    Enable Indirect Syscalls
-                                </label>
-                            </div>
-
-                            <div class="form-group">
-                                <label for="sleepTechnique">Sleep Technique</label>
-                                <select id="sleepTechnique" name="sleepTechnique">
-                                    <option value="standard">Standard</option>
-                                    <option value="winapi">WinAPI</option>
-                                    <option value="modified">Modified/Obfuscated</option>
-                                </select>
-                            </div>
-
-                            <div class="form-group">
-                                <label class="checkbox-label">
-                                    <input type="checkbox" id="dllSideloading" name="dllSideloading">
-                                    Enable DLL Sideloading
-                                </label>
-                            </div>
-
-                            <div id="sideloadingOptions" class="hidden">
-                                <div class="form-group">
-                                    <label for="sideloadDll">Sideload DLL Name</label>
-                                    <input type="text" id="sideloadDll" name="sideloadDll">
-                                </div>
-                                <div class="form-group">
-                                    <label for="exportName">Export Name</label>
-                                    <input type="text" id="exportName" name="exportName">
-                                </div>
                             </div>
                         </div>
 
@@ -138,19 +93,9 @@
                                 <small>Base score (0-100) to transition into Full OPSEC mode.</small>
                             </div>
                             <div class="form-group">
-                                <label for="base_threshold_exit_full_opsec">Score Threshold to Exit Full OPSEC / Enter Reduced</label>
-                                <input type="number" step="0.1" id="base_threshold_exit_full_opsec" name="base_threshold_exit_full_opsec" value="60.0" min="0" max="100">
-                                <small>Base score (0-100) to transition out of Full OPSEC mode (towards Reduced Activity).</small>
-                            </div>
-                             <div class="form-group">
                                 <label for="base_threshold_enter_reduced_activity">Score Threshold to Enter Reduced Activity</label>
                                 <input type="number" step="0.1" id="base_threshold_enter_reduced_activity" name="base_threshold_enter_reduced_activity" value="20.0" min="0" max="100">
                                 <small>Base score (0-100) to transition from Background to Reduced Activity.</small>
-                            </div>
-                            <div class="form-group">
-                                <label for="base_threshold_exit_reduced_activity">Score Threshold to Exit Reduced Activity / Enter Background</label>
-                                <input type="number" step="0.1" id="base_threshold_exit_reduced_activity" name="base_threshold_exit_reduced_activity" value="20.0" min="0" max="100">
-                                <small>Base score (0-100) to transition from Reduced Activity to Background.</small>
                             </div>
                             <div class="form-group">
                                 <label for="min_duration_full_opsec_secs">Min Duration in Full OPSEC (s)</label>
@@ -214,6 +159,7 @@
                         <span class="filesize"></span>
                     </div>
                     <button class="download-button">Download Payload</button>
+                    <a class="manifest-link action-button secondary" hidden>Inspect Build Manifest</a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

- whitelist the two operational payload profiles and fail unsupported or partial options before listener, credential, database, filesystem, or build work
- publish one deterministic artifact plus a versioned, credential-free manifest sourced from the exact Rust config embedded in the payload
- expose durable manifest inspection and artifact digest/link metadata through the API and operator UI
- document the supported matrix and require locked Rust dependency resolution

## Validation

- `go test ./internal/handlers/api/payload -count=1`
- `go vet ./internal/handlers/api/payload`
- Windows payload-package cross-compile
- `cargo check --locked`
- `cargo fmt --all -- --check`
- `node --test server/web/js/*.test.js`
- `node --check server/web/js/payload.js`
- `git diff --check`

Targets `dev` only; no `main` promotion.

Closes #99