### PR TITLE
docs(research): add pinned defensive evidence categories

### DIFF
--- a/docs/research/defensive-research-categories.md
+++ b/docs/research/defensive-research-categories.md
@@ -1,0 +1,51 @@
+## Defensive Research Categories
+
+The defensive research category registry (`defensive-research-categories-v1`) is the single source of truth for classifying redacted and synthetic defensive research evidence. Categories classify only redacted or synthetic defensive evidence and never describe operations, tradecraft, or capabilities. Every category encodes a bounded defensive-purpose description, a closed set of permitted evidence classes, and the full seven-item excluded-surface set.
+
+### Purpose
+
+- **Classification, not mapping.** The registry enumerates abstract defensive research categories. It contains no product names, ATT&CK technique identifiers, payload paths, agent identifiers, server endpoints, or raw event data.
+- **Evidence-only scope.** Every category exists exclusively to classify redacted or synthetic defensive research evidence—never to enumerate offensive capabilities or operational tradecraft.
+
+### Immutable-Publication Policy
+
+  - Every published `registry_version` is immutable. Semantic changes require a new exact registry version.
+  - Consumers **MUST** pin an exact `registry_id` + `registry_version` pair. References that omit or mismatch the published pair are invalid. Consumers never use version ranges or implicit upgrades.
+  - Category IDs are never reused or repurposed across any version. Renaming or renumbering requires a new registry version.
+
+### Exact-Version-Pin Compatibility Rule
+
+A consumer reference (`defensive-research-category-reference-v1`) declares:
+
+1. The exact `registry_id` (`microc2-defensive-research-categories`).
+2. The exact `registry_version` semantic version string.
+3. A syntactically valid `category_id` that the consumer asserts exists in that registry version.
+
+Automated validation can (and should) reject references where the `category_id` is not present in the pinned registry. This is enforced in the schema test suite via a deterministic semantic helper.
+
+### Forbidden-Surface Semantics
+
+Every category includes the full seven-item `excluded_surfaces` set:
+
+- `agent`
+- `payload`
+- `tasking`
+- `transport`
+- `evasion`
+- `credentials`
+- `live_control`
+
+These surfaces are **never** in scope for any defensive research category. The `excluded_surfaces` set is **closed**—no other values are permitted—and **always present** at cardinality 7. This is a structural invariant of the registry schema, not a runtime policy.
+
+### Relationship to Future Work
+
+- **Issue #123 (detection-measurement rubric)** may reference categories from this registry to scope what is measured and how.
+- **Issue #124 (redacted experiment-evidence package manifest)** may record a pinned category reference in its package metadata.
+- Neither issue requires changes to the registry itself; they consume it as a pinned, immutable reference.
+
+### What This Registry Is Not
+
+- **Not the R1 lab protocol.** The R1 mutation-engine research document (`docs/research/r1-mutation-engine.md`) and measurement protocol (`docs/research/r1-measurement-protocol.md`) are separate, lab-scoped artifacts.
+- **Not a manifest.** This file is documentation for a JSON Schema artifact; the authoritative shape lives in `docs/schemas/defensive-research-categories-v1.schema.json`.
+- **Contains no mappings.** No C2 capability → category mapping, no ATT&CK mapping, no surface → evidence mapping.
+- **Introduces no runtime behavior.** This is a static schema registry; adding, removing, or changing categories has no effect on the MicroC2 server, agent, or transport.

--- a/docs/schemas/defensive-research-categories-v1.schema.json
+++ b/docs/schemas/defensive-research-categories-v1.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/defensive-research-categories-v1.schema.json",
+  "title": "MicroC2 Defensive Research Categories Registry v1",
+  "description": "Immutable, closed-category registry for redacted defensive research evidence classification. Every published registry_version is immutable; semantic changes require a new exact registry version. Consumers pin by registry_id + registry_version and never use ranges or implicit upgrades.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "registry_id",
+    "registry_version",
+    "schema_version",
+    "categories"
+  ],
+  "properties": {
+    "registry_id": {
+      "const": "microc2-defensive-research-categories"
+    },
+    "registry_version": {
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/category"
+      }
+    }
+  },
+  "$defs": {
+    "category": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "purpose",
+        "allowed_evidence_classes",
+        "excluded_surfaces"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*$",
+          "minLength": 2,
+          "maxLength": 64,
+          "description": "Stable, immutable category identifier (kebab-case)."
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Short human-readable category label."
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "description": "Defensive-purpose description of what this category covers and why it is studied."
+        },
+        "allowed_evidence_classes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "redacted-observation-summary",
+              "aggregate-measurement-summary",
+              "integrity-metadata",
+              "synthetic-control-summary"
+            ]
+          },
+          "description": "Closed set of evidence classes permitted for this category."
+        },
+        "excluded_surfaces": {
+          "type": "array",
+          "minItems": 7,
+          "maxItems": 7,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "agent",
+              "payload",
+              "tasking",
+              "transport",
+              "evasion",
+              "credentials",
+              "live_control"
+            ]
+          },
+          "description": "Fixed seven-item set enumerating every category-excluded surface."
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/defensive-research-category-reference-v1.schema.json
+++ b/docs/schemas/defensive-research-category-reference-v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/defensive-research-category-reference-v1.schema.json",
+  "title": "MicroC2 Defensive Research Category Reference v1",
+  "description": "Static reference pinning an exact registry version and a single category within it. Not a runtime manifest or contract—consumers use it to declare which category they reference.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "registry_id",
+    "registry_version",
+    "category_id"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "registry_id": {
+      "const": "microc2-defensive-research-categories"
+    },
+    "registry_version": {
+      "const": "1.0.0"
+    },
+    "category_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*$",
+      "minLength": 2,
+      "maxLength": 64,
+      "description": "Syntactically valid category identifier; resolvable only against the pinned registry version."
+    }
+  }
+}

