### PR TITLE
[Docs] Define a multidimensional defensive detection-measurement rubric

### DIFF
--- a/docs/research/defensive-research-detection-measurement-rubric.md
+++ b/docs/research/defensive-research-detection-measurement-rubric.md
@@ -1,0 +1,162 @@
+# Defensive Research Detection-Measurement Rubric
+
+## Version and Immutability
+
+- **Rubric ID**: `microc2-defensive-research-detection-measurement-rubric`
+- **Rubric version**: `1.0.0`
+- **Schema version**: `1`
+
+This rubric is **immutable at its published version**. Any semantic change (dimension addition, removal, redefinition, or evidence-class change) requires a new exact version. Consumers pin by `rubric_id` + `rubric_version` and MUST NOT use ranges or implicit upgrades. The `schema_version` tracks the JSON Schema document version independently.
+
+## Scope and Purpose
+
+This rubric defines a versioned, evidence-only framework for interpreting saved or synthetic defensive observations across five dimensions. It is a **static measurement contract**, not an operational tool. It contains no products, executors, payloads, agents, tasking instructions, telemetry-capture mechanics, raw evidence, endpoints, commands, run instructions, ATT&CK mappings, task/module mappings, or evasion guidance.
+
+### Distinction from the R1 Lab Scaffold
+
+The R1 lab scaffold (`docs/research/r1-measurement-protocol.md`, `docs/research/r1-mutation-engine.md`) defines **operational** measurement procedures: how to configure, execute, and collect from measurement trials. This rubric defines the **interpretive** framework that governs how those collected observations are assessed and compared. The R1 scaffold produces observations; this rubric grades them.
+
+### Distinction from the Defensive Research Categories Registry
+
+The [defensive research categories registry](./defensive-research-categories.md) defines **what** evidence can be classified and under which categories. This rubric defines **how** classified evidence is measured and interpreted across dimensions. Each dimension pins a category reference to the registry, inheriting that category's allowed evidence classes and excluded surfaces.
+
+## Five Dimensions
+
+### 1. Provenance
+
+**Category**: `integrity-metadata`
+
+Provenance assesses the tamper-evidence and reproducibility properties of redacted observation artifacts by comparing structural metadata across measurement runs. It establishes whether observation metadata can be independently reconstructed and whether structural tampering would be detectable.
+
+**Admissible evidence**: integrity-metadata (subset of the pinned category's allowed classes).
+
+**Invalid handling**: Evidence with corrupt or unverifiable integrity metadata is rejected (reject-assessment).
+
+**Unknown handling**: Missing provenance metadata is reported as unknown (report-as-unknown).
+
+**Uncertainty**: A level with rationale is required for every provenance assessment.
+
+**Comparability**: Provenance comparisons are valid only between measurement runs that share the same observation-artifact schema version. Cross-schema provenance comparisons require explicit normalisation.
+
+### 2. Collection Coverage
+
+**Category**: `coverage-summary`
+
+Collection coverage summarises the defensive-surface coverage achieved by a set of synthetic control measurements, providing a gap-analysis baseline without enumerating individual collection points.
+
+**Admissible evidence**: synthetic-control-summary (subset of the pinned category's allowed classes).
+
+**Invalid handling**: Evidence with unresolvable surface identifiers is downgraded to unknown (downgrade-to-unknown).
+
+**Unknown handling**: Gaps where data existence cannot be confirmed are reported as unknown (report-as-unknown).
+
+**Uncertainty**: A level with rationale is required.
+
+**Comparability**: Collection-coverage comparisons require the same defensive-surface inventory. Differing inventories demand a normalised coverage metric with explicit inventory mapping.
+
+### 3. Validity
+
+**Category**: `defensive-observation-summary`
+
+Validity aggregates redacted sensor observations to identify whether observed patterns are consistent with the expected defensive-signal model. It determines whether the synthetic observation method produces measurements distinguishable from noise.
+
+**Admissible evidence**: redacted-observation-summary (subset of the pinned category's allowed classes).
+
+**Invalid handling**: Evidence that fails the validity threshold is rejected (reject-assessment).
+
+**Unknown handling**: Dimensions with absent validity evidence are excluded from comparative analysis (exclude-from-comparison).
+
+**Uncertainty**: A discrete level is required (level).
+
+**Comparability**: Validity comparisons are valid only for measurements using identical synthetic-observation parameters.
+
+### 4. Uncertainty
+
+**Category**: `defensive-observation-summary`
+
+Uncertainty characterises the quantification limits and confidence bounds of aggregate measurements, identifying systematic and random error sources that affect reliability without exposing raw collection data.
+
+**Admissible evidence**: aggregate-measurement-summary (subset of the pinned category's allowed classes).
+
+**Invalid handling**: Evidence with unquantifiable error bounds is downgraded to unknown (downgrade-to-unknown).
+
+**Unknown handling**: Absent uncertainty characterisations are reported as unknown (report-as-unknown).
+
+**Uncertainty**: A level with rationale is required for the uncertainty dimension itself (level-with-rationale).
+
+**Comparability**: Uncertainty characterisations are valid for comparison only when the measurement protocol, sensor configuration, and aggregation method are held constant.
+
+### 5. Missing / Unknown Data
+
+**Category**: `coverage-summary`
+
+Missing-unknown-data identifies and classifies observational gaps where expected defensive evidence is absent, incomplete, or cannot be confirmed. It distinguishes between known gaps (data expected but absent) and unknown gaps (data whose existence cannot be confirmed), establishing the completeness boundary of a measurement run.
+
+**Admissible evidence**: aggregate-measurement-summary (subset of the pinned category's allowed classes).
+
+**Invalid handling**: Evidence with indeterminate gap classification is downgraded to unknown (downgrade-to-unknown).
+
+**Unknown handling**: This dimension MUST use `report-as-unknown`. Unknown gaps are the dimension's subject matter and cannot be excluded from analysis.
+
+**Uncertainty**: A level with rationale is required (level-with-rationale).
+
+**Comparability**: Missing-unknown-data comparisons require identical surface inventories and observation expectations. Normalise to a common surface inventory before comparison.
+
+## Admissible Evidence
+
+Evidence is admissible for a dimension only when:
+
+1. It belongs to an evidence class listed in that dimension's `admissible_evidence_classes`.
+2. That evidence class is a subset of the pinned category's `allowed_evidence_classes` in the defensive research categories registry.
+3. All surfaces enumerated in the pinned category's `excluded_surfaces` are absent from the evidence.
+
+Evidence that does not meet these criteria is invalid and handled according to the dimension's `invalid_handling` policy.
+
+## Invalid vs Unknown Semantics
+
+- **Invalid evidence**: Evidence that is present but known to be corrupt, unverifiable, or out-of-scope for the dimension. Handled by `reject-assessment` (the observation must not contribute) or `downgrade-to-unknown` (reclassified as unknown).
+- **Unknown evidence**: Evidence whose existence, completeness, or provenance cannot be confirmed. Handled by `report-as-unknown` (the absence is recorded) or `exclude-from-comparison` (the dimension is omitted from comparative analysis).
+
+Invalid and unknown are distinct: invalid means "present but unusable"; unknown means "cannot confirm presence or absence."
+
+## Uncertainty Disclosure
+
+Every dimension MUST disclose uncertainty:
+
+- `level`: A discrete uncertainty level (e.g., low/medium/high) must be assigned.
+- `level-with-rationale`: Both a level and a written rationale describing the dominant error sources are required.
+
+There is no `none` option. Uncertainty cannot be opted out of.
+
+## Reporting Requirements
+
+Each dimension defines a `reporting_requirement` specifying what must be included in assessment reports: the required content, format constraints, and any per-dimension specificity. Reports that omit required content are incomplete.
+
+## Comparability Limits
+
+Each dimension defines a `comparability_limit` specifying what comparisons are valid across measurement runs. Comparisons that violate a dimension's limit are invalid and must not be presented as equivalent. Cross-run comparisons require explicit preconditions to be satisfied.
+
+## Inherited Category Exclusions
+
+Each dimension inherits the excluded surfaces from its pinned category in the defensive research categories registry. All seven surfaces — agent, payload, tasking, transport, evasion, credentials, live_control — are excluded from every dimension. No observation may contain or reference any of these surfaces.
+
+## No-Evasion Rule
+
+This rubric MUST NOT be used to design, evaluate, or grade evasion techniques. Dimensions, evidence classes, and assessment procedures are defined exclusively for defensive research observations. Any use that incorporates evasion analysis or evasion-effectiveness measurement is out of scope and invalid.
+
+## No Single-Verdict Rule
+
+This rubric MUST NOT produce a single composite score, pass/fail verdict, or aggregated safety rating. Each dimension is assessed independently. Combining dimensions into a single verdict conceals the trade-offs and uncertainty that the rubric is designed to expose. Consumers MAY present all five dimension assessments together but MUST NOT reduce them to a single claim.
+
+## Relationship to Issue #124
+
+Issue #124 (upcoming) defines a redacted experiment-evidence package manifest for measurement-trial packages. That manifest MAY pin this rubric by `rubric_id` + `rubric_version` to declare which interpretive framework governs the contained observations. This rubric does not create, validate, or reference any package, manifest, or evidence record. The dependency is one-way: #124 may point here; this rubric points only to the defensive research categories registry.
+
+## Validation
+
+A JSON Schema (Draft 2020-12) for this rubric is available at:
+
+- Schema: `docs/schemas/defensive-research-detection-measurement-rubric-v1.schema.json`
+- Example: `docs/schemas/examples/defensive-research-detection-measurement-rubric-v1.json`
+
+The static validator at `docs/schemas/validate-examples.js` enforces both schema conformance and semantic contracts (dimension ID set completeness, category reference resolution, evidence-class subset validation, and missing-unknown-data handling enforcement).

--- a/docs/schemas/defensive-research-detection-measurement-rubric-v1.schema.json
+++ b/docs/schemas/defensive-research-detection-measurement-rubric-v1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://microc2.local/schemas/defensive-research-detection-measurement-rubric-v1.schema.json",
+  "title": "MicroC2 Defensive Research Detection-Measurement Rubric v1",
+  "description": "Versioned, evidence-only rubric for interpreting saved or synthetic defensive observations across five immutable dimensions: provenance, collection-coverage, validity, uncertainty, and missing-unknown-data. Each dimension pins a category reference to the microc2-defensive-research-categories registry. The rubric defines admissible evidence classes, invalid/unknown handling semantics, uncertainty disclosure requirements, reporting requirements, and comparability limits. This rubric does not prescribe products, executors, payloads, agents, tasking, telemetry capture, or run instructions. It forbids evasion guidance and single-verdict claims.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "rubric_id",
+    "rubric_version",
+    "schema_version",
+    "dimensions"
+  ],
+  "properties": {
+    "rubric_id": {
+      "const": "microc2-defensive-research-detection-measurement-rubric"
+    },
+    "rubric_version": {
+      "const": "1.0.0"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "dimensions": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/dimension"
+      }
+    }
+  },
+  "$defs": {
+    "dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "definition",
+        "category_reference",
+        "admissible_evidence_classes",
+        "invalid_handling",
+        "unknown_handling",
+        "uncertainty_disclosure",
+        "reporting_requirement",
+        "comparability_limit"
+      ],
+      "properties": {
+        "id": {
+          "enum": [
+            "provenance",
+            "collection-coverage",
+            "validity",
+            "uncertainty",
+            "missing-unknown-data"
+          ],
+          "description": "Immutable dimension identifier from the closed five-dimension set."
+        },
+        "definition": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "description": "Dimension definition describing what this dimension measures and how it should be interpreted in the context of defensive research."
+        },
+        "category_reference": {
+          "$ref": "defensive-research-category-reference-v1.schema.json",
+          "description": "Pinned reference to a category in the microc2-defensive-research-categories registry that governs admissible evidence classes for this dimension."
+        },
+        "admissible_evidence_classes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "integrity-metadata",
+              "redacted-observation-summary",
+              "aggregate-measurement-summary",
+              "synthetic-control-summary"
+            ]
+          },
+          "description": "Non-empty, unique subset of the pinned registry's four closed evidence-class values. Must be a subset of the referenced category's allowed_evidence_classes."
+        },
+        "invalid_handling": {
+          "enum": [
+            "reject-assessment",
+            "downgrade-to-unknown"
+          ],
+          "description": "How knowingly invalid or corrupted evidence is handled for this dimension. reject-assessment: the observation must not contribute to the dimension assessment. downgrade-to-unknown: the observation is reclassified as unknown and processed accordingly."
+        },
+        "unknown_handling": {
+          "enum": [
+            "report-as-unknown",
+            "exclude-from-comparison"
+          ],
+          "description": "How missing or absent evidence is handled for this dimension. report-as-unknown: the absence is recorded as an explicit unknown observation. exclude-from-comparison: the dimension is omitted from comparative analysis when evidence is absent."
+        },
+        "uncertainty_disclosure": {
+          "enum": [
+            "level",
+            "level-with-rationale"
+          ],
+          "description": "Required uncertainty reporting for this dimension. level: a discrete uncertainty level must be assigned. level-with-rationale: both a level and a written rationale are required."
+        },
+        "reporting_requirement": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "description": "What must be reported for this dimension: the required content, format constraints, and any per-dimension specificity."
+        },
+        "comparability_limit": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "description": "Explicit constraint on what comparisons are valid across measurement runs for this dimension, including any necessary precondition, normalisation, or scope boundary."
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/examples/defensive-research-detection-measurement-rubric-v1.json
+++ b/docs/schemas/examples/defensive-research-detection-measurement-rubric-v1.json
@@ -1,0 +1,97 @@
+{
+  "rubric_id": "microc2-defensive-research-detection-measurement-rubric",
+  "rubric_version": "1.0.0",
+  "schema_version": 1,
+  "dimensions": [
+    {
+      "id": "provenance",
+      "definition": "Assess the tamper-evidence and reproducibility properties of redacted observation artifacts by comparing structural metadata across measurement runs. Provenance verification establishes whether observation metadata can be independently reconstructed and whether structural tampering would be detectable.",
+      "category_reference": {
+        "schema_version": 1,
+        "registry_id": "microc2-defensive-research-categories",
+        "registry_version": "1.0.0",
+        "category_id": "integrity-metadata"
+      },
+      "admissible_evidence_classes": [
+        "integrity-metadata"
+      ],
+      "invalid_handling": "reject-assessment",
+      "unknown_handling": "report-as-unknown",
+      "uncertainty_disclosure": "level-with-rationale",
+      "reporting_requirement": "Report provenance integrity level and supporting structural-metadata summary. When integrity verification is impossible due to missing metadata, report provenance as unknown with an explicit rationale.",
+      "comparability_limit": "Provenance comparisons are valid only between measurement runs that share the same observation-artifact schema version. Cross-schema provenance comparisons require explicit normalisation and a documented compatibility matrix."
+    },
+    {
+      "id": "collection-coverage",
+      "definition": "Summarise the defensive-surface coverage achieved by a set of synthetic control measurements. Collection-coverage provides a gap-analysis baseline indicating which defensive surfaces were observed and which remain unobserved without enumerating individual collection points.",
+      "category_reference": {
+        "schema_version": 1,
+        "registry_id": "microc2-defensive-research-categories",
+        "registry_version": "1.0.0",
+        "category_id": "coverage-summary"
+      },
+      "admissible_evidence_classes": [
+        "synthetic-control-summary"
+      ],
+      "invalid_handling": "downgrade-to-unknown",
+      "unknown_handling": "report-as-unknown",
+      "uncertainty_disclosure": "level-with-rationale",
+      "reporting_requirement": "Report coverage level, the set of covered defensive surfaces, and the set of known-unobserved surfaces. Express coverage as a fraction of the total surface inventory defined by the measurement protocol.",
+      "comparability_limit": "Collection-coverage comparisons require the same defensive-surface inventory to be meaningful. Differing surface inventories demand a normalised coverage metric with explicit inventory mapping."
+    },
+    {
+      "id": "validity",
+      "definition": "Aggregate redacted sensor observations to identify whether observed patterns are consistent with the expected defensive-signal model. Validity assessment determines whether the synthetic observation method produces measurements that can be distinguished from noise.",
+      "category_reference": {
+        "schema_version": 1,
+        "registry_id": "microc2-defensive-research-categories",
+        "registry_version": "1.0.0",
+        "category_id": "defensive-observation-summary"
+      },
+      "admissible_evidence_classes": [
+        "redacted-observation-summary"
+      ],
+      "invalid_handling": "reject-assessment",
+      "unknown_handling": "exclude-from-comparison",
+      "uncertainty_disclosure": "level",
+      "reporting_requirement": "Report a discrete validity level with supporting signal-to-noise characterisation. Include the redacted observation count and the fraction that passed the validity threshold.",
+      "comparability_limit": "Validity comparisons are valid only for measurements using identical synthetic-observation parameters. Changes to observation method, sensor configuration, or threshold criteria invalidate direct comparison."
+    },
+    {
+      "id": "uncertainty",
+      "definition": "Characterise the quantification limits and confidence bounds of aggregate measurements. Uncertainty assessment identifies systematic and random error sources that affect the reliability of aggregate observation summaries without exposing raw collection data.",
+      "category_reference": {
+        "schema_version": 1,
+        "registry_id": "microc2-defensive-research-categories",
+        "registry_version": "1.0.0",
+        "category_id": "defensive-observation-summary"
+      },
+      "admissible_evidence_classes": [
+        "aggregate-measurement-summary"
+      ],
+      "invalid_handling": "downgrade-to-unknown",
+      "unknown_handling": "report-as-unknown",
+      "uncertainty_disclosure": "level-with-rationale",
+      "reporting_requirement": "Report an uncertainty level with explicit rationale describing the dominant error sources. Include the estimated magnitude of systematic and random error components and their combined effect on aggregate measurements.",
+      "comparability_limit": "Uncertainty characterisations are valid for comparison only when the measurement protocol, sensor configuration, and aggregation method are held constant. Changes to any of these require a full re-characterisation."
+    },
+    {
+      "id": "missing-unknown-data",
+      "definition": "Identify and classify observational gaps where expected defensive evidence is absent, incomplete, or cannot be confirmed. Missing-unknown-data assessment distinguishes between known gaps (data expected but absent) and unknown gaps (data whose existence cannot be confirmed) to establish the completeness boundary of a measurement run.",
+      "category_reference": {
+        "schema_version": 1,
+        "registry_id": "microc2-defensive-research-categories",
+        "registry_version": "1.0.0",
+        "category_id": "coverage-summary"
+      },
+      "admissible_evidence_classes": [
+        "aggregate-measurement-summary"
+      ],
+      "invalid_handling": "downgrade-to-unknown",
+      "unknown_handling": "report-as-unknown",
+      "uncertainty_disclosure": "level-with-rationale",
+      "reporting_requirement": "Report the count and classification of missing or unknown data points, mapping each gap to the expected defensive surface. Distinguish between known gaps (data expected but absent) and unknown gaps (data whose existence cannot be confirmed).",
+      "comparability_limit": "Missing-unknown-data comparisons require identical surface inventories and observation expectations. Differing measurement-protocol coverage scopes invalidate direct gap comparisons; normalise to a common surface inventory first."
+    }
+  ]
+}

