### PR TITLE
test(contracts): add shared v1 contract conformance vectors

### DIFF
--- a/agent/src/tasks.rs
+++ b/agent/src/tasks.rs
@@ -647,4 +647,83 @@ mod tests {
         task.arguments.command = "é".repeat(MAX_SHELL_COMMAND_CHARS + 1);
         assert!(task.validate_for_agent("agent-one").is_err());
     }
+
+    #[test]
+    fn v1_contract_conformance_vectors() {
+        const CORPUS: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../docs/schemas/contract-vectors-v1.json"
+        ));
+
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct VectorEntry {
+            id: String,
+            schema_target: String,
+            expected: String,
+            value: serde_json::Value,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Corpus {
+            schema_version: u32,
+            vectors: Vec<VectorEntry>,
+        }
+
+        let corpus: Corpus =
+            serde_json::from_str(CORPUS).expect("deserialize contract vectors corpus");
+
+        assert_eq!(corpus.schema_version, 1, "corpus schema_version must be 1");
+        assert!(
+            !corpus.vectors.is_empty(),
+            "corpus vectors must be nonempty"
+        );
+
+        let mut seen = std::collections::HashSet::new();
+        for v in &corpus.vectors {
+            assert!(!v.id.is_empty(), "vector id must be nonempty");
+            assert!(seen.insert(&v.id), "duplicate vector id {:?}", v.id);
+
+            assert!(
+                v.schema_target == "task-result-v1.schema.json"
+                    || v.schema_target == "task-status-update-v1.schema.json",
+                "unknown schema_target {:?} in vector {:?}",
+                v.schema_target,
+                v.id
+            );
+
+            assert!(
+                v.expected == "accept" || v.expected == "reject",
+                "invalid expected value {:?} in vector {:?}",
+                v.expected,
+                v.id
+            );
+        }
+
+        for v in &corpus.vectors {
+            let accepted = match v.schema_target.as_str() {
+                "task-result-v1.schema.json" => {
+                    match serde_json::from_value::<TaskResult>(v.value.clone()) {
+                        Ok(result) => result.validate().is_ok(),
+                        Err(_) => false,
+                    }
+                }
+                "task-status-update-v1.schema.json" => {
+                    match serde_json::from_value::<TaskStatusUpdate>(v.value.clone()) {
+                        Ok(update) => update.validate().is_ok(),
+                        Err(_) => false,
+                    }
+                }
+                _ => unreachable!("schema_target already validated"),
+            };
+
+            let want_accept = v.expected == "accept";
+            assert_eq!(
+                accepted, want_accept,
+                "vector {:?} target {}: expected accepted={}, got accepted={}",
+                v.id, v.schema_target, want_accept, accepted
+            );
+        }
+    }
 }

--- a/docs/schemas/contract-vectors-v1.json
+++ b/docs/schemas/contract-vectors-v1.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": 1,
+  "vectors": [
+    {
+      "id": "cv-result-completed-accept",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "accept",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "outcome": "completed",
+        "started_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "exit_code": 0,
+        "output": {"stdout": "fixture", "stderr": ""}
+      }
+    },
+    {
+      "id": "cv-result-failed-accept",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "accept",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-02",
+        "agent_id": "cv-agent-01",
+        "outcome": "failed",
+        "started_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:03Z",
+        "exit_code": 1,
+        "output": {"stdout": "", "stderr": "fixture error output"},
+        "error": "command not found"
+      }
+    },
+    {
+      "id": "cv-status-running-accept",
+      "schema_target": "task-status-update-v1.schema.json",
+      "expected": "accept",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "status": "running",
+        "timestamp": "2026-07-28T10:00:00Z"
+      }
+    },
+    {
+      "id": "cv-result-missing-output-reject",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "reject",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "outcome": "completed",
+        "started_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "exit_code": 0
+      }
+    },
+    {
+      "id": "cv-result-unknown-field-reject",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "reject",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "outcome": "completed",
+        "started_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "exit_code": 0,
+        "output": {"stdout": "", "stderr": ""},
+        "future_field": true
+      }
+    },
+    {
+      "id": "cv-result-unsupported-version-reject",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "reject",
+      "value": {
+        "schema_version": 2,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "outcome": "completed",
+        "started_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "exit_code": 0,
+        "output": {"stdout": "", "stderr": ""}
+      }
+    },
+    {
+      "id": "cv-result-invalid-identifier-reject",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "reject",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv/agent",
+        "outcome": "completed",
+        "started_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "exit_code": 0,
+        "output": {"stdout": "", "stderr": ""}
+      }
+    },
+    {
+      "id": "cv-result-invalid-timestamp-reject",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "reject",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "outcome": "completed",
+        "started_at": "not-a-timestamp",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "exit_code": 0,
+        "output": {"stdout": "", "stderr": ""}
+      }
+    },
+    {
+      "id": "cv-result-empty-error-completed-reject",
+      "schema_target": "task-result-v1.schema.json",
+      "expected": "reject",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "outcome": "completed",
+        "started_at": "2026-07-28T10:00:00Z",
+        "completed_at": "2026-07-28T10:00:01Z",
+        "exit_code": 0,
+        "output": {"stdout": "", "stderr": ""},
+        "error": ""
+      }
+    },
+    {
+      "id": "cv-status-non-running-reject",
+      "schema_target": "task-status-update-v1.schema.json",
+      "expected": "reject",
+      "value": {
+        "schema_version": 1,
+        "task_id": "cv-task-01",
+        "agent_id": "cv-agent-01",
+        "status": "completed",
+        "timestamp": "2026-07-28T10:00:00Z"
+      }
+    }
+  ]
+}

