### PR TITLE
docs(payload): audit configuration safety and reproducibility

### DIFF
--- a/docs/payload-builds.md
+++ b/docs/payload-builds.md
@@ -40,6 +40,49 @@ OPSEC entry thresholds from 0 through 100 with the Reduced Activity threshold
 strictly below the Full OPSEC threshold. An omitted SOCKS5 host and port resolve
 to `127.0.0.1:9050`; an omitted sleep technique resolves to `standard`.
 
+## Configuration resolution and fallback boundary
+
+Payload requests are bounded to one JSON value and reject unknown fields. The
+decoder preloads the existing OPSEC defaults (scan interval `300`, entry
+thresholds `60`/`20`, durations `300`/`120`/`60`, reduced sleep `120`, and C2
+values `5`, `1.1`, `0.9`, `3600`, and `2`) before decoding. Consequently,
+omitted OPSEC settings receive those defaults, while explicit zero values
+overwrite them and remain subject to validation. The resolver separately maps
+an empty sleep technique to `standard`, an empty SOCKS5 host or zero port to
+`127.0.0.1:9050`, and `max_sessions: 0` to one.
+
+The request must identify a listener, select `agent` or `debugAgent`, select a
+supported architecture/format pair, and provide a positive sleep interval. It
+rejects unsupported profiles, indirect syscalls, custom sleep techniques, all
+DLL-sideload fields, nonzero reserved OPSEC exit thresholds, and invalid
+network or numeric ranges. The server, rather than the request, resolves the
+authoritative listener endpoint and transport, creates the payload identity and
+ephemeral enrollment credential, pins build jitter and transport-safety flags,
+and generates a mutation seed when one is not supplied.
+
+`build.rs` treats any nonempty member of `LISTENER_HOST`, `LISTENER_PORT`,
+`SERVER_URL`, `LISTENER_ID`, `PAYLOAD_ID`, or `ENROLLMENT_CREDENTIAL` as
+production input. That path requires the complete set, a canonical credential,
+and a build nonce; it does not fill a partial production configuration from
+fallback values. When none is present, the hardcoded development fallback has
+blank server URL, listener and payload identities, and enrollment credential,
+so it is unusable for a server connection or enrollment.
+
+Resolved request values are embedded at build time. At startup, the agent
+deobfuscates and validates that embedded configuration, then rejects any
+runtime argument: runtime C2 URL overrides are disabled and require rebuilding
+the payload for a different listener.
+
+For a server build, `build.rs` removes `enrollment_credential` before exporting
+the expected private per-build effective-config file. The server accepts that
+file only when `payload_id`, `listener_id`, and `mutation_seed` match the build
+and its `protocol` is independently `http` or `https`; it rejects both an
+`enrollment_credential` field and the current credential bytes anywhere in the
+JSON. The exact credential-free bytes are then published as `config.json` and
+recorded with their digest in provenance. The raw credential is absent from
+those files, API responses, and logs; enrollment state retains only its hash
+and provenance records `server-generated-ephemeral`.
+
 ## Deterministic Output
 
 Each accepted build publishes exactly one artifact beneath the configured

--- a/server/internal/handlers/api/payload/build_contract_test.go
+++ b/server/internal/handlers/api/payload/build_contract_test.go
@@ -454,6 +454,95 @@ func TestManifestUsesExactCredentialFreeConfigExportedByBuild(t *testing.T) {
 	}
 }
 
+func TestReadEffectiveBuildConfigRejectsCredentialMaterial(t *testing.T) {
+	const (
+		payloadID    = "payload-test"
+		listenerID   = "listener-test"
+		mutationSeed = "0123456789abcdef"
+		relativePath = "effective-config.json"
+	)
+	// Base64url for a synthetic 32-byte all-zero credential.
+	credential := strings.Repeat("A", 43)
+	const credentialError = "effective build config contains enrollment credential material"
+
+	testCases := []struct {
+		name    string
+		config  map[string]interface{}
+		wantErr string
+	}{
+		{
+			name: "credential-free identity-matching control",
+			config: map[string]interface{}{
+				"payload_id":    payloadID,
+				"listener_id":   listenerID,
+				"mutation_seed": mutationSeed,
+				"protocol":      "https",
+			},
+		},
+		{
+			name: "enrollment credential field",
+			config: map[string]interface{}{
+				"payload_id":            payloadID,
+				"listener_id":           listenerID,
+				"mutation_seed":         mutationSeed,
+				"protocol":              "https",
+				"enrollment_credential": "not-the-test-credential",
+			},
+			wantErr: credentialError,
+		},
+		{
+			name: "credential bytes elsewhere",
+			config: map[string]interface{}{
+				"payload_id":    payloadID,
+				"listener_id":   listenerID,
+				"mutation_seed": mutationSeed,
+				"protocol":      "https",
+				"note":          credential,
+			},
+			wantErr: credentialError,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			buildRoot := t.TempDir()
+			configJSON, err := json.Marshal(testCase.config)
+			if err != nil {
+				t.Fatalf("marshal effective config: %v", err)
+			}
+			if err := os.WriteFile(
+				filepath.Join(buildRoot, relativePath),
+				configJSON,
+				0o600,
+			); err != nil {
+				t.Fatalf("write effective config: %v", err)
+			}
+
+			_, err = readEffectiveBuildConfig(
+				buildRoot,
+				relativePath,
+				payloadID,
+				listenerID,
+				mutationSeed,
+				credential,
+			)
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("read credential-free effective config: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != testCase.wantErr {
+				t.Fatalf(
+					"read effective config error = %v, want %q",
+					err,
+					testCase.wantErr,
+				)
+			}
+		})
+	}
+}
+
 func validPayloadBuildConfig() PayloadConfig {
 	config := defaultPayloadRequestConfig()
 	config.ListenerID = "listener-one"


### PR DESCRIPTION
Closes #65

## Changes
- Document the existing request-resolution, build-time/runtime, production-fallback, and credential-free provenance boundary in `docs/payload-builds.md`.
- Add focused `readEffectiveBuildConfig` coverage in `server/internal/handlers/api/payload/build_contract_test.go` for a credential-free control plus credential-key and raw-credential-byte rejection.

## Boundary
No production behavior or runtime override was added. Effective config must match the build payload/listener/mutation seed; protocol is independently restricted to `http`/`https`; credentials are stripped or rejected before `config.json` and provenance publication.

## Validation
- `go test -count=1 -run '^TestReadEffectiveBuildConfigRejectsCredentialMaterial$' ./internal/handlers/api/payload` in `server/`
- `go test ./...` in `server/`
- `go vet ./...` in `server/`