--- a/docs/schemas/validate-examples.js
+++ b/docs/schemas/validate-examples.js
@@ -26,6 +26,7 @@ const exampleSchemas = new Map([
     ['audit-page-v1.json', 'audit-page-v1.schema.json'],
     ['defensive-research-categories-v1.json', 'defensive-research-categories-v1.schema.json'],
     ['defensive-research-category-reference-v1.json', 'defensive-research-category-reference-v1.schema.json'],
+    ['defensive-research-detection-measurement-rubric-v1.json', 'defensive-research-detection-measurement-rubric-v1.schema.json'],
     ['task-create-request-v1.json', 'task-create-request-v1.schema.json'],
     ['task-dispatched-v1.json', 'task-v1.schema.json'],
     ['task-page-v1.json', 'task-page-v1.schema.json'],
@@ -548,11 +549,190 @@ for (const testCase of registryNegativeCases) {
     failed = true;
 }
 
+const rubricExample = readJSON(path.join(exampleDirectory, 'defensive-research-detection-measurement-rubric-v1.json'));
+
+const rubricPositiveCases = [
+    {name: 'rubric structure', error: validateRubric(rubricExample, registryExample)}
+];
+for (const testCase of rubricPositiveCases) {
+    if (testCase.error) {
+        console.error(`Defensive research contract failed positive case ${testCase.name}: ${testCase.error}`);
+        failed = true;
+    }
+}
+
+// Schema-negative cases: schema must reject malformed inputs.
+const rubricNegativeCases = [
+    {
+        name: 'rubric rejects 4 dimensions',
+        kind: 'rubric',
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.slice(0, 4)
+        }
+    },
+    {
+        name: 'rubric rejects invalid handling suppress',
+        kind: 'rubric',
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.map((d, i) =>
+                i === 0 ? { ...d, invalid_handling: 'suppress' } : d
+            )
+        }
+    },
+    {
+        name: 'rubric rejects uncertainty disclosure none',
+        kind: 'rubric',
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.map((d, i) =>
+                i === 2 ? { ...d, uncertainty_disclosure: 'none' } : d
+            )
+        }
+    },
+    {
+        name: 'rubric rejects out-of-global-enum evidence class',
+        kind: 'rubric',
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.map((d, i) =>
+                i === 1
+                    ? { ...d, admissible_evidence_classes: ['arbitrary-custom-tooling'] }
+                    : d
+            )
+        }
+    }
+];
+for (const testCase of rubricNegativeCases) {
+    const schemaId = schemaID('defensive-research-detection-measurement-rubric-v1.schema.json');
+    const validateFn = ajv.getSchema(schemaId);
+    if (!validateFn) {
+        console.error(`Defensive research contract schema not loaded: ${schemaId}`);
+        failed = true;
+        continue;
+    }
+    if (validateFn(testCase.value)) {
+        console.error(`Defensive research contract failed negative case ${testCase.name}: schema accepted invalid value`);
+        failed = true;
+    }
+}
+
+// Semantic-negative cases: fixtures are schema-valid before semantic
+// rejection unless explicitly marked expectSchemaValid: false.
+const rubricSemanticNegativeCases = [
+    {
+        name: 'rubric rejects duplicate dimension id',
+        value: {
+            ...rubricExample,
+            dimensions: [
+                rubricExample.dimensions[0],
+                rubricExample.dimensions[1],
+                rubricExample.dimensions[2],
+                rubricExample.dimensions[3],
+                {
+                    ...rubricExample.dimensions[0],
+                    definition: 'A completely different definition for the duplicate-id negative test case that describes an alternative provenance measurement methodology.',
+                    admissible_evidence_classes: ['redacted-observation-summary']
+                }
+            ]
+        }
+    },
+    {
+        name: 'rubric rejects missing dimension id',
+        expectSchemaValid: false,
+        value: {
+            ...rubricExample,
+            dimensions: [
+                rubricExample.dimensions[0],
+                rubricExample.dimensions[2],
+                rubricExample.dimensions[3],
+                rubricExample.dimensions[4]
+            ]
+        }
+    },
+    {
+        name: 'rubric rejects category-disallowed evidence class',
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.map((d, i) =>
+                i === 0
+                    ? { ...d, admissible_evidence_classes: ['synthetic-control-summary'] }
+                    : d
+            )
+        }
+    },
+    {
+        name: 'rubric rejects unknown category id',
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.map((d, i) =>
+                i === 3
+                    ? {
+                        ...d,
+                        category_reference: {
+                            ...d.category_reference,
+                            category_id: 'nonexistent-category'
+                        }
+                    }
+                    : d
+            )
+        }
+    },
+    {
+        name: 'rubric rejects missing-unknown-data with exclude-from-comparison',
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.map((d) =>
+                d.id === 'missing-unknown-data'
+                    ? { ...d, unknown_handling: 'exclude-from-comparison' }
+                    : d
+            )
+        }
+    },
+    {
+        name: 'rubric rejects incompatible registry version',
+        expectSchemaValid: false,
+        value: {
+            ...rubricExample,
+            dimensions: rubricExample.dimensions.map((d) => ({
+                ...d,
+                category_reference: {
+                    ...d.category_reference,
+                    registry_version: '2.0.0'
+                }
+            }))
+        }
+    }
+];
+const rubricSchemaId = schemaID('defensive-research-detection-measurement-rubric-v1.schema.json');
+const rubricValidateFn = ajv.getSchema(rubricSchemaId);
+if (!rubricValidateFn) {
+    console.error(`Defensive research contract schema not loaded: ${rubricSchemaId}`);
+    failed = true;
+}
+if (rubricValidateFn) {
+    for (const testCase of rubricSemanticNegativeCases) {
+        if (testCase.expectSchemaValid !== false) {
+            if (!rubricValidateFn(testCase.value)) {
+                console.error(`Defensive research semantic-negative fixture ${testCase.name} must be schema-valid before semantic rejection but is not: ${ajv.errorsText(rubricValidateFn.errors)}`);
+                failed = true;
+                continue;
+            }
+        }
+        const err = validateRubric(testCase.value, registryExample);
+        if (!err) {
+            console.error(`Defensive research contract failed semantic-negative case: ${testCase.name}`);
+            failed = true;
+        }
+    }
+}
+
 if (failed) {
     process.exitCode = 1;
 } else {
     console.log(
-        `Validated ${exampleFiles.length} examples, ${lifecyclePositiveCases.length} lifecycle states, ${negativeCases.length} schema-negative cases, ${semanticNegativeCases.length + semanticStatusNegativeCases.length} semantic-negative cases, ${registryReferencePositiveCases.length} registry-positive cases, and ${registryNegativeCases.length} registry-negative cases against ${schemaFiles.length} Draft 2020-12 schemas.`
+        `Validated ${exampleFiles.length} examples, ${lifecyclePositiveCases.length} lifecycle states, ${negativeCases.length} schema-negative cases, ${semanticNegativeCases.length + semanticStatusNegativeCases.length} semantic-negative cases, ${registryReferencePositiveCases.length} registry-positive cases, ${registryNegativeCases.length} registry-negative cases, ${rubricNegativeCases.length} rubric schema-negative cases, ${rubricPositiveCases.length} rubric-positive cases, and ${rubricSemanticNegativeCases.length} rubric semantic-negative cases against ${schemaFiles.length} Draft 2020-12 schemas.`
     );
 }
 