--- a/docs/schemas/examples/defensive-research-categories-v1.json
+++ b/docs/schemas/examples/defensive-research-categories-v1.json
@@ -1,0 +1,28 @@
+{
+  "registry_id": "microc2-defensive-research-categories",
+  "registry_version": "1.0.0",
+  "schema_version": 1,
+  "categories": [
+    {
+      "id": "integrity-metadata",
+      "label": "Integrity Metadata",
+      "purpose": "Characterise the tamper-evidence and reproducibility properties of redacted observation artifacts by comparing structural metadata across measurement runs.",
+      "allowed_evidence_classes": ["integrity-metadata", "redacted-observation-summary"],
+      "excluded_surfaces": ["agent", "payload", "tasking", "transport", "evasion", "credentials", "live_control"]
+    },
+    {
+      "id": "defensive-observation-summary",
+      "label": "Defensive Observation Summary",
+      "purpose": "Aggregate redacted sensor observations to identify baseline patterns useful for defensive classification research without exposing raw collection data.",
+      "allowed_evidence_classes": ["redacted-observation-summary", "aggregate-measurement-summary"],
+      "excluded_surfaces": ["agent", "payload", "tasking", "transport", "evasion", "credentials", "live_control"]
+    },
+    {
+      "id": "coverage-summary",
+      "label": "Coverage Summary",
+      "purpose": "Summarise the defensive-surface coverage achieved by a set of synthetic control measurements, providing a gap-analysis baseline without enumerating individual collection points.",
+      "allowed_evidence_classes": ["synthetic-control-summary", "aggregate-measurement-summary"],
+      "excluded_surfaces": ["agent", "payload", "tasking", "transport", "evasion", "credentials", "live_control"]
+    }
+  ]
+}

--- a/docs/schemas/examples/defensive-research-category-reference-v1.json
+++ b/docs/schemas/examples/defensive-research-category-reference-v1.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "registry_id": "microc2-defensive-research-categories",
+  "registry_version": "1.0.0",
+  "category_id": "integrity-metadata"
+}

--- a/docs/schemas/validate-examples.js
+++ b/docs/schemas/validate-examples.js
@@ -24,13 +24,15 @@ for (const file of schemaFiles) {
 
 const exampleSchemas = new Map([
     ['audit-page-v1.json', 'audit-page-v1.schema.json'],
+    ['defensive-research-categories-v1.json', 'defensive-research-categories-v1.schema.json'],
+    ['defensive-research-category-reference-v1.json', 'defensive-research-category-reference-v1.schema.json'],
     ['task-create-request-v1.json', 'task-create-request-v1.schema.json'],
     ['task-dispatched-v1.json', 'task-v1.schema.json'],
     ['task-page-v1.json', 'task-page-v1.schema.json'],
     ['task-result-failed-v1.json', 'task-result-v1.schema.json'],
     ['task-result-v1.json', 'task-result-v1.schema.json'],
     ['task-status-update-v1.json', 'task-status-update-v1.schema.json'],
-    ['task-v1.json', 'task-v1.schema.json']
+    ['task-v1.json', 'task-v1.schema.json'],
 ]);
 
 let failed = false;
@@ -465,11 +467,92 @@ for (const testCase of semanticStatusNegativeCases) {
     }
 }
 
