### PR TITLE
docs(readme): link health telemetry documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This framework can be used to:
 - [Durable storage, recovery, and backup](docs/storage.md)
 - [Roadmap](docs/roadmap.md)
 - [Development workflow and CI](docs/development-workflow.md)
+- [Health, readiness, and runtime telemetry](docs/health-telemetry.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the root README link to the existing health, readiness, and runtime telemetry documentation.
- Keeps endpoint semantics, commands, and verification guidance in the canonical linked document.

## Scope
Documentation discovery only; no runtime behavior, configuration, API, or test-suite change.