@@ -654,5 +834,54 @@ function validateCategoryReference(ref, registry) {
     if (!catIds.has(ref.category_id)) {
         return `referenced category_id ${ref.category_id} is not present in the pinned registry`;
     }
+    return '';
+}
+
+function validateRubric(rubric, registry) {
+    const expectedIDs = new Set([
+        'provenance',
+        'collection-coverage',
+        'validity',
+        'uncertainty',
+        'missing-unknown-data'
+    ]);
+    const seenIDs = new Set();
+    const catMap = new Map(registry.categories.map(c => [c.id, c]));
+
+    for (const dim of rubric.dimensions) {
+        if (seenIDs.has(dim.id)) {
+            return `duplicate dimension id ${dim.id}`;
+        }
+        seenIDs.add(dim.id);
+
+        // Resolve category reference using the existing reusable helper.
+        const refErr = validateCategoryReference(dim.category_reference, registry);
+        if (refErr) {
+            return `dimension ${dim.id}: ${refErr}`;
+        }
+
+        // Each dimension's admissible_evidence_classes must be a subset
+        // of the referenced category's allowed_evidence_classes.
+        const cat = catMap.get(dim.category_reference.category_id);
+        const allowed = new Set(cat.allowed_evidence_classes);
+        for (const cls of dim.admissible_evidence_classes) {
+            if (!allowed.has(cls)) {
+                return `dimension ${dim.id}: evidence class ${cls} is not allowed by category ${cat.id}`;
+            }
+        }
+
+        // missing-unknown-data must use report-as-unknown.
+        if (dim.id === 'missing-unknown-data' && dim.unknown_handling !== 'report-as-unknown') {
+            return `dimension missing-unknown-data: unknown_handling must be report-as-unknown, got ${dim.unknown_handling}`;
+        }
+    }
+
+    // Exact five-ID set: detect missing IDs.
+    for (const id of expectedIDs) {
+        if (!seenIDs.has(id)) {
+            return `missing required dimension id ${id}`;
+        }
+    }
+
     return '';
 }


### PR DESCRIPTION
Closes #123

- Pin each dimension to the defensive-category registry.
- Validate the static schema/example and semantic contract.
- Keep the R1, evasion, and single-verdict boundary explicit.