+const registryExample = readJSON(path.join(exampleDirectory, 'defensive-research-categories-v1.json'));
+const referenceExample = readJSON(path.join(exampleDirectory, 'defensive-research-category-reference-v1.json'));
+
+const registryReferencePositiveCases = [
+    {name: 'registry structure', error: validateRegistry(registryExample)},
+    {name: 'reference structure', error: validateCategoryReference(referenceExample, registryExample)}
+];
+for (const testCase of registryReferencePositiveCases) {
+    if (testCase.error) {
+        console.error(`Defensive research contract failed positive case ${testCase.name}: ${testCase.error}`);
+        failed = true;
+    }
+}
+
+// Semantic negative: the duplicate-ID and unknown-category fixtures
+// satisfy their respective JSON Schemas; only the semantic helper
+// must reject them.  The mismatched-version reference is deliberately
+// schema-invalid (const mismatch) — the semantic helper must
+// independently reject it regardless.
+const registryNegativeCases = [
+    {
+        name: 'registry rejects duplicate category id',
+        kind: 'registry',
+        expectSchemaValid: true,
+        value: {
+            ...registryExample,
+            categories: [
+                ...registryExample.categories,
+                {
+                    ...registryExample.categories[0],
+                    label: 'Different Label',
+                    purpose: 'A completely different defensive research purpose for the duplicate-id negative test case.',
+                    allowed_evidence_classes: ['synthetic-control-summary']
+                }
+            ]
+        }
+    },
+    {
+        name: 'reference rejects unknown category id',
+        kind: 'reference',
+        expectSchemaValid: true,
+        value: {
+            ...referenceExample,
+            category_id: 'nonexistent-category'
+        }
+    },
+    {
+        name: 'reference rejects mismatched registry version',
+        kind: 'reference',
+        value: {
+            ...referenceExample,
+            registry_version: '2.0.0'
+        }
+    }
+];
+for (const testCase of registryNegativeCases) {
+    if (testCase.expectSchemaValid) {
+        const schemaId = testCase.kind === 'registry'
+            ? schemaID('defensive-research-categories-v1.schema.json')
+            : schemaID('defensive-research-category-reference-v1.schema.json');
+        const validateFn = ajv.getSchema(schemaId);
+        if (!validateFn) {
+            console.error(`Defensive research contract schema not loaded: ${schemaId}`);
+            failed = true;
+            continue;
+        }
+        if (!validateFn(testCase.value)) {
+            console.error(`Defensive research contract negative fixture ${testCase.name} must be schema-valid before semantic rejection but is not: ${ajv.errorsText(validateFn.errors)}`);
+            failed = true;
+            continue;
+        }
+    }
+    if (testCase.kind === 'registry') {
+        if (validateRegistry(testCase.value)) continue;
+    } else {
+        if (validateCategoryReference(testCase.value, registryExample)) continue;
+    }
+    console.error(`Defensive research contract failed negative case: ${testCase.name}`);
+    failed = true;
+}
+
 if (failed) {
     process.exitCode = 1;
 } else {
     console.log(
-        `Validated ${exampleFiles.length} examples, ${lifecyclePositiveCases.length} lifecycle states, ${negativeCases.length} schema-negative cases, and ${semanticNegativeCases.length + semanticStatusNegativeCases.length} semantic-negative cases against ${schemaFiles.length} Draft 2020-12 schemas.`
+        `Validated ${exampleFiles.length} examples, ${lifecyclePositiveCases.length} lifecycle states, ${negativeCases.length} schema-negative cases, ${semanticNegativeCases.length + semanticStatusNegativeCases.length} semantic-negative cases, ${registryReferencePositiveCases.length} registry-positive cases, and ${registryNegativeCases.length} registry-negative cases against ${schemaFiles.length} Draft 2020-12 schemas.`
     );
 }
 
@@ -548,6 +631,28 @@ function validateStatusTimestamp(update) {
     }
     if (timestamp === Date.parse('0001-01-01T00:00:00Z')) {
         return 'timestamp must not be the zero instant';
+    }
+    return '';
+}
+
+function validateRegistry(registry) {
+    const ids = new Set();
+    for (const cat of registry.categories) {
+        if (ids.has(cat.id)) {
+            return `duplicate category id ${cat.id}`;
+        }
+        ids.add(cat.id);
+    }
+    return '';
+}
+
+function validateCategoryReference(ref, registry) {
+    if (ref.registry_id !== registry.registry_id || ref.registry_version !== registry.registry_version) {
+        return `reference pins ${ref.registry_id}@${ref.registry_version} but registry is ${registry.registry_id}@${registry.registry_version}`;
+    }
+    const catIds = new Set(registry.categories.map(c => c.id));
+    if (!catIds.has(ref.category_id)) {
+        return `referenced category_id ${ref.category_id} is not present in the pinned registry`;
     }
     return '';
 }


### PR DESCRIPTION
Closes #121

## Summary
- Add a version-pinned, immutable registry for redacted and synthetic defensive research evidence.
- Validate exact references plus duplicate and unknown category rejection without runtime behavior.
- Keep operational surfaces, task/module/ATT&CK mappings, and live control outside the contract.

## Validation
- `node --check docs/schemas/validate-examples.js`
- JSON parse sweep for `docs/schemas/*.json` and `docs/schemas/examples/*.json`
- `NODE_PATH=/Users/darkroom/Projects/node_modules node docs/schemas/validate-examples.js`
- `git diff --check`