### PR TITLE
[CI] Add focused Go race-detector gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Race (focused)
+        run: go test -race ./internal/enrollment ./internal/listeners ./internal/tasks ./internal/behaviour
+
       - name: Vet
         run: go vet ./...
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -50,7 +50,9 @@ It also enforces that pull requests into `main` come from `dev`.
 
 ## Context-Aware Suites
 
-- Server changes run `Go Server`: `go test ./...`, `go vet ./...`, and a server
+- Server changes run `Go Server`: `go test ./...`, a focused
+  `go test -race ./internal/enrollment ./internal/listeners ./internal/tasks ./internal/behaviour`,
+  `go vet ./...`, and a server
   build on Linux, plus `Go Server (Windows)` tests and a native Windows build.
 - Agent changes run `Rust Agent`: `cargo test --locked`,
   `cargo clippy --locked --all-targets`, and `cargo build --locked` on Linux,
@@ -80,6 +82,7 @@ Useful local equivalents before opening a pull request:
 ```sh
 cd server
 go test ./...
+go test -race ./internal/enrollment ./internal/listeners ./internal/tasks ./internal/behaviour
 go vet ./...
 go build -o /tmp/microc2-server ./cmd
 ```


### PR DESCRIPTION
Closes #119

- Adds a focused Linux race-detector step (`go test -race ./internal/enrollment ./internal/listeners ./internal/tasks ./internal/behaviour`) to the existing `Go Server` job, between `Test` and `Vet`.
- Docs (`docs/development-workflow.md`) now list the exact local command in Context-Aware Suites and Local Checks.

Validation (from `server/`):
- `go test -race ./internal/enrollment ./internal/listeners ./internal/tasks ./internal/behaviour` — 4 packages ok
- `go test ./...` — 16 packages ok, 2 no tests
- `go vet ./...` — clean
- `go build -o /tmp/microc2-server ./cmd` — ok

Scope: Windows job, path-based job selection, CI Gate, and runtime behavior are unchanged.