--- a/server/internal/tasks/model_test.go
+++ b/server/internal/tasks/model_test.go
@@ -258,3 +258,87 @@ func TestIdentifierValidationUsesCanonicalASCIIAlphabet(t *testing.T) {
 		}
 	}
 }
+
+func TestV1ContractConformanceVectors(t *testing.T) {
+	corpusPath := filepath.Join("..", "..", "..", "docs", "schemas", "contract-vectors-v1.json")
+	data, err := os.ReadFile(corpusPath)
+	if err != nil {
+		t.Fatalf("read contract vectors corpus: %v", err)
+	}
+
+	type vectorEntry struct {
+		ID           string          `json:"id"`
+		SchemaTarget string          `json:"schema_target"`
+		Expected     string          `json:"expected"`
+		Value        json.RawMessage `json:"value"`
+	}
+	var raw struct {
+		SchemaVersion int           `json:"schema_version"`
+		Vectors       []vectorEntry `json:"vectors"`
+	}
+	if err := decodeStrictBytes(data, &raw); err != nil {
+		t.Fatalf("decode contract vectors corpus: %v", err)
+	}
+
+	if raw.SchemaVersion != 1 {
+		t.Fatalf("corpus schema_version must be 1, got %d", raw.SchemaVersion)
+	}
+	if len(raw.Vectors) == 0 {
+		t.Fatal("corpus vectors must be nonempty")
+	}
+
+	seen := make(map[string]bool)
+	for _, v := range raw.Vectors {
+		if v.ID == "" {
+			t.Fatal("vector id must be nonempty")
+		}
+		if seen[v.ID] {
+			t.Fatalf("duplicate vector id %q", v.ID)
+		}
+		seen[v.ID] = true
+
+		switch v.SchemaTarget {
+		case "task-result-v1.schema.json", "task-status-update-v1.schema.json":
+		default:
+			t.Fatalf("unknown schema_target %q in vector %q", v.SchemaTarget, v.ID)
+		}
+
+		switch v.Expected {
+		case "accept", "reject":
+		default:
+			t.Fatalf("invalid expected value %q in vector %q", v.Expected, v.ID)
+		}
+
+		if len(v.Value) == 0 || !json.Valid(v.Value) {
+			t.Fatalf("vector %q has missing or invalid JSON value", v.ID)
+		}
+	}
+
+	for _, v := range raw.Vectors {
+		t.Run(v.ID, func(t *testing.T) {
+			var accepted bool
+			switch v.SchemaTarget {
+			case "task-result-v1.schema.json":
+				var result Result
+				if err := json.Unmarshal(v.Value, &result); err != nil {
+					accepted = false
+				} else {
+					err := result.validate(result.AgentID)
+					accepted = err == nil
+				}
+			case "task-status-update-v1.schema.json":
+				var update StatusUpdate
+				if err := decodeStrictBytes(v.Value, &update); err != nil {
+					accepted = false
+				} else {
+					err := update.validate(update.AgentID, update.TaskID)
+					accepted = err == nil
+				}
+			}
+			wantAccept := v.Expected == "accept"
+			if accepted != wantAccept {
+				t.Fatalf("vector %q target %s: expected accepted=%v, got accepted=%v", v.ID, v.SchemaTarget, wantAccept, accepted)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #122

## Summary
- Add one inert, versioned JSON corpus of v1 result and status-update accept/reject vectors.
- Run the same corpus through the existing Go and Rust contract validators.
- Keep runtime behavior, schemas, dependencies, and CI workflow unchanged.

## Validation
- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/microc2-server-122-review ./cmd`
- `cargo test --locked` — 82 passed
- `cargo clippy --locked --all-targets`
- `cargo build --locked`
- `cargo fmt --check`
- `node docs/schemas/validate-examples.js`
